### PR TITLE
Redesign alphabet picker to fit all letters on screen

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CardGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CardGrid.kt
@@ -383,6 +383,7 @@ fun CardGrid(
                             }
                         Timber.d("Alphabet jump to $jumpPosition")
                         if (jumpPosition >= 0) {
+                            pager.getOrNull(jumpPosition)
                             gridState.scrollToItem(jumpPosition)
                             focusOn(jumpPosition)
                             alphabetFocus = true


### PR DESCRIPTION
- Switch to tv.material3.Button with ButtonDefaults for better styling
- Add opacity changes based on focus (0.85f focused, 0.2f unfocused)
- Keep selected letter fully visible when picker is unfocused
- Reduce button size from 24.dp to 14.dp to fit all letters
- Reduce spacing between letters (1.1.dp vertical, 2.dp horizontal)
- Use transparent backgrounds for unfocused letters
- Use border color for selected letter when focused, tertiary when unfocused
- Add Box with CircleShape clip to prevent focus indicator overflow
- Reduce font size by 15%
- Add 16.dp end padding to push picker away from screen edge

When using the 'Show details' view option, the alphabet picker will still overflow the bottom edge of the screen. I find this an acceptable option though, as the backdrop pushes the card grid further down the page.


Alphabet picker not in focus
<img width="1920" height="1080" alt="Screenshot_20251217_044710" src="https://github.com/user-attachments/assets/875b58fc-e3ff-49b6-b212-aae2b6b1ce1a" />

Alphabet picker in focus
<img width="1920" height="1080" alt="Screenshot_20251217_044729" src="https://github.com/user-attachments/assets/9c5e2ff9-f6b3-4303-84d2-b3de37864d5e" />

Show details view
<img width="1920" height="1080" alt="Screenshot_20251217_052250" src="https://github.com/user-attachments/assets/fd40acef-60eb-4d7b-93a1-9373b4bf5fcc" />


Closes https://github.com/damontecres/Wholphin/issues/386

>[!NOTE]
> AI was used in the making of this PR