### PR TITLE
Support VC-1 direct play if device supports it

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/util/profile/Codec.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/profile/Codec.kt
@@ -67,6 +67,7 @@ object Codec {
         const val VP8 = "vp8"
         const val VP9 = "vp9"
         const val AV1 = "av1"
+        const val VC1 = "vc1"
     }
 
     object Subtitle {

--- a/app/src/main/java/com/github/damontecres/wholphin/util/profile/DeviceProfileUtils.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/profile/DeviceProfileUtils.kt
@@ -92,9 +92,11 @@ fun createDeviceProfile(
     val avcHigh10Level = mediaTest.getAVCHigh10Level()
     val supportsAV1 = mediaTest.supportsAV1()
     val supportsAV1Main10 = mediaTest.supportsAV1Main10()
+    val supportsVC1 = mediaTest.supportsVc1()
     val maxResolutionAVC = mediaTest.getMaxResolution(MimeTypes.VIDEO_H264)
     val maxResolutionHevc = mediaTest.getMaxResolution(MimeTypes.VIDEO_H265)
     val maxResolutionAV1 = mediaTest.getMaxResolution(MimeTypes.VIDEO_AV1)
+    val maxResolutionVC1 = mediaTest.getMaxResolution(MimeTypes.VIDEO_VC1)
 
     // / HDR capabilities
 
@@ -171,6 +173,7 @@ fun createDeviceProfile(
             Codec.Video.HEVC,
             Codec.Video.MPEG,
             Codec.Video.MPEG2VIDEO,
+            Codec.Video.VC1,
             Codec.Video.VP8,
             Codec.Video.VP9,
         )
@@ -329,6 +332,19 @@ fun createDeviceProfile(
         }
     }
 
+    // VC1 profile
+    codecProfile {
+        type = CodecType.VIDEO
+        codec = Codec.Video.VC1
+
+        conditions {
+            when {
+                !supportsVC1 -> ProfileConditionValue.VIDEO_PROFILE equals "none"
+                else -> ProfileConditionValue.VIDEO_PROFILE notEquals "none"
+            }
+        }
+    }
+
     // Get max resolutions for common codecs
     // AVC
     codecProfile {
@@ -360,6 +376,17 @@ fun createDeviceProfile(
         conditions {
             ProfileConditionValue.WIDTH lowerThanOrEquals maxResolutionAV1.width
             ProfileConditionValue.HEIGHT lowerThanOrEquals maxResolutionAV1.height
+        }
+    }
+
+    // VC1
+    codecProfile {
+        type = CodecType.VIDEO
+        codec = Codec.Video.VC1
+
+        conditions {
+            ProfileConditionValue.WIDTH lowerThanOrEquals maxResolutionVC1.width
+            ProfileConditionValue.HEIGHT lowerThanOrEquals maxResolutionVC1.height
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/profile/MediaCodecCapabilitiesTest.kt
@@ -9,6 +9,7 @@ import android.media.MediaFormat
 import android.os.Build
 import android.util.Size
 import androidx.core.content.ContextCompat
+import androidx.media3.common.MimeTypes
 import timber.log.Timber
 
 class MediaCodecCapabilitiesTest(
@@ -213,6 +214,8 @@ class MediaCodecCapabilitiesTest(
                 level >= item.first
             }?.second ?: 0
     }
+
+    fun supportsVc1(): Boolean = hasCodecForMime(MimeTypes.VIDEO_VC1)
 
     private fun getDecoderLevel(
         mime: String,


### PR DESCRIPTION
Adds VC-1 to ExoPlayer direct play profile, if the device supports it.

Also proposed to add this to the official app in https://github.com/jellyfin/jellyfin-androidtv/pull/5208