### PR TITLE
Add slf4j-simple

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -226,6 +226,7 @@ dependencies {
     ksp(libs.hilt.android.compiler)
 
     implementation(libs.timber)
+    implementation(libs.slf4j.simple)
     implementation(libs.aboutlibraries.core)
     implementation(libs.aboutlibraries.compose.m3)
     implementation(libs.multiplatform.markdown.renderer)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ composeBom = "2025.10.01"
 compose-runtime = "1.9.4"
 multiplatformMarkdownRenderer = "0.37.0"
 programguide = "1.6.0"
+slf4j = "2.0.17"
 timber = "5.0.1"
 tvFoundation = "1.0.0-alpha12"
 tvMaterial = "1.0.1"
@@ -97,6 +98,7 @@ androidx-room-common-jvm = { group = "androidx.room", name = "room-common-jvm", 
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preferenceKtx" }
 androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }


### PR DESCRIPTION
Fixes #99 

While not an actual error, it does look like a transitive dependency of the Jellyfin Kotlin SDK may log using slf4j, so it would be good to include an slf4j implementation just in case.