### PR TITLE
Fix: disable MPV hardware decoding by default

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -772,7 +772,7 @@ sealed interface AppPreference<Pref, T> {
         val MpvHardwareDecoding =
             AppSwitchPreference<AppPreferences>(
                 title = R.string.mpv_hardware_decoding,
-                defaultValue = true,
+                defaultValue = false,
                 getter = { it.playbackPreferences.mpvOptions.enableHardwareDecoding },
                 setter = { prefs, value ->
                     prefs.updateMpvOptions { enableHardwareDecoding = value }
@@ -783,7 +783,7 @@ sealed interface AppPreference<Pref, T> {
         val MpvGpuNext =
             AppSwitchPreference<AppPreferences>(
                 title = R.string.mpv_use_gpu_next,
-                defaultValue = true,
+                defaultValue = false,
                 getter = { it.playbackPreferences.mpvOptions.useGpuNext },
                 setter = { prefs, value ->
                     prefs.updateMpvOptions { useGpuNext = value }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/AppUpgradeHandler.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/AppUpgradeHandler.kt
@@ -209,4 +209,13 @@ suspend fun upgradeApp(
         }
         showToast(context, context.getString(R.string.upgrade_mpv_toast), Toast.LENGTH_LONG)
     }
+
+    if (previous.isEqualOrBefore(Version.fromString("0.4.0-2-g0"))) {
+        appPreferences.updateData {
+            it.updateMpvOptions {
+                enableHardwareDecoding = false
+                useGpuNext = false
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description

Switched MPV to software decoding by default and disabled gpu-next. Hardware decoding was causing skipping and flickering in some videos, and gpu-next was giving a purple screen on certain devices (NVIDIA Shield being one). Software decoding just works everywhere, so making it the default makes sense.

- Set `MpvHardwareDecoding` and `MpvGpuNext` defaults to false
- Added a migration to flip these off for existing users that may be upgrading to 0.4.1 (where MPV will be set to preferred) and are not aware of their current MPV default settings.

## Related issues

Resolves #755

## Screenshots

N/A (Backend/Preference changes only).

## AI/LLM usage

Drafted PR description with AI assistance.