### PR TITLE
Optional setting for one click pause w/ d-pad center

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -654,6 +654,18 @@ sealed interface AppPreference<T> {
                 summaryOn = R.string.enabled,
                 summaryOff = R.string.disabled,
             )
+
+        val OneClickPause =
+            AppSwitchPreference(
+                title = R.string.one_click_pause,
+                defaultValue = false,
+                getter = { it.playbackPreferences.oneClickPause },
+                setter = { prefs, value ->
+                    prefs.updatePlaybackPreferences { oneClickPause = value }
+                },
+                summaryOn = R.string.one_click_pause_summary_on,
+                summaryOff = R.string.disabled,
+            )
     }
 }
 
@@ -732,6 +744,7 @@ val advancedPreferences =
             title = R.string.playback,
             preferences =
                 listOf(
+                    AppPreference.OneClickPause,
                     AppPreference.SkipIntros,
                     AppPreference.SkipOutros,
                     AppPreference.SkipCommercials,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
@@ -23,6 +23,7 @@ class PlaybackKeyHandler(
     private val controllerViewState: ControllerViewState,
     private val updateSkipIndicator: (Long) -> Unit,
     private val skipBackOnResume: Duration?,
+    private val oneClickPause: Boolean,
     private val onInteraction: () -> Unit,
 ) {
     fun onKeyEvent(it: KeyEvent): Boolean {
@@ -33,7 +34,7 @@ class PlaybackKeyHandler(
             result = false
         } else if (it.type != KeyEventType.KeyUp) {
             result = false
-        } else if (isDpad(it)) {
+        } else if (isDirectionalDpad(it) || isEnterKey(it)) {
             if (!controllerViewState.controlsVisible) {
                 if (skipWithLeftRight && it.key == Key.DirectionLeft) {
                     updateSkipIndicator(-seekBack.inWholeMilliseconds)
@@ -41,6 +42,15 @@ class PlaybackKeyHandler(
                 } else if (skipWithLeftRight && it.key == Key.DirectionRight) {
                     player.seekForward(seekForward)
                     updateSkipIndicator(seekForward.inWholeMilliseconds)
+                } else if (oneClickPause && isEnterKey(it)) {
+                    Util.handlePlayPauseButtonAction(player)
+                    if (!player.isPlaying) {
+                        controllerViewState.showControls()
+                    } else {
+                        skipBackOnResume?.let {
+                            player.seekBack(it)
+                        }
+                    }
                 } else {
                     controllerViewState.showControls()
                 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -208,6 +208,7 @@ fun PlaybackPage(
                     updateSkipIndicator = updateSkipIndicator,
                     skipBackOnResume = preferences.appPreferences.playbackPreferences.skipBackOnResume,
                     onInteraction = viewModel::reportInteraction,
+                    oneClickPause = preferences.appPreferences.playbackPreferences.oneClickPause,
                 )
 
             val showSegment =

--- a/app/src/main/proto/WholphinDataStore.proto
+++ b/app/src/main/proto/WholphinDataStore.proto
@@ -58,6 +58,7 @@ message PlaybackPreferences {
   int64 pass_out_protection_ms = 16;
   PrefContentScale global_content_scale = 17;
   ShowNextUpWhen show_next_up_when = 18;
+  bool one_click_pause = 19;
 }
 
 message HomePagePreferences{

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,8 @@
     <string name="aired_episode_order">Aired Episode Order</string>
     <string name="create_playlist">Create new playlist</string>
     <string name="add_to_playlist">Add to playlist</string>
+    <string name="one_click_pause">Pause with one click</string>
+    <string name="one_click_pause_summary_on">Press D-Pad center to pause/play</string>
 
     <plurals name="downloads">
         <item quantity="zero">%d downloads</item>


### PR DESCRIPTION
Closes #152 

Adds a setting to enable one-click-pausing via the D-Pad center button. It is disabled by default.

If enabled, when the video is playing, it will be pause and show the controls which is just like pressing the Pause or Play/Pause button.

If enable, when the video is paused and controls is not showing, it will resume playback including using the skip back on resume setting.