### PR TITLE
Show subtitles even when controller is visible

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -262,6 +262,7 @@ fun PlaybackPage(
 
                     // Subtitles
                     if (skipIndicatorDuration == 0L && currentItemPlayback.subtitleIndexEnabled) {
+                        val maxSize by animateFloatAsState(if (controllerViewState.controlsVisible) .7f else 1f)
                         AndroidView(
                             factory = { context ->
                                 SubtitleView(context).apply {
@@ -277,7 +278,7 @@ fun PlaybackPage(
                             },
                             modifier =
                                 Modifier
-                                    .fillMaxSize(if (controllerViewState.controlsVisible) .7f else 1f)
+                                    .fillMaxSize(maxSize)
                                     .align(Alignment.TopCenter)
                                     .background(Color.Transparent),
                         )


### PR DESCRIPTION
Closes #20 

Show subtitles slightly smaller and higher when the controls are visible

This needs to be revisited when custom subtitle styling is implemented (#11).