### PR TITLE
Handle larger TV guide data

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/TvGuideGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/TvGuideGrid.kt
@@ -106,7 +106,7 @@ fun TvGuideGrid(
                     channels = channels,
                     programs = programs,
                     channelProgramCount = viewModel.channelProgramCount,
-                    start = viewModel.start,
+                    start = viewModel.guideStart,
                     onClickChannel = { index, channel ->
                         viewModel.navigationManager.navigateTo(
                             Destination.Playback(


### PR DESCRIPTION
Fixes #110 

Switches loading the EPG/TV Guide data to lazy loading. The app will load all of the channels, but only keep ~100 channels worth of data in memory. As the user scrolls up and down, new channel program data will be fetched as needed.

Eventually this technique can be applied to supporting more than 48 hours of data.

The logic for determine which program to focus on is also simplified and more of it is delegated to composition.

Credit to @joshjryan for #131 hinting to use a different API endpoint to avoid 414 errors.