### PR TITLE
Fixes "Pause with one click" for MPV

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
@@ -45,8 +45,9 @@ class PlaybackKeyHandler(
                     player.seekForward(seekForward)
                     updateSkipIndicator(seekForward.inWholeMilliseconds)
                 } else if (oneClickPause && isEnterKey(it)) {
+                    val wasPlaying = player.isPlaying
                     Util.handlePlayPauseButtonAction(player)
-                    if (!player.isPlaying) {
+                    if (wasPlaying) {
                         controllerViewState.showControls()
                     } else {
                         skipBackOnResume?.let {


### PR DESCRIPTION
## Description
Fixes "Pause with one click" so the desired behavior isn't reversed and now shows the controls when pausing.

This bug happened because MPV commands are async, so there is a tiny delay before the pausing occurs and the playback state is updated. However, the logic to decided whether to show the controls or not checks the playback state immediately.

### Related issues
Fixes #697 