### PR TITLE
Use full phases for skip buttons for better translations

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/Formatting.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/Formatting.kt
@@ -181,3 +181,15 @@ val MediaSegmentType.stringRes: Int
             MediaSegmentType.OUTRO -> R.string.outro
             MediaSegmentType.INTRO -> R.string.intro
         }
+
+@get:StringRes
+val MediaSegmentType.skipStringRes: Int
+    get() =
+        when (this) {
+            MediaSegmentType.UNKNOWN -> R.string.skip_segment_unknown
+            MediaSegmentType.COMMERCIAL -> R.string.skip_segment_commercial
+            MediaSegmentType.PREVIEW -> R.string.skip_segment_preview
+            MediaSegmentType.RECAP -> R.string.skip_segment_recap
+            MediaSegmentType.OUTRO -> R.string.skip_segment_outro
+            MediaSegmentType.INTRO -> R.string.skip_segment_intro
+        }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackControls.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackControls.kt
@@ -62,7 +62,7 @@ import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.ui.AppColors
 import com.github.damontecres.wholphin.ui.seekBack
 import com.github.damontecres.wholphin.ui.seekForward
-import com.github.damontecres.wholphin.ui.stringRes
+import com.github.damontecres.wholphin.ui.skipStringRes
 import com.github.damontecres.wholphin.ui.tryRequestFocus
 import com.github.damontecres.wholphin.util.ExceptionHandler
 import kotlinx.coroutines.delay
@@ -199,7 +199,7 @@ fun PlaybackControls(
                                 .padding(end = 32.dp),
                     ) {
                         Text(
-                            text = stringResource(R.string.skip) + " " + stringResource(segment.type.stringRes),
+                            text = stringResource(segment.type.skipStringRes),
                         )
                     }
                 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -60,7 +60,6 @@ import androidx.tv.material3.Button
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import androidx.tv.material3.surfaceColorAtElevation
-import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.model.ItemPlayback
 import com.github.damontecres.wholphin.data.model.Playlist
 import com.github.damontecres.wholphin.preferences.PlayerBackend
@@ -74,7 +73,7 @@ import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.preferences.subtitle.SubtitleSettings.applyToMpv
 import com.github.damontecres.wholphin.ui.preferences.subtitle.SubtitleSettings.toSubtitleStyle
 import com.github.damontecres.wholphin.ui.seasonEpisode
-import com.github.damontecres.wholphin.ui.stringRes
+import com.github.damontecres.wholphin.ui.skipStringRes
 import com.github.damontecres.wholphin.ui.tryRequestFocus
 import com.github.damontecres.wholphin.util.ExceptionHandler
 import com.github.damontecres.wholphin.util.LoadingState
@@ -413,7 +412,7 @@ fun PlaybackPage(
                             modifier = Modifier.focusRequester(focusRequester),
                         ) {
                             Text(
-                                text = stringResource(R.string.skip) + " " + stringResource(segment.type.stringRes),
+                                text = stringResource(segment.type.skipStringRes),
                             )
                         }
                     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -274,4 +274,10 @@
     <string name="skip_back_preference">Zurückspringen</string>
     <string name="player_backend">Wiedergabe backend</string>
     <string name="rewatch_next_up">Aktiviere erneut wiedergeben in als nächstes</string>
+    <string name="skip_segment_unknown">Segment Überspringen</string>
+    <string name="skip_segment_commercial">Werbung Überspringen</string>
+    <string name="skip_segment_preview">Vorschau Überspringen</string>
+    <string name="skip_segment_recap">Rückblick Überspringen</string>
+    <string name="skip_segment_outro">Outro Überspringen</string>
+    <string name="skip_segment_intro">Intro Überspringen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -313,6 +313,12 @@
     <string name="disable_if_crash">Disable if you experience crashes</string>
     <string name="mpv_options">MPV Options</string>
     <string name="exoplayer_options">ExoPlayer Options</string>
+    <string name="skip_segment_unknown">Skip Segment</string>
+    <string name="skip_segment_commercial">Skip Ads</string>
+    <string name="skip_segment_preview">Skip Preview</string>
+    <string name="skip_segment_recap">Skip Recap</string>
+    <string name="skip_segment_outro">Skip Outro</string>
+    <string name="skip_segment_intro">Skip Intro</string>
 
     <string-array name="theme_song_volume">
         <item>Disabled</item>


### PR DESCRIPTION
Changes the skip segment button text to use a single phrase instead of concatenating two strings. This allows correct context when translating.

Follow up from #292