### PR TITLE
Don't process reqeued MPV commands

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/util/mpv/MpvPlayer.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/mpv/MpvPlayer.kt
@@ -848,7 +848,7 @@ class MpvPlayer(
             // Note: this means nothing will play until it is attached to a surface,
             // so MpvPlayer can't be used for background audio/music playback
             Timber.v("MPV is not initialized/attached yet, requeue cmd %s", cmd)
-            internalHandler.sendMessageDelayed(Message.obtain(msg), 50)
+            internalHandler.sendMessageDelayed(Message.obtain(msg), 250)
             return true
         }
         when (cmd) {


### PR DESCRIPTION
## Description
This is an embarrassing bug... In #619, a change was made to avoid a race condition and wait for the video output surface to be ready by re-enqueuing commands. Except I missed cancelling executing the current command.

This meant the command would both be executed and queued again. So, if attaching the video surface takes a while, such as needing to wait for a refresh rate change, _a lot_ of commands could have been added to the queue and trigger a constant start-stop playback loop.

I think technically it would eventually resolve itself, but can take a while.

### Related issues
Should fix #626
