### PR TITLE
Minor UI changes

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/Playlist.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/Playlist.kt
@@ -24,7 +24,7 @@ class Playlist(
 
     fun hasPrevious(): Boolean = index > 0
 
-    fun hasNext(): Boolean = index < items.size
+    fun hasNext(): Boolean = (index + 1) < items.size
 
     fun getPreviousAndReverse(): BaseItem = items[--index]
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/BannerCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/BannerCard.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
@@ -62,7 +61,7 @@ fun BannerCard(
         interactionSource = interactionSource,
         colors =
             CardDefaults.colors(
-                containerColor = Color.Transparent,
+//                containerColor = Color.Transparent,
             ),
     ) {
         Box(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
@@ -124,7 +124,7 @@ fun DestinationContent(
                                 preferences,
                                 destination.itemId,
                                 destination.item,
-                                true,
+                                false,
                                 modifier,
                             )
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -392,6 +392,7 @@ fun PlaybackPage(
                         }
                         Button(
                             onClick = {
+                                segmentCancelled = true
                                 player.seekTo(segment.endTicks.ticks.inWholeMilliseconds)
                             },
                             modifier = Modifier.focusRequester(focusRequester),


### PR DESCRIPTION
* Revert transparent cards from #61
* Don't show queue during playback if playing the final item
* Fix nav drawer collection page from showing everything recursively
* Immediately hide the skip intro button when pressed