### PR TITLE
Add FLAG_ACTIVITY_NEW_TASK to fix updates for some older devices

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/util/UpdateChecker.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/UpdateChecker.kt
@@ -236,7 +236,7 @@ class UpdateChecker
                             val targetFile = fallbackDownload(it, callback)
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                                 val intent = Intent(Intent.ACTION_INSTALL_PACKAGE)
-                                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
                                 intent.data =
                                     FileProvider.getUriForFile(
                                         context,


### PR DESCRIPTION
Without this the installation intent is crashing with an error on my Xiaomi Mi Box S (Android 8.1)