### PR TITLE
Increase JVM memory for gradle builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   BRANCH_NAME: ${{ github.ref_name }}
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx4g -XX:MaxMetaspaceSize=512m'"
 
 jobs:
   build:
@@ -55,7 +56,7 @@ jobs:
           KEY_STORE_PASSWORD: "${{ secrets.KEY_STORE_PASSWORD }}"
           SIGNING_KEY: "${{ secrets.SIGNING_KEY }}"
         run: |
-          ./gradlew clean assembleRelease assembleDebug
+          ./gradlew clean assembleRelease assembleDebug --no-daemon
       - name: Verify signatures
         run: |
           echo "Verify APK signatures"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,7 @@ defaults:
 
 env:
   BUILD_DIRS_ARTIFACT: build-dirs
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx4g -XX:MaxMetaspaceSize=512m'"
 
 jobs:
   pre-commit:
@@ -42,7 +43,7 @@ jobs:
       - name: Build app
         id: buildapp
         run: |
-          ./gradlew clean assembleDebug
+          ./gradlew clean assembleDebug --no-daemon
           apks=$(find app/build/outputs/apk -name '*.apk' -print0 | tr '\0' ',' | sed 's/,$//')
           echo "apks=$apks" >> "$GITHUB_OUTPUT"
       - name: Tar build dirs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ defaults:
 
 env:
   APK_SHORT_NAME: Wholphin.apk
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx4g -XX:MaxMetaspaceSize=512m'"
 
 jobs:
   publish:
@@ -36,7 +37,7 @@ jobs:
           KEY_STORE_PASSWORD: "${{ secrets.KEY_STORE_PASSWORD }}"
           SIGNING_KEY: "${{ secrets.SIGNING_KEY }}"
         run: |
-          ./gradlew clean assembleRelease
+          ./gradlew clean assembleRelease --no-daemon
       - name: Verify signatures
         run: |
           echo "Verify APK signatures"


### PR DESCRIPTION
Updates to increase amount of memory available during CI builds. I think this will help with the intermittent `A failure occurred while executing "com.android.build.gradle.tasks.PackageAndroidArtifact$IncrementalSplitterRunnable` CI errors.

No user facing changes