### PR TITLE
Fix issue where theme songs played when the app is backgrounded

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
@@ -37,6 +37,7 @@ import com.github.damontecres.wholphin.ui.nav.NavigationManager
 import com.github.damontecres.wholphin.ui.theme.WholphinTheme
 import com.github.damontecres.wholphin.util.AppUpgradeHandler
 import com.github.damontecres.wholphin.util.ExceptionHandler
+import com.github.damontecres.wholphin.util.ThemeSongPlayer
 import com.github.damontecres.wholphin.util.UpdateChecker
 import com.github.damontecres.wholphin.util.profile.createDeviceProfile
 import dagger.hilt.android.AndroidEntryPoint
@@ -67,6 +68,9 @@ class MainActivity : AppCompatActivity() {
 
     @Inject
     lateinit var appUpgradeHandler: AppUpgradeHandler
+
+    @Inject
+    lateinit var themeSongPlayer: ThemeSongPlayer
 
     @OptIn(ExperimentalTvMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -163,5 +167,10 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        themeSongPlayer.stop()
     }
 }

--- a/app/src/main/java/com/github/damontecres/wholphin/util/ThemeSongPlayer.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/ThemeSongPlayer.kt
@@ -1,0 +1,68 @@
+package com.github.damontecres.wholphin.util
+
+import android.content.Context
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import com.github.damontecres.wholphin.hilt.AuthOkHttpClient
+import com.github.damontecres.wholphin.preferences.ThemeSongVolume
+import dagger.hilt.android.qualifiers.ApplicationContext
+import okhttp3.OkHttpClient
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Simple service to play theme song music
+ */
+@Singleton
+class ThemeSongPlayer
+    @Inject
+    constructor(
+        @param:ApplicationContext val context: Context,
+        @param:AuthOkHttpClient val okHttpClient: OkHttpClient,
+    ) {
+        private var player: Player? = null
+
+        @OptIn(UnstableApi::class)
+        fun play(
+            volume: ThemeSongVolume,
+            url: String,
+        ) {
+            val volumeLevel =
+                when (volume) {
+                    ThemeSongVolume.UNRECOGNIZED,
+                    ThemeSongVolume.DISABLED,
+                    -> return
+
+                    ThemeSongVolume.LOWEST -> .05f
+                    ThemeSongVolume.LOW -> .1f
+                    ThemeSongVolume.MEDIUM -> .25f
+                    ThemeSongVolume.HIGH -> .5f
+                    ThemeSongVolume.HIGHEST -> 75f
+                }
+            val player =
+                ExoPlayer
+                    .Builder(context)
+                    .setMediaSourceFactory(
+                        DefaultMediaSourceFactory(
+                            OkHttpDataSource.Factory(okHttpClient),
+                        ),
+                    ).build()
+                    .apply {
+                        this.volume = volumeLevel
+                        playWhenReady = true
+                    }
+            player.setMediaItem(MediaItem.fromUri(url))
+            player.prepare()
+            this.player = player
+        }
+
+        fun stop() {
+            player?.stop()
+            player?.release()
+        }
+    }


### PR DESCRIPTION
Previously if the app is playing a show's theme song and the app is backgrounded, such as by pressing Home, the music would continue. This PR fixes that.