### PR TITLE
Add Play Next On Click Option and add show Logo to card

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,17 +21,23 @@ val isCI = if (System.getenv("CI") != null) System.getenv("CI").toBoolean() else
 val shouldSign = isCI && System.getenv("KEY_ALIAS") != null
 val ffmpegModuleExists = project.file("libs/lib-decoder-ffmpeg-release.aar").exists()
 
-val gitTags =
+val gitTags = try {
     providers
         .exec { commandLine("git", "tag", "--list", "v*", "p*") }
         .standardOutput.asText
         .get()
+} catch (e: Exception) {
+    ""
+}
 
-val gitDescribe =
+val gitDescribe = try {
     providers
         .exec { commandLine("git", "describe", "--tags", "--long", "--match=v*") }
         .standardOutput.asText
         .getOrElse("v0.0.0")
+} catch (e: Exception) {
+    "v0.0.0"
+}
 
 android {
     namespace = "com.github.damontecres.wholphin"

--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -210,6 +210,18 @@ sealed interface AppPreference<Pref, T> {
                 summaryOff = R.string.disabled,
             )
 
+        val PlayNextUpOnClick =
+            AppSwitchPreference<AppPreferences>(
+                title = R.string.play_next_up_on_click,
+                defaultValue = false,
+                getter = { it.homePagePreferences.playNextUpOnClick },
+                setter = { prefs, value ->
+                    prefs.updateHomePagePreferences { playNextUpOnClick = value }
+                },
+                summaryOn = R.string.enabled,
+                summaryOff = R.string.disabled,
+            )
+
         val PlayThemeMusic =
             AppChoicePreference<AppPreferences, ThemeSongVolume>(
                 title = R.string.play_theme_music,
@@ -878,6 +890,7 @@ val basicPreferences =
                     AppPreference.AutoPlayNextUp,
                     AppPreference.AutoPlayNextDelay,
                     AppPreference.PassOutProtection,
+                    AppPreference.PlayNextUpOnClick,
                 ),
         ),
         PreferenceGroup(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
@@ -39,6 +39,7 @@ import com.github.damontecres.wholphin.util.LoadingState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.MediaType
 import java.util.UUID
 
@@ -147,10 +148,15 @@ fun RecommendedContent(
         }
 
         LoadingState.Success -> {
+            val playNextUpOnClick = preferences.appPreferences.homePagePreferences.playNextUpOnClick
             HomePageContent(
                 homeRows = rows,
-                onClickItem = { _, item ->
-                    viewModel.navigationManager.navigateTo(item.destination())
+                onClickItem = { rowColumn, item ->
+                    if (playNextUpOnClick && rowColumn.row == 0 && item.type == BaseItemKind.EPISODE) {
+                        viewModel.navigationManager.navigateTo(Destination.Playback(item))
+                    } else {
+                        viewModel.navigationManager.navigateTo(item.destination())
+                    }
                 },
                 onLongClickItem = { position, item ->
                     moreDialog.makePresent(RowColumnItem(position, item))
@@ -159,9 +165,12 @@ fun RecommendedContent(
                     viewModel.navigationManager.navigateTo(Destination.Playback(item))
                 },
                 onFocusPosition = onFocusPosition,
-                showClock = preferences.appPreferences.interfacePreferences.showClock,
                 onUpdateBackdrop = viewModel::updateBackdrop,
                 modifier = modifier,
+                playNextUpOnClick = playNextUpOnClick,
+                numWatchingRows = if (rows.isNotEmpty()) 1 else 0,
+                numLatestRows = rows.size - (if (rows.isNotEmpty()) 1 else 0),
+                showClock = preferences.appPreferences.interfacePreferences.showClock,
             )
         }
     }

--- a/app/src/main/proto/WholphinDataStore.proto
+++ b/app/src/main/proto/WholphinDataStore.proto
@@ -78,6 +78,7 @@ message HomePagePreferences{
   int32 max_items_per_row = 1;
   bool enable_rewatching_next_up = 2;
   bool combine_continue_next = 3;
+  bool play_next_up_on_click = 4;
 }
 
 enum ThemeSongVolume {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,7 @@
     <string name="check_for_updates">Check for updates</string>
     <string name="combine_continue_next_summary">Applies to TV Series only</string>
     <string name="combine_continue_next"><![CDATA[Combine Continue Watching & Next Up]]></string>
+    <string name="play_next_up_on_click">Play Next Up on click</string>
     <string name="direct_play_ass">Direct play ASS subtitles</string>
     <string name="direct_play_pgs">Direct play PGS subtitles</string>
     <string name="downmix_stereo">Always downmix to stereo</string>


### PR DESCRIPTION
## Description

Add an option to enable Home Screen and Library pages to show direct links to Episodes for Play Next and Continue Watching. Also, add an additional option to add the Show logo to the episode cards. Both options are contained within a settings options. 

### Related issues
None

### Screenshots

<img width="1920" height="1080" alt="screenshot2" src="https://github.com/user-attachments/assets/61936857-3755-4fd8-9b07-11e08fd4eff3" />
<img width="1920" height="1080" alt="screenshot3" src="https://github.com/user-attachments/assets/e31ab1f0-de2e-4d04-92e4-788f452089d2" />
<img width="1920" height="1080" alt="screenshot4" src="https://github.com/user-attachments/assets/d2ce5fdc-38f8-4623-95ff-1b2998f9092b" />

### AI/LLM usage
Gemini Flash was used to create branch as I am not a Java or Kotlin Dev. However, I have built an APK and have been using it all day to test functionality. I tried to keep the changes to a minimum and overall it looks workable. 
