### PR TITLE
Fix duplicate commands from key presses/MediaSession

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/MediaSessionPlayer.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/MediaSessionPlayer.kt
@@ -1,0 +1,27 @@
+package com.github.damontecres.wholphin.ui.playback
+
+import androidx.media3.common.ForwardingSimpleBasePlayer
+import androidx.media3.common.Player
+import com.github.damontecres.wholphin.preferences.PlaybackPreferences
+import com.github.damontecres.wholphin.preferences.skipBackOnResume
+import com.github.damontecres.wholphin.ui.seekBack
+import com.google.common.util.concurrent.ListenableFuture
+import timber.log.Timber
+
+class MediaSessionPlayer(
+    player: Player,
+    private val controllerViewState: ControllerViewState,
+    private val playbackPreferences: PlaybackPreferences,
+) : ForwardingSimpleBasePlayer(player) {
+    override fun handleSetPlayWhenReady(playWhenReady: Boolean): ListenableFuture<*> {
+        Timber.v("handleSetPlayWhenReady: playWhenReady=$playWhenReady")
+        if (!playWhenReady && player.isPlaying) {
+            controllerViewState.showControls()
+        } else if (playWhenReady) {
+            playbackPreferences.skipBackOnResume?.let {
+                player.seekBack(it)
+            }
+        }
+        return super.handleSetPlayWhenReady(playWhenReady)
+    }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
@@ -61,27 +61,8 @@ class PlaybackKeyHandler(
             }
         } else if (isMedia(it)) {
             when (it.key) {
-                Key.MediaPlay -> {
-                    Util.handlePlayButtonAction(player)
-                    skipBackOnResume?.let {
-                        player.seekBack(it)
-                    }
-                }
-
-                Key.MediaPause -> {
-                    Util.handlePauseButtonAction(player)
-                    controllerViewState.showControls()
-                }
-
-                Key.MediaPlayPause -> {
-                    Util.handlePlayPauseButtonAction(player)
-                    if (!player.isPlaying) {
-                        controllerViewState.showControls()
-                    } else {
-                        skipBackOnResume?.let {
-                            player.seekBack(it)
-                        }
-                    }
+                Key.MediaPlay, Key.MediaPause, Key.MediaPlayPause -> {
+                    // no-op, MediaSession will handle
                 }
 
                 Key.MediaFastForward, Key.MediaSkipForward -> {


### PR DESCRIPTION
## Description
Fixes duplicate play/pause commands from a remote button press and `MediaSession`.

This ended up being a bit complicated because Wholphin overrides the default play/pause behavior for the skip back setting and to show the controller on pause. This means using a forwarding player which meant implementing more functionality into `MpvPlayer`.

### Related issues
Fixes #653