### PR TITLE
Option to automatically go to new page on focus instead of clicking

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -590,13 +590,25 @@ sealed interface AppPreference<T> {
                 getter = { },
                 setter = { prefs, _ -> prefs },
             )
+
+        val NavDrawerSwitchOnFocus =
+            AppSwitchPreference(
+                title = R.string.nav_drawer_switch_on_focus,
+                defaultValue = true,
+                getter = { it.interfacePreferences.navDrawerSwitchOnFocus },
+                setter = { prefs, value ->
+                    prefs.updateInterfacePreferences { navDrawerSwitchOnFocus = value }
+                },
+                summaryOn = R.string.enabled,
+                summaryOff = R.string.nav_drawer_switch_on_focus_summary_off,
+            )
     }
 }
 
 val basicPreferences =
     listOf(
         PreferenceGroup(
-            title = R.string.basic_interface,
+            title = R.string.ui_interface,
             preferences =
                 listOf(
                     AppPreference.HomePageItems,
@@ -648,6 +660,13 @@ val uiPreferences = listOf<PreferenceGroup>()
 
 val advancedPreferences =
     listOf(
+        PreferenceGroup(
+            title = R.string.ui_interface,
+            preferences =
+                listOf(
+                    AppPreference.NavDrawerSwitchOnFocus,
+                ),
+        ),
         PreferenceGroup(
             title = R.string.playback,
             preferences =

--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreferencesSerializer.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreferencesSerializer.kt
@@ -70,6 +70,8 @@ class AppPreferencesSerializer
                             .apply {
                                 playThemeSongs = AppPreference.PlayThemeMusic.defaultValue
                                 appThemeColors = AppPreference.ThemeColors.defaultValue
+                                navDrawerSwitchOnFocus =
+                                    AppPreference.NavDrawerSwitchOnFocus.defaultValue
                             }.build()
                 }.build()
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/NavDrawer.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/NavDrawer.kt
@@ -253,21 +253,27 @@ fun NavDrawer(
             }
         }
     }
-    LaunchedEffect(derivedFocusedIndex) {
-        val index = derivedFocusedIndex
-        delay(500)
-        if (index != selectedIndex) {
-            if (index == -1) {
-                viewModel.setIndex(-1)
-                viewModel.navigationManager.goToHome()
-            } else if (index in libraries.indices) {
-                if (moreLibraries.isEmpty() || index != libraries.lastIndex) {
-                    onClick.invoke(index, libraries[index])
-                }
-            } else {
-                val newIndex = libraries.size - index + 1
-                if (newIndex in moreLibraries.indices) {
-                    onClick.invoke(index, moreLibraries[newIndex])
+    if (preferences.appPreferences.interfacePreferences.navDrawerSwitchOnFocus) {
+        LaunchedEffect(derivedFocusedIndex) {
+            val index = derivedFocusedIndex
+            delay(600)
+            if (index != selectedIndex) {
+                if (index == -1) {
+                    viewModel.setIndex(-1)
+                    viewModel.navigationManager.goToHome()
+                } else if (index in libraries.indices) {
+                    if (moreLibraries.isEmpty() || index != libraries.lastIndex) {
+                        libraries.getOrNull(index)?.let {
+                            onClick.invoke(index, it)
+                        }
+                    }
+                } else {
+                    val newIndex = libraries.size - index + 1
+                    if (newIndex in moreLibraries.indices) {
+                        moreLibraries.getOrNull(newIndex)?.let {
+                            onClick.invoke(index, it)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/util/AppUpgradeHandler.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/AppUpgradeHandler.kt
@@ -8,6 +8,7 @@ import androidx.preference.PreferenceManager
 import com.github.damontecres.wholphin.WholphinApplication
 import com.github.damontecres.wholphin.preferences.AppPreference
 import com.github.damontecres.wholphin.preferences.AppPreferences
+import com.github.damontecres.wholphin.preferences.updateInterfacePreferences
 import com.github.damontecres.wholphin.preferences.updatePlaybackOverrides
 import dagger.hilt.android.qualifiers.ApplicationContext
 import timber.log.Timber
@@ -78,6 +79,13 @@ suspend fun upgradeApp(
                 downmixStereo = AppPreference.DownMixStereo.defaultValue
                 directPlayAss = AppPreference.DirectPlayAss.defaultValue
                 directPlayPgs = AppPreference.DirectPlayPgs.defaultValue
+            }
+        }
+    }
+    if (previous.isEqualOrBefore(Version.fromString("0.2.3-6-g0"))) {
+        appPreferences.updateData {
+            it.updateInterfacePreferences {
+                navDrawerSwitchOnFocus = AppPreference.NavDrawerSwitchOnFocus.defaultValue
             }
         }
     }

--- a/app/src/main/proto/WholphinDataStore.proto
+++ b/app/src/main/proto/WholphinDataStore.proto
@@ -81,6 +81,7 @@ message InterfacePreferences {
   bool remember_selected_tab = 2;
   map<string, int32> remembered_tabs = 3;
   AppThemeColors app_theme_colors = 4;
+  bool nav_drawer_switch_on_focus = 5;
 }
 
 message AppPreferences {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="cancel">Cancel</string>
     <string name="save">Save</string>
     <string name="app_name_long">Wholphin</string>
-    <string name="basic_interface">Basic Interface</string>
+    <string name="ui_interface">Interface</string>
     <string name="playback">Playback</string>
     <string name="about">About</string>
     <string name="advanced_settings">Advanced Settings</string>
@@ -98,5 +98,7 @@
     <string name="send_app_logs_summary">Useful for debugging</string>
     <string name="global_content_scale">Default content scale</string>
     <string name="ffmpeg_extension_pref">Use FFmpeg decoder module</string>
+    <string name="nav_drawer_switch_on_focus">Switch nav drawer pages on focus</string>
+    <string name="nav_drawer_switch_on_focus_summary_off">Click to switch pages</string>
 
 </resources>


### PR DESCRIPTION
Closes #95 

Adds a setting (defaults to enabled) to automatically go to a page when the navigation drawer item is focused after a brief delay.

Basically, if you open the left nav drawer, and scroll down to "Movies" after a brief delay (600ms), the app will switch to the Movies page without having to click.

It can be disabled in advanced settings.