### PR TITLE
Fix a couple issues with transcoding

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -460,7 +460,7 @@ class PlaybackViewModel
                             audioStreamIndex = audioIndex,
                             subtitleStreamIndex = subtitleIndex,
                             mediaSourceId = currentItemPlayback.sourceId?.toServerString(),
-                            alwaysBurnInSubtitleWhenTranscoding = subtitleIndex != null && subtitleIndex >= 0,
+                            alwaysBurnInSubtitleWhenTranscoding = false,
                             maxStreamingBitrate = maxBitrate.toInt(),
                             enableDirectPlay = enableDirectPlay,
                             enableDirectStream = enableDirectStream,
@@ -597,7 +597,7 @@ class PlaybackViewModel
                                                 player,
                                                 playerBackend,
                                                 source.supportsDirectPlay,
-                                                audioIndex,
+                                                audioIndex.takeIf { transcodeType == PlayMethod.DIRECT_PLAY },
                                                 subtitleIndex,
                                                 source,
                                             )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/TrackSelectionUtils.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/TrackSelectionUtils.kt
@@ -10,6 +10,7 @@ import com.github.damontecres.wholphin.preferences.PlayerBackend
 import org.jellyfin.sdk.model.api.MediaSourceInfo
 import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.MediaStreamType
+import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import timber.log.Timber
 
 object TrackSelectionUtils {
@@ -211,12 +212,16 @@ val MediaSourceInfo.audioStreamCount: Int
             ?.count { it.type == MediaStreamType.AUDIO } ?: 0
 
 /**
- * Returns the [MediaStream] for the given subtitle index iff it is external
+ * Returns the [MediaStream] for the given subtitle index iff it is delivered external
  */
-fun MediaSourceInfo.findExternalSubtitle(subtitleIndex: Int?): MediaStream? =
+fun MediaSourceInfo.findExternalSubtitle(subtitleIndex: Int?): MediaStream? = mediaStreams?.findExternalSubtitle(subtitleIndex)
+
+fun List<MediaStream>.findExternalSubtitle(subtitleIndex: Int?): MediaStream? =
     subtitleIndex?.let {
-        mediaStreams
-            ?.firstOrNull { it.type == MediaStreamType.SUBTITLE && it.isExternal && it.index == subtitleIndex }
+        firstOrNull {
+            it.type == MediaStreamType.SUBTITLE && it.deliveryMethod == SubtitleDeliveryMethod.EXTERNAL &&
+                it.index == subtitleIndex
+        }
     }
 
 data class TrackSelectionResult(


### PR DESCRIPTION
If playing with transcoding, changing tracks during playback will continue to transcode instead of possibly switching to direct play.

Also support embedded subtitles that are being delivered externally.


Fixes #256
Fixes #257