### PR TITLE
Fix timing issues with segments

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -834,7 +834,7 @@ class PlaybackViewModel
                                         it.type != MediaSegmentType.UNKNOWN && currentTicks >= it.startTicks && currentTicks < it.endTicks
                                     }
                             if (currentSegment != null &&
-                                currentSegment.itemId == itemId &&
+                                currentSegment.itemId == this@PlaybackViewModel.itemId &&
                                 autoSkippedSegments.add(currentSegment.id)
                             ) {
                                 Timber.d(


### PR DESCRIPTION
## Description
Processing segments happens in a separate coroutine which wasn't cancelled until _after_ playback of the next item begins. So in some cases the outro from a previous item might be triggered during the very beginning of the newly starting item.

So this PR instead cancels segment processing immediately when starting the process for playback of an item. Additionally, the processing also now checks that the current segment is for the current playback item as an additional safeguard.

### Related issues
I believe this should fix both of these issues:

Fixes #369
Fixes #647
