### PR TITLE
Fix backdrop not clearing on favorite tab changes

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
@@ -205,6 +205,9 @@ class CollectionFolderViewModel
             this.viewOptions.value = viewOptions
             viewModelScope.launch(ExceptionHandler() + Dispatchers.IO) {
                 saveLibraryDisplayInfo(viewOptions = viewOptions)
+                if (!viewOptions.showDetails) {
+                    backdropService.clearBackdrop()
+                }
             }
         }
 
@@ -514,7 +517,7 @@ fun CollectionFolderGrid(
     playEnabled: Boolean,
     defaultViewOptions: ViewOptions,
     modifier: Modifier = Modifier,
-    viewModel: CollectionFolderViewModel = hiltViewModel(),
+    viewModel: CollectionFolderViewModel = hiltViewModel(key = itemId),
     playlistViewModel: AddPlaylistViewModel = hiltViewModel(),
     initialSortAndDirection: SortAndDirection? = null,
     showTitle: Boolean = true,


### PR DESCRIPTION
## Description
Fixes the backdrop not being cleared when switching tabs on the favorites page by ensuring each has a unique view model.

Also clears the backdrop if the view option to show details is turned off.

### Related issues
#476 
#499