### PR TITLE
Fix issue when holding down on playback overylay queue

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackOverlay.kt
@@ -291,6 +291,8 @@ fun PlaybackOverlay(
                                         state = OverlayViewState.CONTROLLER
                                     }
                                     true
+                                } else if (isDown(e)) {
+                                    true
                                 } else {
                                     false
                                 }


### PR DESCRIPTION
Fixes an issues where if the playback overlay is showing and there is a queue of items, then holding the D-Pad down button would scroll down but visually lose focus on the queue items.