### PR TITLE
Add default sort option for collections

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
@@ -88,7 +88,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.api.client.ApiClient
@@ -154,8 +153,8 @@ class CollectionFolderViewModel
                     }
 
                 val sortAndDirection =
-                    initialSortAndDirection
-                        ?: libraryDisplayInfo?.sortAndDirection
+                    libraryDisplayInfo?.sortAndDirection
+                        ?: initialSortAndDirection
                         ?: SortAndDirection.DEFAULT
 
                 val filterToUse =
@@ -233,7 +232,6 @@ class CollectionFolderViewModel
                     this@CollectionFolderViewModel.sortAndDirection.value = sortAndDirection
                     this@CollectionFolderViewModel.filter.value = filter
                 }
-                delay(1000)
                 val newPager = createPager(sortAndDirection, recursive, filter, useSeriesForPrimary)
                 newPager.init()
                 if (newPager.isNotEmpty()) newPager.getBlocking(0)
@@ -270,22 +268,26 @@ class CollectionFolderViewModel
                                 excludeItemIds = item?.let { listOf(item.id) },
                                 sortBy =
                                     buildList {
-                                        add(sortAndDirection.sort)
-                                        if (sortAndDirection.sort != ItemSortBy.SORT_NAME) {
-                                            add(ItemSortBy.SORT_NAME)
-                                        }
-                                        if (item?.data?.collectionType == CollectionType.MOVIES) {
-                                            add(ItemSortBy.PRODUCTION_YEAR)
+                                        if (sortAndDirection.sort != ItemSortBy.DEFAULT) {
+                                            add(sortAndDirection.sort)
+                                            if (sortAndDirection.sort != ItemSortBy.SORT_NAME) {
+                                                add(ItemSortBy.SORT_NAME)
+                                            }
+                                            if (item?.data?.collectionType == CollectionType.MOVIES) {
+                                                add(ItemSortBy.PRODUCTION_YEAR)
+                                            }
                                         }
                                     },
                                 sortOrder =
                                     buildList {
-                                        add(sortAndDirection.direction)
-                                        if (sortAndDirection.sort != ItemSortBy.SORT_NAME) {
-                                            add(SortOrder.ASCENDING)
-                                        }
-                                        if (item?.data?.collectionType == CollectionType.MOVIES) {
-                                            add(SortOrder.ASCENDING)
+                                        if (sortAndDirection.sort != ItemSortBy.DEFAULT) {
+                                            add(sortAndDirection.direction)
+                                            if (sortAndDirection.sort != ItemSortBy.SORT_NAME) {
+                                                add(SortOrder.ASCENDING)
+                                            }
+                                            if (item?.data?.collectionType == CollectionType.MOVIES) {
+                                                add(SortOrder.ASCENDING)
+                                            }
                                         }
                                     },
                                 fields = SlimItemFields,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/data/SortAndDirection.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/data/SortAndDirection.kt
@@ -84,6 +84,21 @@ val PlaylistSortOptions =
         ItemSortBy.RANDOM,
     )
 
+val BoxSetSortOptions =
+    listOf(
+        ItemSortBy.DEFAULT,
+        ItemSortBy.SORT_NAME,
+        ItemSortBy.PREMIERE_DATE,
+        ItemSortBy.DATE_CREATED,
+        ItemSortBy.DATE_PLAYED,
+        ItemSortBy.COMMUNITY_RATING,
+        ItemSortBy.CRITIC_RATING,
+        ItemSortBy.OFFICIAL_RATING,
+        ItemSortBy.RUNTIME,
+        ItemSortBy.PLAY_COUNT,
+        ItemSortBy.RANDOM,
+    )
+
 @StringRes
 fun getStringRes(sort: ItemSortBy): Int =
     when (sort) {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderBoxSet.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderBoxSet.kt
@@ -14,8 +14,11 @@ import com.github.damontecres.wholphin.data.model.GetItemsFilter
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.CollectionFolderGrid
 import com.github.damontecres.wholphin.ui.components.CollectionFolderGridParameters
-import com.github.damontecres.wholphin.ui.data.MovieSortOptions
+import com.github.damontecres.wholphin.ui.data.BoxSetSortOptions
+import com.github.damontecres.wholphin.ui.data.SortAndDirection
 import com.github.damontecres.wholphin.ui.preferences.PreferencesViewModel
+import org.jellyfin.sdk.model.api.ItemSortBy
+import org.jellyfin.sdk.model.api.SortOrder
 import java.util.UUID
 
 @Composable
@@ -37,7 +40,8 @@ fun CollectionFolderBoxSet(
         initialFilter = filter,
         showTitle = showHeader,
         recursive = recursive,
-        sortOptions = MovieSortOptions,
+        sortOptions = BoxSetSortOptions,
+        initialSortAndDirection = SortAndDirection(ItemSortBy.DEFAULT, SortOrder.ASCENDING),
         modifier =
             modifier
                 .padding(start = 16.dp),

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderGeneric.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderGeneric.kt
@@ -17,6 +17,7 @@ import com.github.damontecres.wholphin.ui.components.CollectionFolderGrid
 import com.github.damontecres.wholphin.ui.components.CollectionFolderGridParameters
 import com.github.damontecres.wholphin.ui.data.VideoSortOptions
 import com.github.damontecres.wholphin.ui.preferences.PreferencesViewModel
+import org.jellyfin.sdk.model.api.ItemSortBy
 import java.util.UUID
 
 @Composable
@@ -29,6 +30,7 @@ fun CollectionFolderGeneric(
     modifier: Modifier = Modifier,
     filter: GetItemsFilter = GetItemsFilter(),
     filterOptions: List<ItemFilterBy<*>> = DefaultFilterOptions,
+    sortOptions: List<ItemSortBy> = VideoSortOptions,
     preferencesViewModel: PreferencesViewModel = hiltViewModel(),
 ) {
     var showHeader by remember { mutableStateOf(true) }
@@ -47,7 +49,7 @@ fun CollectionFolderGeneric(
         initialFilter = filter,
         showTitle = showHeader,
         recursive = recursive,
-        sortOptions = VideoSortOptions,
+        sortOptions = sortOptions,
         modifier =
             modifier
                 .padding(start = 16.dp),

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
@@ -7,6 +7,7 @@ import com.github.damontecres.wholphin.data.filter.DefaultForGenresFilterOptions
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.ItemGrid
 import com.github.damontecres.wholphin.ui.components.LicenseInfo
+import com.github.damontecres.wholphin.ui.data.MovieSortOptions
 import com.github.damontecres.wholphin.ui.detail.CollectionFolderBoxSet
 import com.github.damontecres.wholphin.ui.detail.CollectionFolderGeneric
 import com.github.damontecres.wholphin.ui.detail.CollectionFolderLiveTv
@@ -239,12 +240,14 @@ fun CollectionFolder(
             )
 
         CollectionType.BOXSETS ->
-            CollectionFolderBoxSet(
-                preferences,
-                destination.itemId,
-                destination.item,
-                false,
-                modifier,
+            CollectionFolderGeneric(
+                preferences = preferences,
+                itemId = destination.itemId,
+                usePosters = true,
+                recursive = false,
+                playEnabled = false,
+                modifier = modifier,
+                sortOptions = MovieSortOptions,
             )
 
         CollectionType.PLAYLISTS ->


### PR DESCRIPTION
Adds a "default" sort option for collections/boxsets. This makes the app request no sort at all and leaves it up to the server to order the items.

Fixes #83 