### PR TITLE
Fix season numbers not appearing when scrolling

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
@@ -109,11 +109,12 @@ fun SeriesOverviewContent(
     var requestFocusAfterSeason by remember { mutableStateOf(false) }
 
     val seasonStr = stringResource(R.string.tv_season)
-    val tabs = seasons.map { season ->
-        season?.name
-            ?: season?.data?.indexNumber?.let { "$seasonStr $it" }
-            ?: ""
-    }
+    val tabs =
+        seasons.map { season ->
+            season?.name
+                ?: season?.data?.indexNumber?.let { "$seasonStr $it" }
+                ?: ""
+        }
     val focusRequesters = remember(seasons) { List(seasons.size) { FocusRequester() } }
 
     Box(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
@@ -109,14 +109,11 @@ fun SeriesOverviewContent(
     var requestFocusAfterSeason by remember { mutableStateOf(false) }
 
     val seasonStr = stringResource(R.string.tv_season)
-    val tabs =
-        remember(seasons) {
-            seasons.mapNotNull {
-                it?.name
-                    ?: it?.data?.indexNumber?.let { "$seasonStr $it" }
-                    ?: ""
-            }
-        }
+    val tabs = seasons.map { season ->
+        season?.name
+            ?: season?.data?.indexNumber?.let { "$seasonStr $it" }
+            ?: ""
+    }
     val focusRequesters = remember(seasons) { List(seasons.size) { FocusRequester() } }
 
     Box(


### PR DESCRIPTION
**Description**

Fixes a regression where season numbers in the tab strip were invisible when scrolling through long series (15+ seasons).

**Related issues**

Fixes #677

**AI/LLM usage**

Used Claude Code to analyze diffs from recent commits in order to find which commit caused the regression.