### PR TITLE
Catch errors on discover request tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This is not a fork of the [official client](https://github.com/jellyfin/jellyfin
 ### User interface
 
 - A navigation drawer for quick access to libraries, favorites, search, and settings from almost anywhere in the app
-- Integration with [Seerr](https://github.com/seerr-team/seerr) to discover new movies and TV shows
+- Integration with [Jellyseerr](https://github.com/seerr-team/seerr) to discover new movies and TV shows
 - Option to combine Continue Watching & Next Up rows
 - Show Movie/TV Show titles when browsing libraries
 - Play theme music, if available
@@ -92,6 +92,8 @@ Note: if installed via an app store, the app store will handle updates.
 Requires Android 6+ (or Fire TV OS 6+) and Jellyfin server `10.10.x` or `10.11.x` (tested on primarily `10.11`).
 
 The app is tested on a variety of Android TV/Fire TV OS devices, but if you encounter issues, please file an issue!
+
+Jellyseerr integration is tested with `v2.7.3`. Older versions may not work.
 
 ## Contributions
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/SeerrRequestsPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/SeerrRequestsPage.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -112,6 +113,9 @@ class SeerrRequestsViewModel
 
                         state.update { it.copy(requests = DataLoadingState.Success(results)) }
                     }
+                }.catch { ex ->
+                    Timber.e(ex, "Error fetching requests")
+                    state.update { it.copy(requests = DataLoadingState.Error(ex)) }
                 }.launchIn(viewModelScope)
         }
 


### PR DESCRIPTION
## Description
Handle errors on the Discover/Jellyseerr requests tab preventing crashes

Note: this PR fixes the crash, but the error was a 400, which is likely due to the older Jellyseerr version.

### Related issues
Fixes #764