### PR TITLE
Bump compose version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,7 @@ kotlin = "2.2.21"
 ksp = "2.3.0"
 coreKtx = "1.17.0"
 appcompat = "1.7.1"
-composeBom = "2025.11.01"
-compose-runtime = "1.9.5"
+composeBom = "2025.12.00"
 multiplatformMarkdownRenderer = "0.38.1"
 programguide = "1.6.0"
 slf4j2Timber = "1.2"
@@ -19,7 +18,7 @@ timber = "5.0.1"
 tvFoundation = "1.0.0-alpha12"
 tvMaterial = "1.0.1"
 lifecycleRuntimeKtx = "2.10.0"
-activityCompose = "1.12.0"
+activityCompose = "1.12.1"
 androidx-media3 = "1.8.0"
 coil = "3.3.0"
 jellyfin-sdk = "1.7.1"
@@ -32,7 +31,6 @@ kotlinx-serialization = "1.9.0"
 protobuf-javalite = "4.33.1"
 hilt = "2.57.2"
 room = "2.8.4"
-material3 = "1.4.0"
 preferenceKtx = "1.2.1"
 
 [libraries]
@@ -50,9 +48,9 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
-androidx-compose-runtime = { module = "androidx.compose.runtime:runtime-android", version.ref = "compose-runtime" }
-androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "compose-runtime" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime-android" }
+androidx-compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }
 
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 androidx-tv-foundation = { group = "androidx.tv", name = "tv-foundation", version.ref = "tvFoundation" }


### PR DESCRIPTION
The blog says this compose version improved scroll performance:https://android-developers.googleblog.com/2025/12/whats-new-in-jetpack-compose-december.html

Dev notes: Also switches a few more compose libraries to use the BOM version instead of defining per library