### PR TITLE
Fixes & optimizations to series pages

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/BaseItem.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/BaseItem.kt
@@ -1,6 +1,6 @@
 package com.github.damontecres.wholphin.data.model
 
-import com.github.damontecres.wholphin.ui.detail.series.SeasonEpisode
+import com.github.damontecres.wholphin.ui.detail.series.SeasonEpisodeIds
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.util.seasonEpisode
 import kotlinx.serialization.Serializable
@@ -54,27 +54,23 @@ data class BaseItem(
             // Redirect episodes & seasons to their series if possible
             when (type) {
                 BaseItemKind.EPISODE -> {
-                    indexNumber?.let { episode ->
-                        data.parentIndexNumber?.let { season ->
-                            Destination.SeriesOverview(
-                                data.seriesId!!,
-                                BaseItemKind.SERIES,
-                                this,
-                                SeasonEpisode(season, episode),
-                            )
-                        }
-                    } ?: Destination.MediaItem(id, type, this)
-                }
-
-                BaseItemKind.SEASON ->
-                    data.indexNumber?.let { season ->
+                    data.seasonId?.let { seasonId ->
                         Destination.SeriesOverview(
                             data.seriesId!!,
                             BaseItemKind.SERIES,
                             this,
-                            SeasonEpisode(season, 0),
+                            SeasonEpisodeIds(seasonId, data.parentIndexNumber, id, indexNumber),
                         )
                     } ?: Destination.MediaItem(id, type, this)
+                }
+
+                BaseItemKind.SEASON ->
+                    Destination.SeriesOverview(
+                        data.seriesId!!,
+                        BaseItemKind.SERIES,
+                        this,
+                        SeasonEpisodeIds(id, indexNumber, null, null),
+                    )
 
                 else -> Destination.MediaItem(id, type, this)
             }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/Extensions.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/Extensions.kt
@@ -375,3 +375,8 @@ suspend fun <T> MutableLiveData<T>.setValueOnMain(value: T) =
     withContext(Dispatchers.Main) {
         this@setValueOnMain.value = value
     }
+
+fun equalsNotNull(
+    a: Any?,
+    b: Any?,
+) = a != null && b != null && a == b

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
@@ -92,12 +92,12 @@ fun SeriesDetails(
         }
     }
     LaunchedEffect(Unit) {
-        viewModel.init(preferences, destination.itemId, destination.item, null, null)
+        viewModel.init(preferences, destination.itemId, destination.item, null)
     }
     val loading by viewModel.loading.observeAsState(LoadingState.Loading)
 
     val item by viewModel.item.observeAsState()
-    val seasons by viewModel.seasons.observeAsState(ItemListAndMapping.empty())
+    val seasons by viewModel.seasons.observeAsState(listOf())
     val people by viewModel.people.observeAsState(listOf())
     val similar by viewModel.similar.observeAsState(listOf())
 
@@ -190,7 +190,7 @@ private const val SIMILAR_ROW = PEOPLE_ROW + 1
 fun SeriesDetailsContent(
     preferences: UserPreferences,
     series: BaseItem,
-    seasons: ItemListAndMapping,
+    seasons: List<BaseItem>,
     similar: List<BaseItem>,
     people: List<Person>,
     played: Boolean,
@@ -332,7 +332,7 @@ fun SeriesDetailsContent(
                 item {
                     ItemRow(
                         title = "Seasons",
-                        items = seasons.items,
+                        items = seasons,
                         onClickItem = {
                             position = SEASONS_ROW
                             onClickItem.invoke(it)

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
@@ -85,7 +85,7 @@ fun SeriesOverviewContent(
     val tabRowFocusRequester = remember { FocusRequester() }
 
     val focusedEpisode =
-        (episodes as? EpisodeList.Success)?.episodes?.items?.getOrNull(position.episodeRowIndex)
+        (episodes as? EpisodeList.Success)?.episodes?.getOrNull(position.episodeRowIndex)
 
     Box(
         modifier =
@@ -229,7 +229,7 @@ fun SeriesOverviewContent(
                                         .focusRestorer(firstItemFocusRequester)
                                         .focusRequester(episodeRowFocusRequester),
                             ) {
-                                itemsIndexed(eps.episodes.items) { episodeIndex, episode ->
+                                itemsIndexed(eps.episodes) { episodeIndex, episode ->
                                     val interactionSource = remember { MutableInteractionSource() }
                                     if (interactionSource.collectIsFocusedAsState().value) {
                                         onFocus.invoke(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/Destination.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/Destination.kt
@@ -7,6 +7,7 @@ import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.GetItemsFilter
 import com.github.damontecres.wholphin.data.model.ItemPlayback
 import com.github.damontecres.wholphin.ui.detail.series.SeasonEpisode
+import com.github.damontecres.wholphin.ui.detail.series.SeasonEpisodeIds
 import com.github.damontecres.wholphin.ui.preferences.PreferenceScreenOption
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -48,7 +49,7 @@ sealed class Destination(
         val itemId: UUID,
         val type: BaseItemKind,
         @Transient val item: BaseItem? = null,
-        val seasonEpisode: SeasonEpisode? = null,
+        val seasonEpisode: SeasonEpisodeIds? = null,
     ) : Destination() {
         override fun toString(): String = "SeriesOverview(itemId=$itemId, type=$type, seasonEpisode=$seasonEpisode)"
     }


### PR DESCRIPTION
Simplifies the process for finding the right season id & episode id after clicking on an episode. This can also improve loading time for seasons that have a large number of episodes (hundreds).

Also fixes handling for "unknown" seasons which don't have an index/season number.