### PR TITLE
Prevent quick details from using more veritical space if not enough horizontal space

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
@@ -846,8 +846,7 @@ fun CollectionFolderGridContent(
                     item = focusedItem,
                     modifier =
                         Modifier
-                            .fillMaxWidth(.6f)
-//                            .fillMaxHeight(.25f)
+                            .fillMaxWidth()
                             .height(140.dp)
                             .padding(16.dp),
                 )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/DotSeparatedRow.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/DotSeparatedRow.kt
@@ -20,14 +20,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.LocalTextStyle
@@ -54,22 +57,24 @@ fun DotSeparatedRow(
                     text = text,
                     style = textStyle,
                     color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
                 )
                 if (communityRating != null || criticRating != null || index != texts.lastIndex) {
                     Dot()
                 }
             }
+            val height = with(LocalDensity.current) { textStyle.fontSize.toDp() }
             communityRating?.let {
                 SimpleStarRating(
                     communityRating = it,
-                    modifier = Modifier,
+                    modifier = Modifier.height(height),
                 )
                 if (criticRating != null) {
                     Dot()
                 }
             }
             criticRating?.let {
-                TomatoRating(it)
+                TomatoRating(it, Modifier.height(height))
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/Rating.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/Rating.kt
@@ -102,6 +102,7 @@ fun SimpleStarRating(
         if (text.isNotNullOrBlank()) {
             Text(
                 text = text,
+                maxLines = 1,
                 modifier = Modifier,
             )
             val height = with(LocalDensity.current) { LocalTextStyle.current.fontSize.toDp() }
@@ -130,6 +131,7 @@ fun TomatoRating(
             CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onSurface) {
                 Text(
                     text = rating.toInt().toString() + "%",
+                    maxLines = 1,
                     modifier = Modifier,
                 )
             }


### PR DESCRIPTION
## Description
Prevents the quick details (the dot separated details) from using more vertical space if there is not enough horizontal space. Instead, the row will be clipped at the total width.

This PR also gives more horizontal space to the details header on grid pages. This matches the home page now.

### Related issues
Fixes #542 
