### PR TITLE
prefer fmp4 container option

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -425,6 +425,18 @@ sealed interface AppPreference<Pref, T> {
                 summary = R.string.force_dovi_profile_7_summary,
             )
 
+        val PreferFmp4Container =
+            AppSwitchPreference<AppPreferences>(
+                title = R.string.prefer_fmp4_container,
+                defaultValue = false,
+                getter = { it.playbackPreferences.overrides.preferFmp4Container },
+                setter = { prefs, value ->
+                    prefs.updatePlaybackOverrides { preferFmp4Container = value }
+                },
+                summaryOn = R.string.enabled,
+                summaryOff = R.string.disabled,
+            )
+
         val RememberSelectedTab =
             AppSwitchPreference<AppPreferences>(
                 title = R.string.remember_selected_tab,
@@ -1004,6 +1016,7 @@ val advancedPreferences =
                                 AppPreference.DirectPlayAss,
                                 AppPreference.DirectPlayPgs,
                                 AppPreference.DirectPlayDoviProfile7,
+                                AppPreference.PreferFmp4Container,
                             ),
                         ),
                         ConditionalPreferences(

--- a/app/src/main/java/com/github/damontecres/wholphin/services/DeviceProfileService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/DeviceProfileService.kt
@@ -45,6 +45,7 @@ class DeviceProfileService
                             dolbyVisionELDirectPlay = prefs.overrides.directPlayDolbyVisionEL,
                             jellyfinTenEleven =
                                 serverVersion != null && serverVersion >= ServerVersion(10, 11, 0),
+                            preferFmp4Container = prefs.overrides.preferFmp4Container,
                         )
                     if (deviceProfile == null || this@DeviceProfileService.configuration != newConfig) {
                         this@DeviceProfileService.configuration = newConfig
@@ -58,6 +59,7 @@ class DeviceProfileService
                                 pgsDirectPlay = newConfig.pgsDirectPlay,
                                 dolbyVisionELDirectPlay = newConfig.dolbyVisionELDirectPlay,
                                 jellyfinTenEleven = newConfig.jellyfinTenEleven,
+                                preferFmp4Container = newConfig.preferFmp4Container,
                             )
                     }
                     this@DeviceProfileService.deviceProfile!!
@@ -76,4 +78,5 @@ data class DeviceProfileConfiguration(
     val pgsDirectPlay: Boolean,
     val dolbyVisionELDirectPlay: Boolean,
     val jellyfinTenEleven: Boolean,
+    val preferFmp4Container: Boolean,
 )

--- a/app/src/main/java/com/github/damontecres/wholphin/util/profile/DeviceProfileUtils.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/profile/DeviceProfileUtils.kt
@@ -68,6 +68,7 @@ fun createDeviceProfile(
     pgsDirectPlay: Boolean,
     dolbyVisionELDirectPlay: Boolean,
     jellyfinTenEleven: Boolean,
+    preferFmp4Container: Boolean,
 ) = buildDeviceProfile {
     val allowedAudioCodecs =
         when {
@@ -128,7 +129,7 @@ fun createDeviceProfile(
         type = DlnaProfileType.VIDEO
         context = EncodingContext.STREAMING
 
-        container = Codec.Container.TS
+        container = if (preferFmp4Container) Codec.Container.MP4 else Codec.Container.TS
         protocol = MediaStreamProtocol.HLS
 
         if (supportsHevc) videoCodec(Codec.Video.HEVC)

--- a/app/src/main/proto/WholphinDataStore.proto
+++ b/app/src/main/proto/WholphinDataStore.proto
@@ -46,6 +46,7 @@ message PlaybackOverrides{
   bool direct_play_pgs = 4;
   MediaExtensionStatus media_extensions_enabled = 5;
   bool direct_play_dolby_vision_e_l = 6;
+  bool prefer_fmp4_container = 7;
 }
 
 message PlaybackPreferences {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,6 +288,7 @@
     <string name="downmix_stereo">Always downmix to stereo</string>
     <string name="ffmpeg_extension_pref">Use FFmpeg decoder module</string>
     <string name="global_content_scale">Default content scale</string>
+    <string name="prefer_fmp4_container">Prefer fMP4 container</string>
     <string name="install_update">Install update</string>
     <string name="installed_version">Installed version</string>
     <string name="max_homepage_items">Max items on home page rows</string>


### PR DESCRIPTION
## Background
Exoplayer has issues handling DV Profile 8 + HDR10+ content on some devices.  jellyfin-server already detects and attempts to solve this situation by remuxing content to strip one of the HDR profiles.  The remuxing profile uses MPEG-TS segments (Codec.Container.TS) when requested, which requires FFmpeg's hevc_mp4toannexb bitstream filter. That filter produces malformed output when processing DV RPU NAL units at segment boundaries, which causes playback errors and visual artifacts in the video at the segment boundaries in exoplayer.  

## Proposal
The use of fMP4 segments instead of MPEG-TS doesn't require hevc_mp4toannexb and plays without errors in exoplayer. The server already supports this -- clients must simply request it.   

This PR adds a new option to the exoplayer settings to let the client prefer a fMP4 container.  This will conditionally set the transcoding profile to have container=Codec.Container.MP4.  This is similar to what the jellyfin-web player does.  

<img width="382" height="212" alt="Screenshot 2026-01-12 at 9 58 34 PM" src="https://github.com/user-attachments/assets/1a3d047c-2853-4ac4-8dee-15dc1ad94942" />


## Testing

I've tested this on a FireTV device and confirmed that with the setting on, the artifacts in the remuxed video stream are gone.  
