### PR TITLE
Fix only loading 100 episode in a season

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/FocusedEpisodeHeader.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/FocusedEpisodeHeader.kt
@@ -24,18 +24,18 @@ import org.jellyfin.sdk.model.extensions.ticks
 
 @Composable
 fun FocusedEpisodeHeader(
-    ep: BaseItem,
+    ep: BaseItem?,
     overviewOnClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    val dto = ep.data
+    val dto = ep?.data
     Column(
         verticalArrangement = Arrangement.spacedBy(4.dp),
         modifier = modifier,
     ) {
         Text(
-            text = dto.episodeTitle ?: dto.name ?: "",
+            text = dto?.episodeTitle ?: dto?.name ?: "",
             style = MaterialTheme.typography.headlineSmall,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
@@ -46,17 +46,17 @@ fun FocusedEpisodeHeader(
         ) {
             val details =
                 buildList {
-                    dto.seasonEpisode?.let(::add)
-                    dto.premiereDate?.let { add(formatDateTime(it)) }
-                    val duration = dto.runTimeTicks?.ticks
+                    dto?.seasonEpisode?.let(::add)
+                    dto?.premiereDate?.let { add(formatDateTime(it)) }
+                    val duration = dto?.runTimeTicks?.ticks
                     duration
                         ?.roundMinutes
                         ?.toString()
                         ?.let {
                             add(it)
                         }
-                    dto.officialRating?.let(::add)
-                    dto.timeRemaining?.roundMinutes?.let { add("$it left") }
+                    dto?.officialRating?.let(::add)
+                    dto?.timeRemaining?.roundMinutes?.let { add("$it left") }
                 }
             DotSeparatedRow(
                 texts = details,
@@ -68,12 +68,12 @@ fun FocusedEpisodeHeader(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             SimpleStarRating(
-                dto.communityRating,
+                dto?.communityRating,
                 Modifier.height(20.dp),
             )
         }
         OverviewText(
-            overview = dto.overview ?: "",
+            overview = dto?.overview ?: "",
             maxLines = 3,
             onClick = overviewOnClick,
         )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
@@ -162,13 +162,11 @@ fun SeriesOverviewContent(
             }
             item {
                 // Episode header
-                focusedEpisode?.let { ep ->
-                    FocusedEpisodeHeader(
-                        ep = ep,
-                        overviewOnClick = overviewOnClick,
-                        modifier = Modifier.fillMaxWidth(.66f),
-                    )
-                }
+                FocusedEpisodeHeader(
+                    ep = focusedEpisode,
+                    overviewOnClick = overviewOnClick,
+                    modifier = Modifier.fillMaxWidth(.66f),
+                )
             }
             item {
                 key(position.seasonTabIndex) {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
@@ -293,17 +293,11 @@ class SeriesViewModel
             itemId: UUID,
             listIndex: Int,
         ) = viewModelScope.launch(ExceptionHandler() + Dispatchers.IO) {
-            val base = api.userLibraryApi.getItem(itemId).content
-            val item = BaseItem.Companion.from(base, api)
             val eps = episodes.value
             if (eps is EpisodeList.Success) {
-                val newItems =
-                    eps.episodes.toMutableList().apply {
-                        this[listIndex] = item
-                    }
-                val newValue = eps.copy(episodes = newItems)
+                eps.episodes.refreshItem(listIndex, itemId)
                 withContext(Dispatchers.Main) {
-                    episodes.value = newValue
+                    episodes.value = eps
                 }
             }
         }
@@ -409,7 +403,7 @@ sealed interface EpisodeList {
     }
 
     data class Success(
-        val episodes: List<BaseItem?>,
+        val episodes: ApiRequestPager<GetEpisodesRequest>,
         val initialIndex: Int,
     ) : EpisodeList
 }


### PR DESCRIPTION
Fixes #184

Data was being fetched, but the UI wasn't being properly notified to display the data.

This PR also adjusts so that "focused episode header" still takes up the space even if the focused episode hasn't fully loaded yet. This prevents the UI from jumping up and down.

Also #42 is _not_ fixed by this PR because it is a different issue.