### PR TITLE
Fix wrong dialog showing after Seerr login

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
@@ -92,7 +92,7 @@ fun PreferencesContent(
     val navDrawerPins by viewModel.navDrawerPins.observeAsState(mapOf())
     var cacheUsage by remember { mutableStateOf(CacheUsage(0, 0, 0)) }
     val seerrIntegrationEnabled by viewModel.seerrEnabled.collectAsState(false)
-    var showSeerrServerDialog by remember { mutableStateOf(false) }
+    var seerrDialogMode by remember { mutableStateOf<SeerrDialogMode>(SeerrDialogMode.None) }
 
     LaunchedEffect(Unit) {
         viewModel.preferenceDataStore.data.collect {
@@ -393,7 +393,14 @@ fun PreferencesContent(
                             AppPreference.SeerrIntegration -> {
                                 ClickPreference(
                                     title = stringResource(pref.title),
-                                    onClick = { showSeerrServerDialog = true },
+                                    onClick = {
+                                        seerrDialogMode =
+                                            if (seerrIntegrationEnabled) {
+                                                SeerrDialogMode.Remove
+                                            } else {
+                                                SeerrDialogMode.Add
+                                            }
+                                    },
                                     modifier = Modifier,
                                     summary =
                                         if (seerrIntegrationEnabled) {
@@ -465,23 +472,27 @@ fun PreferencesContent(
                 )
             }
         }
-        if (showSeerrServerDialog) {
-            if (seerrIntegrationEnabled) {
+        when (seerrDialogMode) {
+            SeerrDialogMode.Remove -> {
                 ConfirmDialog(
                     title = stringResource(R.string.remove_seerr_server),
                     body = "",
-                    onCancel = { showSeerrServerDialog = false },
+                    onCancel = { seerrDialogMode = SeerrDialogMode.None },
                     onConfirm = {
                         seerrVm.removeServer()
-                        showSeerrServerDialog = false
+                        seerrDialogMode = SeerrDialogMode.None
                     },
                 )
-            } else {
+            }
+
+            SeerrDialogMode.Add -> {
                 val currentUser by seerrVm.currentUser.observeAsState()
                 val status by seerrVm.serverConnectionStatus.collectAsState(LoadingState.Pending)
+                val serverAddedMessage = stringResource(R.string.seerr_server_added)
                 LaunchedEffect(status) {
                     if (status == LoadingState.Success) {
-                        showSeerrServerDialog = false
+                        showToast(context, serverAddedMessage)
+                        seerrDialogMode = SeerrDialogMode.None
                     }
                 }
                 AddSeerServerDialog(
@@ -494,9 +505,11 @@ fun PreferencesContent(
                             seerrVm.submitServer(url, username ?: "", passwordOrApiKey, method)
                         }
                     },
-                    onDismissRequest = { showSeerrServerDialog = false },
+                    onDismissRequest = { seerrDialogMode = SeerrDialogMode.None },
                 )
             }
+
+            SeerrDialogMode.None -> {}
         }
     }
 }
@@ -539,3 +552,11 @@ data class CacheUsage(
     val imageMemoryMax: Long,
     val imageDiskUsed: Long,
 )
+
+private sealed class SeerrDialogMode {
+    data object None : SeerrDialogMode()
+
+    data object Add : SeerrDialogMode()
+
+    data object Remove : SeerrDialogMode()
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
@@ -491,7 +491,7 @@ fun PreferencesContent(
                 val serverAddedMessage = stringResource(R.string.seerr_server_added)
                 LaunchedEffect(status) {
                     if (status == LoadingState.Success) {
-                        showToast(context, serverAddedMessage)
+                        Toast.makeText(context, serverAddedMessage, Toast.LENGTH_SHORT).show()
                         seerrDialogMode = SeerrDialogMode.None
                     }
                 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
@@ -394,12 +394,12 @@ fun PreferencesContent(
                                 ClickPreference(
                                     title = stringResource(pref.title),
                                     onClick = {
-                                        seerrDialogMode =
-                                            if (seerrIntegrationEnabled) {
-                                                SeerrDialogMode.Remove
-                                            } else {
-                                                SeerrDialogMode.Add
-                                            }
+                                        if (seerrIntegrationEnabled) {
+                                            seerrDialogMode = SeerrDialogMode.Remove
+                                        } else {
+                                            seerrVm.resetStatus()
+                                            seerrDialogMode = SeerrDialogMode.Add
+                                        }
                                     },
                                     modifier = Modifier,
                                     summary =

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/setup/seerr/SwitchSeerrViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/setup/seerr/SwitchSeerrViewModel.kt
@@ -87,4 +87,8 @@ class SwitchSeerrViewModel
                 seerrServerRepository.removeServer()
             }
         }
+
+        fun resetStatus() {
+            serverConnectionStatus.update { LoadingState.Pending }
+        }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -434,6 +434,7 @@
     <string name="pending">Pending</string>
     <string name="seerr_integration">Seerr integration</string>
     <string name="remove_seerr_server">Remove Seerr Server</string>
+    <string name="seerr_server_added">Seerr server added</string>
     <string name="password">Password</string>
     <string name="username">Username</string>
     <string name="url">URL</string>


### PR DESCRIPTION
**Description**

Fixes a race condition in the Seerr integration.

When you added a new Seerr server and logged in successfully, the app would immediately show the "Disable Seerr?" dialog instead of a success message. The state was getting mixed up during recomposition and thinking you wanted to remove the server you just added.

Fixed by being more explicit about what mode the dialog is in (adding vs removing) so it can't get confused by background state changes. Also added a success toast when login works.

**AI/LLM usage**

Used Claude Code to analyze the issue. 