### PR TITLE
Fixes possible crash if a home row is removed

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
@@ -62,6 +62,7 @@ import com.github.damontecres.wholphin.ui.detail.MoreDialogActions
 import com.github.damontecres.wholphin.ui.detail.PlaylistDialog
 import com.github.damontecres.wholphin.ui.detail.PlaylistLoadingState
 import com.github.damontecres.wholphin.ui.detail.buildMoreDialogItemsForHome
+import com.github.damontecres.wholphin.ui.indexOfFirstOrNull
 import com.github.damontecres.wholphin.ui.isNotNullOrBlank
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.playback.isPlayKeyUp
@@ -203,15 +204,15 @@ fun HomePageContent(
     val rowFocusRequesters = remember(homeRows) { List(homeRows.size) { FocusRequester() } }
     var firstFocused by remember { mutableStateOf(false) }
     LaunchedEffect(homeRows) {
-        if (!firstFocused) {
+        if (!firstFocused && homeRows.isNotEmpty()) {
             if (position.row >= 0) {
-                rowFocusRequesters[position.row].tryRequestFocus()
+                val index = position.row.coerceIn(0, rowFocusRequesters.lastIndex)
+                rowFocusRequesters.getOrNull(index)?.tryRequestFocus()
                 firstFocused = true
             } else {
                 // Waiting for the first home row to load, then focus on it
                 homeRows
-                    .indexOfFirst { it is HomeRowLoadingState.Success && it.items.isNotEmpty() }
-                    .takeIf { it >= 0 }
+                    .indexOfFirstOrNull { it is HomeRowLoadingState.Success && it.items.isNotEmpty() }
                     ?.let {
                         rowFocusRequesters[it].tryRequestFocus()
                         firstFocused = true


### PR DESCRIPTION
## Description
Fixes a possible crash if a row on the home page is removed.

This could potentially happen if you only have one thing on the resume row and watch it by accessing it from the bottom row.