### PR TITLE
Add setting to increase logging verbosity

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
@@ -41,6 +41,7 @@ import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.ui.nav.ApplicationContent
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.theme.WholphinTheme
+import com.github.damontecres.wholphin.util.DebugLogTree
 import com.github.damontecres.wholphin.util.profile.createDeviceProfile
 import dagger.hilt.android.AndroidEntryPoint
 import okhttp3.OkHttpClient
@@ -87,6 +88,9 @@ class MainActivity : AppCompatActivity() {
             CoilConfig(okHttpClient, false)
             val appPreferences by userPreferencesDataStore.data.collectAsState(null)
             appPreferences?.let { appPreferences ->
+                LaunchedEffect(appPreferences.debugLogging) {
+                    DebugLogTree.INSTANCE.enabled = appPreferences.debugLogging
+                }
                 WholphinTheme(
                     true,
                     appThemeColors = appPreferences.interfacePreferences.appThemeColors,

--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -13,6 +13,7 @@ import com.github.damontecres.wholphin.ui.preferences.ConditionalPreferences
 import com.github.damontecres.wholphin.ui.preferences.PreferenceGroup
 import com.github.damontecres.wholphin.ui.preferences.PreferenceScreenOption
 import com.github.damontecres.wholphin.ui.preferences.PreferenceValidation
+import com.github.damontecres.wholphin.util.DebugLogTree
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -699,6 +700,19 @@ sealed interface AppPreference<T> {
                 },
                 summary = R.string.disable_if_crash,
             )
+
+        val DebugLogging =
+            AppSwitchPreference(
+                title = R.string.verbose_logging,
+                defaultValue = false,
+                getter = { DebugLogTree.INSTANCE.enabled },
+                setter = { prefs, value ->
+                    DebugLogTree.INSTANCE.enabled = value
+                    prefs.update { debugLogging = value }
+                },
+                summaryOn = R.string.enabled,
+                summaryOff = R.string.disabled,
+            )
     }
 }
 
@@ -837,6 +851,7 @@ val advancedPreferences =
                     listOf(
                         AppPreference.SendAppLogs,
                         AppPreference.SendCrashReports,
+                        AppPreference.DebugLogging,
                         AppPreference.ClearImageCache,
                         AppPreference.OssLicenseInfo,
                     ),

--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreferencesSerializer.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreferencesSerializer.kt
@@ -20,6 +20,8 @@ class AppPreferencesSerializer
                 .apply {
                     updateUrl = AppPreference.UpdateUrl.defaultValue
                     autoCheckForUpdates = AppPreference.AutoCheckForUpdates.defaultValue
+                    sendCrashReports = AppPreference.SendCrashReports.defaultValue
+                    debugLogging = AppPreference.DebugLogging.defaultValue
 
                     playbackPreferences =
                         PlaybackPreferences

--- a/app/src/main/java/com/github/damontecres/wholphin/util/DebugLogTree.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/DebugLogTree.kt
@@ -1,0 +1,42 @@
+package com.github.damontecres.wholphin.util
+
+import android.util.Log
+import com.github.damontecres.wholphin.BuildConfig
+import timber.log.Timber
+
+class DebugLogTree private constructor() : Timber.Tree() {
+    // Only add logging for below INFO, production logger in WholphinApplication logs >=INFO
+    override fun isLoggable(
+        tag: String?,
+        priority: Int,
+    ): Boolean = priority < Log.INFO && !BuildConfig.DEBUG
+
+    override fun log(
+        priority: Int,
+        tag: String?,
+        message: String,
+        t: Throwable?,
+    ) {
+        Log.println(priority, tag ?: "Wholphin", message)
+    }
+
+    var enabled: Boolean
+        get() = Timber.forest().contains(this)
+        set(value) {
+            synchronized(this) {
+                if (value) {
+                    if (!Timber.forest().contains(this)) {
+                        Timber.plant(this)
+                    }
+                } else {
+                    if (Timber.forest().contains(this)) {
+                        Timber.uproot(this)
+                    }
+                }
+            }
+        }
+
+    companion object {
+        val INSTANCE = DebugLogTree()
+    }
+}

--- a/app/src/main/proto/WholphinDataStore.proto
+++ b/app/src/main/proto/WholphinDataStore.proto
@@ -144,4 +144,5 @@ message AppPreferences {
   bool auto_check_for_updates = 6;
   string update_url = 7;
   bool send_crash_reports = 8;
+  bool debug_logging = 9;
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -327,6 +327,7 @@
     <string name="dolby_vision">Dolby Vision</string>
     <string name="dolby_atmos">Dolby Atmos</string>
     <string name="subtitle_margin">Margin</string>
+    <string name="verbose_logging">Verbose logging</string>
 
     <string-array name="theme_song_volume">
         <item>Disabled</item>


### PR DESCRIPTION
Adds a toggle to increase the verbosity of the app logs for release/production builds

Most users won't need to use this, but it can be helpful when [gathering app logs](https://github.com/damontecres/Wholphin/wiki/Gathering-app-logs) to report an issue.