### PR TITLE
Add setting to change default content scaling

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -522,6 +522,19 @@ sealed interface AppPreference<T> {
                 valueToIndex = { it.number },
             )
 
+        val GlobalContentScale =
+            AppChoicePreference<PrefContentScale>(
+                title = R.string.global_content_scale,
+                defaultValue = PrefContentScale.FIT,
+                getter = { it.playbackPreferences.globalContentScale },
+                setter = { prefs, value ->
+                    prefs.updatePlaybackPreferences { globalContentScale = value }
+                },
+                displayValues = R.array.content_scale,
+                indexToValue = { PrefContentScale.forNumber(it) },
+                valueToIndex = { it.number },
+            )
+
         val ClearImageCache =
             AppClickablePreference(
                 title = R.string.clear_image_cache,
@@ -639,6 +652,7 @@ val advancedPreferences =
             title = R.string.playback_overrides,
             preferences =
                 listOf(
+                    AppPreference.GlobalContentScale,
                     AppPreference.DownMixStereo,
                     AppPreference.Ac3Supported,
                     AppPreference.DirectPlayAss,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackConstants.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackConstants.kt
@@ -1,6 +1,7 @@
 package com.github.damontecres.wholphin.ui.playback
 
 import androidx.compose.ui.layout.ContentScale
+import com.github.damontecres.wholphin.preferences.PrefContentScale
 
 val playbackScaleOptions =
     mapOf(
@@ -12,3 +13,15 @@ val playbackScaleOptions =
         ContentScale.FillWidth to "Fill Width",
         ContentScale.FillHeight to "Fill Height",
     )
+
+val PrefContentScale.scale: ContentScale
+    get() =
+        when (this) {
+            PrefContentScale.FIT -> ContentScale.Fit
+            PrefContentScale.NONE -> ContentScale.None
+            PrefContentScale.CROP -> ContentScale.Crop
+            PrefContentScale.FILL -> ContentScale.FillBounds
+            PrefContentScale.Fill_WIDTH -> ContentScale.FillWidth
+            PrefContentScale.FILL_HEIGHT -> ContentScale.FillHeight
+            PrefContentScale.UNRECOGNIZED -> ContentScale.Fit
+        }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.key.onKeyEvent
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -147,7 +146,7 @@ fun PlaybackPage(
                 onDispose { player.removeListener(cueListener) }
             }
             AmbientPlayerListener(player)
-            var contentScale by remember { mutableStateOf(ContentScale.Fit) }
+            var contentScale by remember { mutableStateOf(prefs.globalContentScale.scale) }
             var playbackSpeed by remember { mutableFloatStateOf(1.0f) }
             LaunchedEffect(playbackSpeed) { player.setPlaybackSpeed(playbackSpeed) }
 

--- a/app/src/main/proto/WholphinDataStore.proto
+++ b/app/src/main/proto/WholphinDataStore.proto
@@ -9,6 +9,15 @@ enum SkipSegmentBehavior{
   ASK_TO_SKIP = 2;
 }
 
+enum PrefContentScale{
+  FIT = 0;
+  NONE = 1;
+  CROP = 2;
+  FILL = 3;
+  Fill_WIDTH = 4;
+  FILL_HEIGHT = 5;
+}
+
 message PlaybackOverrides{
   bool ac3_supported = 1;
   bool downmix_stereo = 2;
@@ -35,6 +44,7 @@ message PlaybackPreferences {
 
   PlaybackOverrides overrides = 15;
   int64 pass_out_protection_ms = 16;
+  PrefContentScale global_content_scale = 17;
 }
 
 message HomePagePreferences{

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -22,4 +22,13 @@
         <item>Ask to skip</item>
     </string-array>
 
+    <string-array name="content_scale">
+        <item>Fit</item>
+        <item>None</item>
+        <item>Crop</item>
+        <item>Fill</item>
+        <item>Fill Width</item>
+        <item>Fill Height</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,5 +96,6 @@
     <string name="send_crash_reports_summary">Will try to send to last connected server</string>
     <string name="send_app_logs">Send app logs to current server</string>
     <string name="send_app_logs_summary">Useful for debugging</string>
+    <string name="global_content_scale">Default content scale</string>
 
 </resources>


### PR DESCRIPTION
Closes #53 #71

Adds an advanced playback setting to set a different default global content scaling. It can still be changed per playback as well.