### PR TITLE
Fix focus on home page load defaulting to nav drawer

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomeViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomeViewModel.kt
@@ -82,17 +82,29 @@ class HomeViewModel
                     val latest = getLatest(userDto, limit, includedIds)
 
                     val homeRows =
-                        listOf(
-                            HomeRow(
-                                section = HomeSection.RESUME,
-                                items = resume,
-                            ),
-                            HomeRow(
-                                section = HomeSection.NEXT_UP,
-                                items = nextUp,
-                            ),
-                            *latest.toTypedArray(),
-                        )
+                        buildList {
+                            if (resume.isNotEmpty()) {
+                                add(
+                                    HomeRow(
+                                        section = HomeSection.RESUME,
+                                        items = resume,
+                                    ),
+                                )
+                            }
+                            if (nextUp.isNotEmpty()) {
+                                add(
+                                    HomeRow(
+                                        section = HomeSection.NEXT_UP,
+                                        items = nextUp,
+                                    ),
+                                )
+                            }
+                            latest.forEach {
+                                if (it.items.isNotEmpty()) {
+                                    add(it)
+                                }
+                            }
+                        }
                     withContext(Dispatchers.Main) {
                         this@HomeViewModel.homeRows.value = homeRows
                         loadingState.value = LoadingState.Success


### PR DESCRIPTION
When the home page loaded, it would only try to focus on the "Resume" row even if there were no items in that row (so it doesn't appear). This resulted in the focus defaulting instead to the nav drawer.

This PR fixes focus so it always starts with the first item in the first row of the home page.