### PR TITLE
Fix home header not updating & row movement

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/Extensions.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/Extensions.kt
@@ -78,12 +78,13 @@ inline fun <T> List<T>.indexOfFirstOrNull(predicate: (T) -> Boolean): Int? {
 /**
  * Try to call [FocusRequester.requestFocus], but catch & log the exception if something is not configured properly
  */
-fun FocusRequester.tryRequestFocus(): Boolean =
+fun FocusRequester.tryRequestFocus(tag: String? = null): Boolean =
     try {
         requestFocus()
+        tag?.let { Timber.v("Request focus tag=%s", tag) }
         true
     } catch (ex: IllegalStateException) {
-        Timber.w(ex, "Failed to request focus")
+        Timber.w(ex, "Failed to request focus, tag=%s", tag)
         false
     }
 


### PR DESCRIPTION
## Description
Removes an incorrect optimization for showing the home page header

Separates logic for focusing on rows on the home page

### Related issues
Fixes #624 
Fixes #620 