### PR TITLE
Fix trickplay image scaling

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/SeekPreviewImage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/SeekPreviewImage.kt
@@ -84,7 +84,7 @@ fun SeekPreviewImage(
     if (previewImageUrl.isNotNullOrBlank()) {
         val height = 160.dp
         val width = height * (trickPlayInfo.width.toFloat() / trickPlayInfo.height)
-        val scale = LocalDensity.current.density
+        val scale = with(LocalDensity.current) { width.toPx() / trickPlayInfo.width }
 
         val model =
             remember(previewImageUrl) {


### PR DESCRIPTION
Fix to #467 to scale the tiles by the actual calculated ratio based on the server's fixed width and our target width instead of using the general density scaling

I verified this on 1080p & 4k with 4:3, 16:9, & 2.35:1 videos.

Fixes https://github.com/damontecres/Wholphin/issues/432#issuecomment-3657381461