### PR TITLE
Don't use saved library info for genre grids

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/GetItemsFilter.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/GetItemsFilter.kt
@@ -15,6 +15,16 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 import java.util.UUID
 
 @Serializable
+data class CollectionFolderFilter(
+    val nameOverride: String? = null,
+    val filter: GetItemsFilter = GetItemsFilter(),
+    /**
+     * Whether to use the libray's saved sort & filter
+     */
+    val useSavedLibraryDisplayInfo: Boolean = true,
+)
+
+@Serializable
 data class GetItemsFilter(
     val favorite: Boolean? = null,
     val genres: List<UUID>? = null,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/GenreCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/GenreCard.kt
@@ -65,7 +65,6 @@ fun GenreCard(
                     .fillMaxSize()
                     .clip(RoundedCornerShape(8.dp)),
         ) {
-            Timber.v("genre image=${genre?.imageUrl}")
             if (genre?.imageUrl.isNotNullOrBlank()) {
                 AsyncImage(
                     model =

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
@@ -58,6 +58,7 @@ import com.github.damontecres.wholphin.data.filter.PlayedFilter
 import com.github.damontecres.wholphin.data.filter.VideoTypeFilter
 import com.github.damontecres.wholphin.data.filter.YearFilter
 import com.github.damontecres.wholphin.data.model.BaseItem
+import com.github.damontecres.wholphin.data.model.CollectionFolderFilter
 import com.github.damontecres.wholphin.data.model.GetItemsFilter
 import com.github.damontecres.wholphin.data.model.GetItemsFilterOverride
 import com.github.damontecres.wholphin.data.model.LibraryDisplayInfo
@@ -136,12 +137,13 @@ class CollectionFolderViewModel
         val viewOptions = MutableLiveData<ViewOptions>()
 
         private var useSeriesForPrimary: Boolean = true
+        private lateinit var collectionFilter: CollectionFolderFilter
 
         fun init(
             itemId: String,
             initialSortAndDirection: SortAndDirection?,
             recursive: Boolean,
-            filter: GetItemsFilter,
+            collectionFilter: CollectionFolderFilter,
             useSeriesForPrimary: Boolean,
             defaultViewOptions: ViewOptions,
         ): Job =
@@ -151,6 +153,7 @@ class CollectionFolderViewModel
                     context.getString(R.string.error_loading_collection, itemId),
                 ) + Dispatchers.IO,
             ) {
+                this@CollectionFolderViewModel.collectionFilter = collectionFilter
                 this@CollectionFolderViewModel.useSeriesForPrimary = useSeriesForPrimary
                 this@CollectionFolderViewModel.itemId = itemId
                 itemId.toUUIDOrNull()?.let {
@@ -166,15 +169,17 @@ class CollectionFolderViewModel
                 )
 
                 val sortAndDirection =
-                    libraryDisplayInfo?.sortAndDirection
-                        ?: initialSortAndDirection
-                        ?: SortAndDirection.DEFAULT
+                    if (collectionFilter.useSavedLibraryDisplayInfo) {
+                        libraryDisplayInfo?.sortAndDirection
+                    } else {
+                        null
+                    } ?: initialSortAndDirection ?: SortAndDirection.DEFAULT
 
                 val filterToUse =
-                    if (libraryDisplayInfo?.filter != null) {
-                        filter.merge(libraryDisplayInfo.filter)
+                    if (collectionFilter.useSavedLibraryDisplayInfo && libraryDisplayInfo?.filter != null) {
+                        collectionFilter.filter.merge(libraryDisplayInfo.filter)
                     } else {
-                        filter
+                        collectionFilter.filter
                     }
 
                 loadResults(true, sortAndDirection, recursive, filterToUse, useSeriesForPrimary)
@@ -185,18 +190,20 @@ class CollectionFolderViewModel
             newSort: SortAndDirection = this.sortAndDirection.value!!,
             viewOptions: ViewOptions? = this.viewOptions.value,
         ) {
-            serverRepository.currentUser.value?.let { user ->
-                viewModelScope.launch(Dispatchers.IO) {
-                    val libraryDisplayInfo =
-                        LibraryDisplayInfo(
-                            userId = user.rowId,
-                            itemId = itemId,
-                            sort = newSort.sort,
-                            direction = newSort.direction,
-                            filter = newFilter,
-                            viewOptions = viewOptions,
-                        )
-                    libraryDisplayInfoDao.saveItem(libraryDisplayInfo)
+            if (collectionFilter.useSavedLibraryDisplayInfo) {
+                serverRepository.currentUser.value?.let { user ->
+                    viewModelScope.launch(Dispatchers.IO) {
+                        val libraryDisplayInfo =
+                            LibraryDisplayInfo(
+                                userId = user.rowId,
+                                itemId = itemId,
+                                sort = newSort.sort,
+                                direction = newSort.direction,
+                                filter = newFilter,
+                                viewOptions = viewOptions,
+                            )
+                        libraryDisplayInfoDao.saveItem(libraryDisplayInfo)
+                    }
                 }
             }
         }
@@ -490,7 +497,7 @@ class CollectionFolderViewModel
 fun CollectionFolderGrid(
     preferences: UserPreferences,
     itemId: UUID,
-    initialFilter: GetItemsFilter,
+    initialFilter: CollectionFolderFilter,
     recursive: Boolean,
     onClickItem: (Int, BaseItem) -> Unit,
     sortOptions: List<ItemSortBy>,
@@ -523,7 +530,7 @@ fun CollectionFolderGrid(
 fun CollectionFolderGrid(
     preferences: UserPreferences,
     itemId: String,
-    initialFilter: GetItemsFilter,
+    initialFilter: CollectionFolderFilter,
     recursive: Boolean,
     onClickItem: (Int, BaseItem) -> Unit,
     sortOptions: List<ItemSortBy>,
@@ -550,7 +557,7 @@ fun CollectionFolderGrid(
         )
     }
     val sortAndDirection by viewModel.sortAndDirection.observeAsState(SortAndDirection.DEFAULT)
-    val filter by viewModel.filter.observeAsState(initialFilter)
+    val filter by viewModel.filter.observeAsState(initialFilter.filter)
     val loading by viewModel.loading.observeAsState(LoadingState.Loading)
     val backgroundLoading by viewModel.backgroundLoading.observeAsState(LoadingState.Loading)
     val item by viewModel.item.observeAsState()
@@ -574,11 +581,17 @@ fun CollectionFolderGrid(
 
         LoadingState.Success -> {
             pager?.let { pager ->
+                val title =
+                    initialFilter.nameOverride
+                        ?: item?.name
+                        ?: item?.data?.collectionType?.name
+                        ?: stringResource(R.string.collection)
                 Box(modifier = modifier) {
                     CollectionFolderGridContent(
-                        preferences,
-                        item,
-                        pager,
+                        preferences = preferences,
+                        item = item,
+                        title = title,
+                        pager = pager,
                         sortAndDirection = sortAndDirection!!,
                         modifier = Modifier.fillMaxSize(),
                         onClickItem = onClickItem,
@@ -699,6 +712,7 @@ fun CollectionFolderGrid(
 fun CollectionFolderGridContent(
     preferences: UserPreferences,
     item: BaseItem?,
+    title: String,
     pager: List<BaseItem?>,
     sortAndDirection: SortAndDirection,
     onClickItem: (Int, BaseItem) -> Unit,
@@ -722,7 +736,6 @@ fun CollectionFolderGridContent(
     onFilterChange: (GetItemsFilter) -> Unit = {},
 ) {
     val context = LocalContext.current
-    val title = item?.name ?: item?.data?.collectionType?.name ?: stringResource(R.string.collection)
 
     var showHeader by rememberSaveable { mutableStateOf(true) }
     var showViewOptions by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderBoxSet.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderBoxSet.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.github.damontecres.wholphin.data.model.BaseItem
-import com.github.damontecres.wholphin.data.model.GetItemsFilter
+import com.github.damontecres.wholphin.data.model.CollectionFolderFilter
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.CollectionFolderGrid
 import com.github.damontecres.wholphin.ui.components.ViewOptionsPoster
@@ -28,7 +28,7 @@ fun CollectionFolderBoxSet(
     item: BaseItem?,
     recursive: Boolean,
     modifier: Modifier = Modifier,
-    filter: GetItemsFilter = GetItemsFilter(),
+    filter: CollectionFolderFilter = CollectionFolderFilter(),
     preferencesViewModel: PreferencesViewModel = hiltViewModel(),
     playEnabled: Boolean = false,
 ) {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderGeneric.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderGeneric.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.github.damontecres.wholphin.data.filter.DefaultFilterOptions
 import com.github.damontecres.wholphin.data.filter.ItemFilterBy
-import com.github.damontecres.wholphin.data.model.GetItemsFilter
+import com.github.damontecres.wholphin.data.model.CollectionFolderFilter
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.CollectionFolderGrid
 import com.github.damontecres.wholphin.ui.components.ViewOptionsPoster
@@ -29,7 +29,7 @@ fun CollectionFolderGeneric(
     recursive: Boolean,
     playEnabled: Boolean,
     modifier: Modifier = Modifier,
-    filter: GetItemsFilter = GetItemsFilter(),
+    filter: CollectionFolderFilter = CollectionFolderFilter(),
     filterOptions: List<ItemFilterBy<*>> = DefaultFilterOptions,
     sortOptions: List<ItemSortBy> = VideoSortOptions,
     preferencesViewModel: PreferencesViewModel = hiltViewModel(),

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderLiveTv.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderLiveTv.kt
@@ -29,7 +29,7 @@ import androidx.lifecycle.viewModelScope
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.model.BaseItem
-import com.github.damontecres.wholphin.data.model.GetItemsFilter
+import com.github.damontecres.wholphin.data.model.CollectionFolderFilter
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.NavigationManager
@@ -164,7 +164,7 @@ fun CollectionFolderLiveTv(
                         preferences = preferences,
                         onClickItem = onClickItem,
                         itemId = folders[folderIndex].id,
-                        initialFilter = GetItemsFilter(),
+                        initialFilter = CollectionFolderFilter(),
                         showTitle = false,
                         recursive = false,
                         sortOptions = VideoSortOptions,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderMovie.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderMovie.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.github.damontecres.wholphin.R
+import com.github.damontecres.wholphin.data.model.CollectionFolderFilter
 import com.github.damontecres.wholphin.data.model.GetItemsFilter
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.CollectionFolderGrid
@@ -115,8 +116,11 @@ fun CollectionFolderMovie(
                     },
                     itemId = destination.itemId,
                     initialFilter =
-                        GetItemsFilter(
-                            includeItemTypes = listOf(BaseItemKind.MOVIE),
+                        CollectionFolderFilter(
+                            filter =
+                                GetItemsFilter(
+                                    includeItemTypes = listOf(BaseItemKind.MOVIE),
+                                ),
                         ),
                     showTitle = false,
                     recursive = true,
@@ -143,8 +147,11 @@ fun CollectionFolderMovie(
                     },
                     itemId = destination.itemId,
                     initialFilter =
-                        GetItemsFilter(
-                            includeItemTypes = listOf(BaseItemKind.BOX_SET),
+                        CollectionFolderFilter(
+                            filter =
+                                GetItemsFilter(
+                                    includeItemTypes = listOf(BaseItemKind.BOX_SET),
+                                ),
                         ),
                     showTitle = false,
                     recursive = true,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderPlaylist.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderPlaylist.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.github.damontecres.wholphin.data.model.BaseItem
-import com.github.damontecres.wholphin.data.model.GetItemsFilter
+import com.github.damontecres.wholphin.data.model.CollectionFolderFilter
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.CollectionFolderGrid
 import com.github.damontecres.wholphin.ui.components.ViewOptionsSquare
@@ -25,7 +25,7 @@ fun CollectionFolderPlaylist(
     item: BaseItem?,
     recursive: Boolean,
     modifier: Modifier = Modifier,
-    filter: GetItemsFilter = GetItemsFilter(),
+    filter: CollectionFolderFilter = CollectionFolderFilter(),
     preferencesViewModel: PreferencesViewModel = hiltViewModel(),
 ) {
     var showHeader by remember { mutableStateOf(true) }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderRecordings.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderRecordings.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import com.github.damontecres.wholphin.data.model.GetItemsFilter
+import com.github.damontecres.wholphin.data.model.CollectionFolderFilter
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.CollectionFolderGrid
 import com.github.damontecres.wholphin.ui.components.ViewOptionsPoster
@@ -23,7 +23,7 @@ fun CollectionFolderRecordings(
     itemId: UUID,
     recursive: Boolean,
     modifier: Modifier = Modifier,
-    filter: GetItemsFilter = GetItemsFilter(),
+    filter: CollectionFolderFilter = CollectionFolderFilter(),
     preferencesViewModel: PreferencesViewModel = hiltViewModel(),
 ) {
     var showHeader by remember { mutableStateOf(true) }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderTv.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderTv.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.model.BaseItem
+import com.github.damontecres.wholphin.data.model.CollectionFolderFilter
 import com.github.damontecres.wholphin.data.model.GetItemsFilter
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.CollectionFolderGrid
@@ -115,8 +116,11 @@ fun CollectionFolderTv(
                     preferences = preferences,
                     itemId = destination.itemId,
                     initialFilter =
-                        GetItemsFilter(
-                            includeItemTypes = listOf(BaseItemKind.SERIES),
+                        CollectionFolderFilter(
+                            filter =
+                                GetItemsFilter(
+                                    includeItemTypes = listOf(BaseItemKind.SERIES),
+                                ),
                         ),
                     showTitle = false,
                     recursive = true,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/FavoritesPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/FavoritesPage.kt
@@ -25,6 +25,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.filter.DefaultForFavoritesFilterOptions
 import com.github.damontecres.wholphin.data.model.BaseItem
+import com.github.damontecres.wholphin.data.model.CollectionFolderFilter
 import com.github.damontecres.wholphin.data.model.GetItemsFilter
 import com.github.damontecres.wholphin.data.model.GetItemsFilterOverride
 import com.github.damontecres.wholphin.preferences.UserPreferences
@@ -117,9 +118,12 @@ fun FavoritesPage(
                     onClickItem = { _, item -> onClickItem.invoke(item) },
                     itemId = "${NavDrawerItem.Favorites.id}_movies",
                     initialFilter =
-                        GetItemsFilter(
-                            favorite = true,
-                            includeItemTypes = listOf(BaseItemKind.MOVIE),
+                        CollectionFolderFilter(
+                            filter =
+                                GetItemsFilter(
+                                    favorite = true,
+                                    includeItemTypes = listOf(BaseItemKind.MOVIE),
+                                ),
                         ),
                     showTitle = false,
                     recursive = true,
@@ -145,9 +149,12 @@ fun FavoritesPage(
                     onClickItem = { _, item -> onClickItem.invoke(item) },
                     itemId = "${NavDrawerItem.Favorites.id}_series",
                     initialFilter =
-                        GetItemsFilter(
-                            favorite = true,
-                            includeItemTypes = listOf(BaseItemKind.SERIES),
+                        CollectionFolderFilter(
+                            filter =
+                                GetItemsFilter(
+                                    favorite = true,
+                                    includeItemTypes = listOf(BaseItemKind.SERIES),
+                                ),
                         ),
                     showTitle = false,
                     recursive = true,
@@ -173,9 +180,12 @@ fun FavoritesPage(
                     onClickItem = { _, item -> onClickItem.invoke(item) },
                     itemId = "${NavDrawerItem.Favorites.id}_episodes",
                     initialFilter =
-                        GetItemsFilter(
-                            favorite = true,
-                            includeItemTypes = listOf(BaseItemKind.EPISODE),
+                        CollectionFolderFilter(
+                            filter =
+                                GetItemsFilter(
+                                    favorite = true,
+                                    includeItemTypes = listOf(BaseItemKind.EPISODE),
+                                ),
                         ),
                     showTitle = false,
                     recursive = true,
@@ -202,9 +212,12 @@ fun FavoritesPage(
                     onClickItem = { _, item -> onClickItem.invoke(item) },
                     itemId = "${NavDrawerItem.Favorites.id}_videos",
                     initialFilter =
-                        GetItemsFilter(
-                            favorite = true,
-                            includeItemTypes = listOf(BaseItemKind.VIDEO),
+                        CollectionFolderFilter(
+                            filter =
+                                GetItemsFilter(
+                                    favorite = true,
+                                    includeItemTypes = listOf(BaseItemKind.VIDEO),
+                                ),
                         ),
                     showTitle = false,
                     recursive = true,
@@ -230,9 +243,12 @@ fun FavoritesPage(
                     onClickItem = { _, item -> onClickItem.invoke(item) },
                     itemId = "${NavDrawerItem.Favorites.id}_playlists",
                     initialFilter =
-                        GetItemsFilter(
-                            favorite = true,
-                            includeItemTypes = listOf(BaseItemKind.PLAYLIST),
+                        CollectionFolderFilter(
+                            filter =
+                                GetItemsFilter(
+                                    favorite = true,
+                                    includeItemTypes = listOf(BaseItemKind.PLAYLIST),
+                                ),
                         ),
                     showTitle = false,
                     recursive = true,
@@ -258,9 +274,12 @@ fun FavoritesPage(
                     onClickItem = { _, item -> onClickItem.invoke(item) },
                     itemId = "${NavDrawerItem.Favorites.id}_people",
                     initialFilter =
-                        GetItemsFilter(
-                            favorite = true,
-                            override = GetItemsFilterOverride.PERSON,
+                        CollectionFolderFilter(
+                            filter =
+                                GetItemsFilter(
+                                    favorite = true,
+                                    override = GetItemsFilterOverride.PERSON,
+                                ),
                         ),
                     initialSortAndDirection =
                         SortAndDirection(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/Destination.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/Destination.kt
@@ -5,6 +5,7 @@ package com.github.damontecres.wholphin.ui.nav
 import androidx.annotation.StringRes
 import androidx.navigation3.runtime.NavKey
 import com.github.damontecres.wholphin.data.model.BaseItem
+import com.github.damontecres.wholphin.data.model.CollectionFolderFilter
 import com.github.damontecres.wholphin.data.model.GetItemsFilter
 import com.github.damontecres.wholphin.data.model.ItemPlayback
 import com.github.damontecres.wholphin.ui.data.SortAndDirection
@@ -94,7 +95,7 @@ sealed class Destination(
     @Serializable
     data class FilteredCollection(
         val itemId: UUID,
-        val filter: GetItemsFilter,
+        val filter: CollectionFolderFilter,
         val recursive: Boolean,
     ) : Destination(false)
 


### PR DESCRIPTION
## Description
The filtering & sorting for the genre results grid is now independent from the actual library.

This prevents having a filter saved on the actual library that conflicts with the Genre grid.

Also shows the genre name in the title of the page

### Related issues
Fixes #536
