### PR TITLE
Improvements to overview/media info dialog

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/data/ItemDetailsDialogInfo.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/data/ItemDetailsDialogInfo.kt
@@ -67,18 +67,18 @@ fun ItemDetailsDialog(
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 Text(
                     text = info.title,
-                    style = MaterialTheme.typography.headlineMedium,
+                    style = MaterialTheme.typography.headlineSmall,
                 )
                 if (info.genres.isNotEmpty()) {
                     Text(
                         text = info.genres.joinToString(", "),
-                        style = MaterialTheme.typography.titleMedium,
+                        style = MaterialTheme.typography.titleSmall,
                     )
                 }
                 if (info.overview.isNotNullOrBlank()) {
                     Text(
                         text = info.overview,
-                        style = MaterialTheme.typography.bodyLarge,
+                        style = MaterialTheme.typography.bodyMedium,
                     )
                 }
             }


### PR DESCRIPTION
## Description
* Splits video details into two columns
* Show index number if multiple streams of the same type
* Different font color for media section titles
* Adjustments to spacing
* Add hearing impaired flag to & remove AVC from subtitle info

### Related issues
Closes #549

## Screenshots
![Screenshot_20251226_173514 Large](https://github.com/user-attachments/assets/d069ef1a-4791-4a79-9c67-e1fae2c2fe00)
