### PR TITLE
Fix(player): Disable gpu-next by default

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -783,7 +783,7 @@ sealed interface AppPreference<Pref, T> {
         val MpvGpuNext =
             AppSwitchPreference<AppPreferences>(
                 title = R.string.mpv_use_gpu_next,
-                defaultValue = true,
+                defaultValue = false,
                 getter = { it.playbackPreferences.mpvOptions.useGpuNext },
                 setter = { prefs, value ->
                     prefs.updateMpvOptions { useGpuNext = value }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/AppUpgradeHandler.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/AppUpgradeHandler.kt
@@ -209,4 +209,12 @@ suspend fun upgradeApp(
         }
         showToast(context, context.getString(R.string.upgrade_mpv_toast), Toast.LENGTH_LONG)
     }
+
+    if (previous.isEqualOrBefore(Version.fromString("0.4.0-2-g0"))) {
+        appPreferences.updateData {
+            it.updateMpvOptions {
+                useGpuNext = false
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description
Disables gpu-next by default in MPV settings. This renderer is experimental and causes broken playback (purple screen) on some older devices like the NVIDIA Shield 2019 Pro.

Also adds a migration to ensure gpu-next is turned off for existing users who upgrade, avoiding playback regressions for users being newly moved over to the Prefer MPV settings so that they can experience a smooth transition.

### Related issues
Fixes #754?

### Screenshots
N/A

### AI/LLM usage
PR drafting 
