### PR TITLE
Disable subtitle download button if user doesn't have permission

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackDialog.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackDialog.kt
@@ -53,6 +53,7 @@ data class PlaybackSettings(
     val playbackSpeed: Float,
     val contentScale: ContentScale,
     val subtitleDelay: Duration,
+    val hasSubtitleDownloadPermission: Boolean,
 )
 
 @Composable
@@ -96,6 +97,7 @@ fun PlaybackDialog(
             SubtitleChoiceBottomDialog(
                 choices = settings.subtitleStreams,
                 currentChoice = settings.subtitleIndex,
+                hasDownloadPermission = settings.hasSubtitleDownloadPermission,
                 onDismissRequest = {
                     onControllerInteraction.invoke()
                     onDismissRequest.invoke()
@@ -273,6 +275,7 @@ fun SubtitleChoiceBottomDialog(
     onSelectChoice: (Int) -> Unit,
     onSelectSearch: () -> Unit,
     gravity: Int,
+    hasDownloadPermission: Boolean,
     currentChoice: Int? = null,
 ) {
     // TODO enforcing a width ends up ignore the gravity
@@ -347,6 +350,7 @@ fun SubtitleChoiceBottomDialog(
                     HorizontalDivider()
                     ListItem(
                         selected = false,
+                        enabled = hasDownloadPermission,
                         onClick = onSelectSearch,
                         leadingContent = {},
                         headlineContent = {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -130,6 +130,7 @@ fun PlaybackPage(
 
             val player = viewModel.player
             val mediaInfo by viewModel.currentMediaInfo.observeAsState()
+            val userDto by viewModel.currentUserDto.observeAsState()
 
             val currentPlayback by viewModel.currentPlayback.collectAsState()
             val currentItemPlayback by viewModel.currentItemPlayback.observeAsState(
@@ -561,6 +562,8 @@ fun PlaybackPage(
                             playbackSpeed = playbackSpeed,
                             contentScale = contentScale,
                             subtitleDelay = subtitleDelay,
+                            hasSubtitleDownloadPermission =
+                                remember(userDto) { userDto?.policy?.let { it.isAdministrator || it.enableSubtitleManagement } == true },
                         ),
                     onDismissRequest = {
                         playbackDialog = null

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -168,6 +168,8 @@ class PlaybackViewModel
         val subtitleSearch = MutableLiveData<SubtitleSearch?>(null)
         val subtitleSearchLanguage = MutableLiveData<String>(Locale.current.language)
 
+        val currentUserDto = serverRepository.currentUserDto
+
         init {
             addCloseable {
                 player.removeListener(this@PlaybackViewModel)


### PR DESCRIPTION
## Description
Just a UI change to disable the Search & Download subtitles button if the user doesn't have permission to manage subtitles.

This avoids the 403 error if the user attempts to use it.

### Related issues
Closes #483