### PR TITLE
Ignore auto sign in if user has PIN

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
@@ -179,7 +179,7 @@ class MainActivity : AppCompatActivity() {
                             } else {
                                 DisposableEffect(Unit) {
                                     onDispose {
-                                        if (!appPreferences.signInAutomatically) {
+                                        if (!appPreferences.signInAutomatically || current?.user?.hasPin == true) {
                                             serverRepository.closeSession()
                                         }
                                     }
@@ -252,7 +252,7 @@ class MainActivity : AppCompatActivity() {
         val signInAutomatically =
             runBlocking { userPreferencesDataStore.data.firstOrNull()?.signInAutomatically } ?: true
         Timber.i("onRestart: signInAutomatically=$signInAutomatically")
-        if (!signInAutomatically) {
+        if (!signInAutomatically || serverRepository.currentUser.value?.hasPin == true) {
             serverRepository.closeSession()
         }
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/data/ServerRepository.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/ServerRepository.kt
@@ -109,6 +109,8 @@ class ServerRepository
 
         /**
          * Restores a session for the given server & user such as when the app reopens
+         *
+         * If user has a PIN, this returns false
          */
         suspend fun restoreSession(
             serverId: UUID?,
@@ -124,7 +126,7 @@ class ServerRepository
                 }
             if (serverAndUsers != null) {
                 val user = serverAndUsers.users.firstOrNull { it.id == userId }
-                if (user != null) {
+                if (user != null && !user.hasPin) {
                     changeUser(serverAndUsers.server, user)
                     return true
                 }

--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/JellyfinServer.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/JellyfinServer.kt
@@ -52,6 +52,8 @@ data class JellyfinUser(
     val accessToken: String?,
     val pin: String? = null,
 ) {
+    val hasPin: Boolean get() = pin.isNotNullOrBlank()
+
     override fun toString(): String =
         "JellyfinUser(rowId=$rowId, id=$id, name=$name, serverId=$serverId, accessToken?=${accessToken.isNotNullOrBlank()}, pin?=${pin.isNotNullOrBlank()})"
 }


### PR DESCRIPTION
If the current user has a PIN, the sign in automatically setting is ignored if the app is put in the background or restarted.

Follow up to #356 & https://github.com/damontecres/Wholphin/issues/321#issuecomment-3621312496

I think the PIN protection needs some more thought overall.