### PR TITLE
Enforce a minimum aspect ratio

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/UiConstants.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/UiConstants.kt
@@ -76,6 +76,8 @@ object AspectRatios {
     const val FOUR_THREE = 4f / 3f
     const val TALL = 2f / 3f
     const val SQUARE = 1f
+
+    const val MIN = TALL
 }
 
 enum class AspectRatio(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/EpisodeCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/EpisodeCard.kt
@@ -64,7 +64,7 @@ fun EpisodeCard(
     } else {
         focusedAfterDelay = false
     }
-    val aspectRatio = item?.aspectRatio ?: AspectRatios.TALL
+    val aspectRatio = item?.aspectRatio?.coerceAtLeast(AspectRatios.MIN) ?: AspectRatios.MIN
     val width = imageHeight * aspectRatio
     val height = imageWidth * (1f / aspectRatio)
     Column(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/GridCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/GridCard.kt
@@ -96,7 +96,7 @@ fun GridCard(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .aspectRatio(imageAspectRatio)
+                        .aspectRatio(imageAspectRatio.coerceAtLeast(AspectRatios.MIN))
                         .background(MaterialTheme.colorScheme.surfaceVariant),
             )
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/SeasonCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/SeasonCard.kt
@@ -139,8 +139,9 @@ fun SeasonCard(
     } else {
         focusedAfterDelay = false
     }
-    val width = imageHeight * aspectRatio
-    val height = imageWidth * (1f / aspectRatio)
+    val aspectRationToUse = aspectRatio.coerceAtLeast(AspectRatios.MIN)
+    val width = imageHeight * aspectRationToUse
+    val height = imageWidth * (1f / aspectRationToUse)
     Column(
         verticalArrangement = Arrangement.spacedBy(spaceBetween),
         modifier = modifier.size(width, height),
@@ -149,7 +150,7 @@ fun SeasonCard(
             modifier =
                 Modifier
                     .size(imageWidth, imageHeight)
-                    .aspectRatio(aspectRatio),
+                    .aspectRatio(aspectRationToUse),
             onClick = onClick,
             onLongClick = onLongClick,
             interactionSource = interactionSource,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/NextUpEpisode.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/NextUpEpisode.kt
@@ -98,7 +98,7 @@ fun NextUpEpisode(
                     modifier =
                         Modifier
                             .fillMaxHeight()
-                            .aspectRatio(aspectRatio)
+                            .aspectRatio(aspectRatio.coerceAtLeast(AspectRatios.MIN))
 //                            .fillMaxSize()
 //                            .weight(1f)
                             .focusRequester(focusRequester),


### PR DESCRIPTION
## Description
When using a server provided aspect, force a minimum value (.666) in case the server returns unusable data like zero.

Note: I have not been able to reproduce the errors in #451 to verify that this PR will fix it. And it's not clear to me why #453 did not fix it either. However, this PR shouldn't impact anything if the server is sending valid aspect ratios and should at least prevent the crash on the UI side.

### Related issues
Follow up to #453
Hopefully fixes #451

