### PR TITLE
Added wholphin://play Intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="wholphin"
+                    android:host="play" />
+            </intent-filter>
         </activity>
 
         <provider

--- a/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
@@ -69,9 +69,16 @@ import com.github.damontecres.wholphin.ui.util.ProvideLocalClock
 import com.github.damontecres.wholphin.util.DebugLogTree
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
+import org.jellyfin.sdk.api.client.extensions.tvShowsApi
+import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.request.GetEpisodesRequest
+import org.jellyfin.sdk.model.extensions.ticks
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import timber.log.Timber
 import java.util.UUID
@@ -134,7 +141,6 @@ class MainActivity : AppCompatActivity() {
             appUpgradeHandler.copySubfont(false)
         }
         refreshRateService.refreshRateMode.observe(this) { modeId ->
-            // Listen for refresh rate changes
             val attrs = window.attributes
             if (attrs.preferredDisplayModeId != modeId) {
                 Timber.d("Switch preferredDisplayModeId to %s", modeId)
@@ -152,13 +158,30 @@ class MainActivity : AppCompatActivity() {
             }
         }
         
-        // PARSE IDs ROBUSTLY
-        val overrideUserId = parseUUID(intent?.getStringExtra(INTENT_USER_ID))
-        val overrideServerId = parseUUID(intent?.getStringExtra(INTENT_SERVER_ID))
+        val intentData = intent?.let { extractIntentData(it) }
+        val overrideUserId = intentData?.userId ?: parseUUID(intent?.getStringExtra(INTENT_USER_ID))
+        val overrideServerId = intentData?.serverId ?: parseUUID(intent?.getStringExtra(INTENT_SERVER_ID))
 
-        // Capture requested destination from intent in onCreate so it's available when AppContent
-        // is composed (avoids losing item/play target after nuclear restart or late composition).
-        viewModel.pendingRequestedDestination = extractDestination(intent)
+        if (intentData != null && intentData.itemId != null) {
+            viewModel.pendingIntentData = intentData
+        }
+
+        intent?.let { 
+            val data = extractIntentData(it)
+            val currentUser = viewModel.serverRepository.currentUser.value
+            val currentServer = viewModel.serverRepository.currentServer.value
+            val needsLogin = data.serverId != null && 
+                    (currentServer?.id != data.serverId || 
+                     data.userId != null && currentUser?.id != data.userId)
+            val needsUserSwitch = !needsLogin && data.userId != null && 
+                    currentUser?.id != data.userId
+            
+            if (!needsLogin && !needsUserSwitch) {
+                lifecycleScope.launchIO {
+                    handleIntent(it, isNewIntent = false)
+                }
+            }
+        }
 
         viewModel.appStart(overrideUserId, overrideServerId)
         
@@ -196,9 +219,46 @@ class MainActivity : AppCompatActivity() {
                                     .background(MaterialTheme.colorScheme.background),
                             shape = RectangleShape,
                         ) {
-//                            val backStack = rememberNavBackStack(SetupDestination.Loading)
-//                            setupNavigationManager.backStack = backStack
                             val backStack = setupNavigationManager.backStack
+                            
+                            // Process pendingIntentData when AppContent is reached
+                            // Use currentUser?.id as source of truth (not destination.current.user.id)
+                            // because destination might not update immediately when switching users
+                            val currentDestination = backStack.lastOrNull()
+                            val currentUser = viewModel.serverRepository.currentUser.value
+                            val currentServer = viewModel.serverRepository.currentServer.value
+                            val appContentKey = remember(currentDestination, currentUser?.id, currentServer?.id) {
+                                if (currentDestination is SetupDestination.AppContent && currentUser != null && currentServer != null) {
+                                    "${currentUser.id}_${currentServer.id}"
+                                } else {
+                                    null
+                                }
+                            }
+                            
+                            LaunchedEffect(appContentKey) {
+                                if (appContentKey != null) {
+                                    delay(200)
+                                    val pendingIntentData = viewModel.pendingIntentData
+                                    if (pendingIntentData != null && pendingIntentData.itemId != null) {
+                                        val pendingItemId = pendingIntentData.itemId
+                                        Timber.i("AppContent reached (key=$appContentKey), processing pendingIntentData for itemId=$pendingItemId")
+                                        viewModel.pendingIntentData = null
+                                        lifecycleScope.launchIO {
+                                            val destination = createDestinationFromIntentData(pendingIntentData)
+                                            if (destination != null) {
+                                                withContext(Dispatchers.Main) {
+                                                    navigationManager.replace(destination)
+                                                    viewModel.lastProcessedItemId = pendingItemId
+                                                    Timber.i("Successfully navigated to destination from pendingIntentData: $destination")
+                                                }
+                                            } else {
+                                                Timber.w("Failed to create destination from pendingIntentData")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            
                             NavDisplay(
                                 backStack = backStack,
                                 onBack = { backStack.removeLastOrNull() },
@@ -269,10 +329,14 @@ class MainActivity : AppCompatActivity() {
                                                     }
 
                                                     if (showContent) {
-                                                        val requestedDestination =
+                                                        var requestedDestination =
                                                             viewModel.pendingRequestedDestination
                                                                 ?.also { viewModel.pendingRequestedDestination = null }
-                                                                ?: intent?.let(::extractDestination)
+                                                        
+                                                        if (requestedDestination == null) {
+                                                            requestedDestination = intent?.let(::extractDestination)
+                                                        }
+                                                        
                                                         ApplicationContent(
                                                             user = current.user,
                                                             server = current.server,
@@ -359,58 +423,250 @@ class MainActivity : AppCompatActivity() {
         Timber.d("onConfigurationChanged")
     }
 
-    // THE HYBRID FIX
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
         
-        val overrideUserId = parseUUID(intent.getStringExtra(INTENT_USER_ID))
-        val overrideServerId = parseUUID(intent.getStringExtra(INTENT_SERVER_ID))
-        val newItemId = parseUUID(intent.getStringExtra(INTENT_ITEM_ID))
-
-        val currentUser = viewModel.serverRepository.currentUser.value
+        val currentDestination = setupNavigationManager.backStack.lastOrNull()
+        val isOnSetupScreen = currentDestination is SetupDestination.ServerList || 
+                              currentDestination is SetupDestination.UserList
         
-        // Are we already logged in as the correct user?
-        val isSameSession = overrideUserId != null &&
-                currentUser?.id == overrideUserId &&
-                (overrideServerId == null || currentUser.serverId == overrideServerId)
-
-        // navigationManager.replace() only works when ApplicationContent is composed (i.e. we're
-        // in AppContent). On Loading, ServerList, or UserList, that backstack isn't shown — only
-        // setupNavigationManager.backStack is. So we must restart to run appStart and reach AppContent.
-        val isInAppContent = setupNavigationManager.backStack.lastOrNull() is SetupDestination.AppContent
-        val mustRestartToReachApp = overrideUserId != null && !isInAppContent
-
-        if (overrideUserId != null && (!isSameSession || mustRestartToReachApp)) {
-            // SCENARIO 1: Stuck on Select Screen, Wrong User, or not yet in AppContent.
-            // Action: NUCLEAR RESTART. This forces a cold start, ensuring login and navigation work.
-            Timber.i("Automation: Different user/session or not in AppContent. Restarting activity.")
-            val restartIntent = Intent(this, MainActivity::class.java)
-            restartIntent.putExtras(intent)
-            intent.data?.let { restartIntent.data = it }
-            restartIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-            startActivity(restartIntent)
-            finish()
+        if (isOnSetupScreen) {
+            Timber.i("onNewIntent: On setup screen ($currentDestination), treating like cold start")
+            val intentData = extractIntentData(intent)
+            val overrideUserId = intentData.userId ?: parseUUID(intent.getStringExtra(INTENT_USER_ID))
+            val overrideServerId = intentData.serverId ?: parseUUID(intent.getStringExtra(INTENT_SERVER_ID))
+            
+            if (intentData.itemId != null) {
+                viewModel.pendingIntentData = intentData
+            }
+            
+            viewModel.appStart(overrideUserId, overrideServerId)
             return
-        } 
+        }
         
-        // SCENARIO 2: We are logged in correctly. 
-        // Action: Gentle Navigation (No restart).
+        lifecycleScope.launchIO {
+            handleIntent(intent, isNewIntent = true)
+        }
+    }
+    
+    private suspend fun handleIntent(intent: Intent, isNewIntent: Boolean = false) {
+        val intentData = extractIntentData(intent)
         
-        // Optimization: Don't do anything if we just launched this item.
-        if (newItemId != null && newItemId == viewModel.lastProcessedItemId) {
-             Timber.i("Automation: Ignoring duplicate request for item $newItemId")
-             return
+        if (intentData.itemId == null) {
+            Timber.d("Intent has no itemId, ignoring")
+            return
         }
-
-        Timber.i("Automation: Session valid, navigating directly.")
-        if (newItemId != null) {
-            viewModel.lastProcessedItemId = newItemId
+        
+        val currentUser = viewModel.serverRepository.currentUser.value
+        val currentServer = viewModel.serverRepository.currentServer.value
+        
+        val needsLogin = intentData.serverId != null && 
+                (currentServer?.id != intentData.serverId || 
+                 intentData.userId != null && currentUser?.id != intentData.userId)
+        val needsUserSwitch = !needsLogin && intentData.userId != null && 
+                currentUser?.id != intentData.userId
+        
+        val isInAppContent = setupNavigationManager.backStack.lastOrNull() is SetupDestination.AppContent
+        
+        if (needsLogin || needsUserSwitch) {
+            Timber.i("Intent: Need to login/switch user (userId=${intentData.userId}, serverId=${intentData.serverId}). Current user: ${currentUser?.id}. Treating as fresh start.")
+            
+            // Stop playback before switching users to avoid stale state
+            if (isInAppContent && intentData.autoplay) {
+                val currentDestination = navigationManager.backStack.lastOrNull()
+                if (currentDestination is Destination.Playback) {
+                    Timber.i("Intent: Currently playing ${currentDestination.itemId}, stopping playback before user switch")
+                    withContext(Dispatchers.Main) {
+                        navigationManager.goToHome()
+                    }
+                }
+            }
+            
+            viewModel.pendingIntentData = intentData
+            Timber.i("Intent: Calling appStart to handle login/switch")
+            viewModel.appStart(intentData.userId, intentData.serverId)
+            return
         }
-
-        extractDestination(intent)?.let { destination ->
-            navigationManager.replace(destination)
+        
+        if (isInAppContent && intentData.autoplay) {
+            val currentDestination = navigationManager.backStack.lastOrNull()
+            if (currentDestination is Destination.Playback && currentDestination.itemId == intentData.itemId) {
+                val currentUserId = currentUser?.id
+                if (currentUserId == intentData.userId || (intentData.userId == null && currentUserId != null)) {
+                    Timber.i("Intent: Already playing item ${intentData.itemId} as user $currentUserId, ignoring")
+                    return
+                }
+            }
         }
+        
+        if (isInAppContent) {
+            Timber.i("Intent: In AppContent, navigating directly")
+            lifecycleScope.launchIO {
+                val destination = createDestinationFromIntentData(intentData)
+                if (destination != null) {
+                    withContext(Dispatchers.Main) {
+                        navigationManager.replace(destination)
+                        viewModel.lastProcessedItemId = intentData.itemId
+                    }
+                }
+            }
+            return
+        }
+        
+        Timber.i("Intent: Not in AppContent yet, storing destination")
+        lifecycleScope.launchIO {
+            val destination = createDestinationFromIntentData(intentData)
+            withContext(Dispatchers.Main) {
+                viewModel.pendingRequestedDestination = destination
+                viewModel.pendingIntentData = intentData
+            }
+        }
+    }
+    
+    private fun extractIntentData(intent: Intent): IntentData {
+        val uri = intent.data
+        if (uri != null && uri.scheme == "wholphin" && uri.host == "play") {
+            val itemId = parseUUID(uri.pathSegments.firstOrNull())
+            val autoplay = uri.getQueryParameter("autoplay")?.toBooleanStrictOrNull() ?: false
+            val type = uri.getQueryParameter("type")?.let(BaseItemKind::fromNameOrNull)
+            val serverId = parseUUID(intent.getStringExtra(INTENT_SERVER_ID))
+            val userId = parseUUID(intent.getStringExtra(INTENT_USER_ID))
+            
+            return IntentData(
+                serverId = serverId,
+                userId = userId,
+                itemId = itemId,
+                itemType = type,
+                autoplay = autoplay,
+                seriesId = null,
+                seasonId = null,
+                episodeNumber = null,
+                seasonNumber = null,
+            )
+        }
+        
+        return IntentData(
+            serverId = parseUUID(intent.getStringExtra(INTENT_SERVER_ID)),
+            userId = parseUUID(intent.getStringExtra(INTENT_USER_ID)),
+            itemId = parseUUID(intent.getStringExtra(INTENT_ITEM_ID)),
+            itemType = intent.getStringExtra(INTENT_ITEM_TYPE)?.let(BaseItemKind::fromNameOrNull),
+            autoplay = intent.getBooleanExtra(INTENT_AUTOPLAY, false),
+            seriesId = parseUUID(intent.getStringExtra(INTENT_SERIES_ID)),
+            seasonId = parseUUID(intent.getStringExtra(INTENT_SEASON_ID)),
+            episodeNumber = intent.getIntExtra(INTENT_EPISODE_NUMBER, -1).takeIf { it >= 0 },
+            seasonNumber = intent.getIntExtra(INTENT_SEASON_NUMBER, -1).takeIf { it >= 0 },
+        )
+    }
+    
+    private suspend fun createDestinationFromIntentData(intentData: IntentData): Destination? {
+        if (intentData.itemId == null) return null
+        
+        val itemId = intentData.itemId
+        val autoplay = intentData.autoplay
+        
+        var type = intentData.itemType
+        if (type == null) {
+            val currentUser = viewModel.serverRepository.currentUser.value
+            if (currentUser != null) {
+                try {
+                    val itemDto = viewModel.serverRepository.apiClient.userLibraryApi.getItem(itemId).content
+                    type = itemDto.type
+                    Timber.d("Fetched item type ${type} for itemId $itemId")
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to fetch item type for $itemId")
+                    return null
+                }
+            } else {
+                Timber.d("User not logged in, cannot fetch item type for $itemId")
+                return null
+            }
+        }
+        
+        if (intentData.seriesId != null && intentData.seasonId != null && 
+            intentData.episodeNumber != null && intentData.seasonNumber != null) {
+            return Destination.SeriesOverview(
+                itemId = intentData.seriesId,
+                type = BaseItemKind.SERIES,
+                seasonEpisode = SeasonEpisodeIds(
+                    seasonId = intentData.seasonId,
+                    seasonNumber = intentData.seasonNumber,
+                    episodeId = itemId,
+                    episodeNumber = intentData.episodeNumber,
+                ),
+            )
+        }
+        
+        if (autoplay) {
+            val currentUser = viewModel.serverRepository.currentUser.value
+            if (currentUser != null) {
+                try {
+                    val apiClient = viewModel.serverRepository.apiClient
+                    
+                    if (type == BaseItemKind.SERIES) {
+                        Timber.d("Series autoplay: Finding next unwatched episode for series $itemId")
+                        val nextUpResult = apiClient.tvShowsApi.getNextUp(seriesId = itemId).content
+                        val nextEpisode = nextUpResult.items.firstOrNull() 
+                            ?: apiClient.tvShowsApi.getEpisodes(seriesId = itemId, limit = 1).content.items.firstOrNull()
+                        
+                        if (nextEpisode != null) {
+                            val resumePositionTicks = nextEpisode.userData?.playbackPositionTicks
+                            val resumeMs = resumePositionTicks?.ticks?.inWholeMilliseconds ?: 0L
+                            Timber.i("Series autoplay: Playing episode ${nextEpisode.id} with resume position $resumeMs ms")
+                            return Destination.Playback(itemId = nextEpisode.id, positionMs = resumeMs)
+                        } else {
+                            Timber.w("Series autoplay: Could not find an episode to play for series $itemId")
+                            return null
+                        }
+                    }
+                    
+                    if (type == BaseItemKind.SEASON) {
+                        Timber.d("Season autoplay: Finding first episode for season $itemId")
+                        val seasonDto = apiClient.userLibraryApi.getItem(itemId).content
+                        val seriesId = seasonDto.seriesId
+                        if (seriesId != null) {
+                            val request = GetEpisodesRequest(
+                                seriesId = seriesId,
+                                seasonId = itemId,
+                            )
+                            val episodesResult = apiClient.tvShowsApi.getEpisodes(request).content
+                            val firstEpisode = episodesResult.items.firstOrNull()
+                            if (firstEpisode != null) {
+                                val resumePositionTicks = firstEpisode.userData?.playbackPositionTicks
+                                val resumeMs = resumePositionTicks?.ticks?.inWholeMilliseconds ?: 0L
+                                Timber.i("Season autoplay: Playing first episode ${firstEpisode.id} with resume position $resumeMs ms")
+                                return Destination.Playback(itemId = firstEpisode.id, positionMs = resumeMs)
+                            } else {
+                                Timber.w("Season autoplay: Could not find episodes for season $itemId")
+                                return null
+                            }
+                        } else {
+                            Timber.w("Season autoplay: Season $itemId has no seriesId")
+                            return null
+                        }
+                    }
+                    
+                    Timber.d("Fetching item $itemId for resume position as user ${currentUser.id}")
+                    val itemDto = apiClient.userLibraryApi.getItem(itemId).content
+                    val resumeMs = itemDto.userData?.playbackPositionTicks?.ticks?.inWholeMilliseconds ?: 0L
+                    Timber.i("Creating playback destination for $itemId with resume position $resumeMs ms (from server, user=${currentUser.id})")
+                    return Destination.Playback(itemId = itemId, positionMs = resumeMs)
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to fetch item for playback as user ${currentUser.id}")
+                    if (type == BaseItemKind.SEASON || type == BaseItemKind.SERIES) {
+                        return null
+                    }
+                    return Destination.Playback(itemId = itemId, positionMs = 0L)
+                }
+            }
+            Timber.w("No current user when creating playback destination")
+            if (type == BaseItemKind.SEASON || type == BaseItemKind.SERIES) {
+                return null
+            }
+            return Destination.Playback(itemId = itemId, positionMs = 0L)
+        }
+        
+        return Destination.MediaItem(itemId = itemId, type = type, autoPlayOnLoad = false)
     }
 
     private fun extractDestination(intent: Intent): Destination? =
@@ -439,6 +695,9 @@ class MainActivity : AppCompatActivity() {
                             ),
                     )
                 } else {
+                    if (autoplay && (type == BaseItemKind.SEASON || type == BaseItemKind.SERIES)) {
+                        return null
+                    }
                     Destination.MediaItem(itemId, type, autoPlayOnLoad = autoplay)
                 }
             } else {
@@ -454,24 +713,26 @@ class MainActivity : AppCompatActivity() {
         val autoplay = uri.getQueryParameter("autoplay")?.toBooleanStrictOrNull() ?: false
         val type = uri.getQueryParameter("type")?.let(BaseItemKind::fromNameOrNull)
 
-        if (autoplay && type == null) {
-            return Destination.Playback(itemId = itemId, positionMs = 0L)
+        // For SEASON/SERIES with autoplay, or autoplay with unknown type, return null
+        // to let createDestinationFromIntentData resolve seasons/series to episodes
+        if (autoplay && (type == BaseItemKind.SEASON || type == BaseItemKind.SERIES || type == null)) {
+            return null
         }
+        
         return if (type != null) {
             Destination.MediaItem(itemId = itemId, type = type, autoPlayOnLoad = autoplay)
         } else {
+            Timber.d("Cannot create destination for $itemId: type unknown and autoplay=false")
             null
         }
     }
     
-    // Helper: Handles UUIDs with or without dashes
     private fun parseUUID(input: String?): UUID? {
         if (input.isNullOrBlank()) return null
         return try {
             if (input.contains("-")) {
                 UUID.fromString(input)
             } else {
-                // Insert dashes: 8-4-4-4-12
                 val f = input.replace("-", "")
                 if (f.length == 32) {
                     val formatted = "${f.substring(0, 8)}-${f.substring(8, 12)}-${f.substring(12, 16)}-${f.substring(16, 20)}-${f.substring(20)}"
@@ -485,6 +746,18 @@ class MainActivity : AppCompatActivity() {
             null
         }
     }
+
+    data class IntentData(
+        val serverId: UUID?,
+        val userId: UUID?,
+        val itemId: UUID?,
+        val itemType: BaseItemKind?,
+        val autoplay: Boolean,
+        val seriesId: UUID?,
+        val seasonId: UUID?,
+        val episodeNumber: Int?,
+        val seasonNumber: Int?,
+    )
 
     companion object {
         const val INTENT_ITEM_ID = "itemId"
@@ -510,11 +783,9 @@ class MainActivityViewModel
         private val backdropService: BackdropService,
     ) : ViewModel() {
 
-        /** Destination from the launching intent, consumed when AppContent is first composed. */
         var pendingRequestedDestination: Destination? = null
-
-        // TRACKER for the last item we successfully navigated to
         var lastProcessedItemId: UUID? = null
+        var pendingIntentData: MainActivity.IntentData? = null
 
         fun appStart(overrideUserId: java.util.UUID? = null, overrideServerId: java.util.UUID? = null) {
             viewModelScope.launchIO {

--- a/app/src/main/java/com/github/damontecres/wholphin/services/PlaybackLifecycleObserver.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/PlaybackLifecycleObserver.kt
@@ -1,5 +1,6 @@
 package com.github.damontecres.wholphin.services
 
+import android.app.Activity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.github.damontecres.wholphin.ui.nav.Destination
@@ -36,9 +37,16 @@ class PlaybackLifecycleObserver
         }
 
         override fun onPause(owner: LifecycleOwner) {
-            playerFactory.currentPlayer?.let {
-                wasPlaying = it.isPlaying
-                it.pause()
+            // Skip pausing when activity is finishing (e.g. nuclear restart): the player will be
+            // released as the activity is destroyed, and pause() can hit "Handler on a dead thread"
+            // if the player's handler is torn down before the message is processed.
+            if ((owner as? Activity)?.isFinishing != true) {
+                playerFactory.currentPlayer?.let {
+                    if (!it.isReleased) {
+                        wasPlaying = it.isPlaying
+                        it.pause()
+                    }
+                }
             }
             themeSongPlayer.stop()
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -91,6 +92,7 @@ import kotlin.time.Duration
 fun SeriesDetails(
     preferences: UserPreferences,
     destination: Destination.MediaItem,
+    autoPlayOnLoad: Boolean = false,
     modifier: Modifier = Modifier,
     viewModel: SeriesViewModel =
         hiltViewModel<SeriesViewModel, SeriesViewModel.Factory>(
@@ -116,6 +118,18 @@ fun SeriesDetails(
     var seasonDialog by remember { mutableStateOf<DialogParams?>(null) }
     var showPlaylistDialog by remember { mutableStateOf<Optional<UUID>>(Optional.absent()) }
     val playlistState by playlistViewModel.playlistState.observeAsState(PlaylistLoadingState.Pending)
+
+    val didAutoPlay = remember(destination.itemId, autoPlayOnLoad) { mutableStateOf(false) }
+    LaunchedEffect(loading, item, autoPlayOnLoad) {
+        if (!didAutoPlay.value &&
+            autoPlayOnLoad &&
+            loading == LoadingState.Success &&
+            item != null
+        ) {
+            didAutoPlay.value = true
+            viewModel.playNextUp()
+        }
+    }
 
     when (val state = loading) {
         is LoadingState.Error -> {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/Destination.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/Destination.kt
@@ -55,6 +55,7 @@ sealed class Destination(
         val itemId: UUID,
         val type: BaseItemKind,
         val collectionType: CollectionType? = null,
+        val autoPlayOnLoad: Boolean = false,
     ) : Destination() {
         constructor(item: BaseItem) : this(item.id, item.type, item.data.collectionType)
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
@@ -93,6 +93,7 @@ fun DestinationContent(
                     SeriesDetails(
                         preferences,
                         destination,
+                        autoPlayOnLoad = destination.autoPlayOnLoad,
                         modifier,
                     )
                 }
@@ -101,6 +102,7 @@ fun DestinationContent(
                     MovieDetails(
                         preferences,
                         destination,
+                        autoPlayOnLoad = destination.autoPlayOnLoad,
                         modifier,
                     )
                 }
@@ -110,6 +112,7 @@ fun DestinationContent(
                     MovieDetails(
                         preferences,
                         destination,
+                        autoPlayOnLoad = destination.autoPlayOnLoad,
                         modifier,
                     )
                 }
@@ -118,6 +121,7 @@ fun DestinationContent(
                     EpisodeDetails(
                         preferences,
                         destination,
+                        autoPlayOnLoad = destination.autoPlayOnLoad,
                         modifier,
                     )
                 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -289,6 +289,7 @@ class PlaybackViewModel
                 mediaSession =
                     MediaSession
                         .Builder(context, sessionPlayer)
+                        .setId(UUID.randomUUID().toString())
                         .build()
 
                 val item = BaseItem.from(base, api)


### PR DESCRIPTION
## Description
This PR implements **new deep linking functionality** for media playback, enabling external tools (e.g., ADB, Home Assistant) to trigger content directly.

Previously, there was no support for deep linking directly into playback. This PR introduces the `wholphin://play/` scheme and adds specific intent parameters (`userId`, `serverId`) to **bypass the login and server selection screens entirely**, allowing for seamless automation from a cold or warm start.

**Changes Implemented:**
* **New Deep Link Support:** Added handling for `wholphin://play/{itemId}` URIs.
* **Auth Bypass for Automation:** Implemented logic to accept `userId` and `serverId` via intent extras.
    * If these IDs are present, the app skips the standard startup flow (Server/User Select) and forces a session restoration for the requested user.
    * This works even if the app is already running (via `onNewIntent`), allowing for instant user switching.
* **Robust State Handling:**
    * **Cold Start:** App initializes, logs in silently, and starts playback.
    * **Warm Start / Wrong User:** If the app is already open but on a setup screen or logged into a different user, the activity is restarted to ensure a clean authentication flow.
    * **Same User:** If the app is already logged in as the target user, navigation happens instantly without reloading.
* **UUID Helper:** Added robust parsing to handle UUIDs with or without dashes (common in external tools).
* **Duplicate Prevention:** Added logic to ignore the playback command if the requested item is already playing.

### Related issues
Implements deep linking support for home automation integration.

**Steps to verify:**
1.  Close the app (or leave it on the User Select screen).
2.  Send the following ADB command:
    ```bash
    adb shell am start -W -a android.intent.action.VIEW \
    -d "wholphin://play/{ITEM_UUID}?autoplay=true" \
    --es "userId" "{USER_UUID}" \
    --es "serverId" "{SERVER_UUID}" \
    -n com.github.damontecres.wholphin/.MainActivity
    ```
3.  Observe that the app launches, bypasses all selection screens, and immediately starts playing the content.

### Screenshots
N/A - Logic implementation only.

### AI/LLM usage
I utilized an LLM (Gemini) to assist with the architecture of the `appStart` authentication flow and the intent handling lifecycle (`onNewIntent`) to ensuring smooth transitions between cold and warm states. Validated via ADB debugging and Home Assistant integration.
