### PR TITLE
Fix: Prevent password from being sent as API key header

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/SeerrServerRepository.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/SeerrServerRepository.kt
@@ -137,7 +137,8 @@ class SeerrServerRepository
             username: String?,
             passwordOrApiKey: String,
         ): LoadingState {
-            val api = SeerrApiClient(url, passwordOrApiKey, okHttpClient)
+            val apiKey = passwordOrApiKey.takeIf { authMethod == SeerrAuthMethod.API_KEY }
+            val api = SeerrApiClient(url, apiKey, okHttpClient)
             login(api, authMethod, username, passwordOrApiKey)
             return LoadingState.Success
         }


### PR DESCRIPTION
## Summary
Fixes an issue where passwords for local/Jellyfin authentication were incorrectly being sent as API key headers.

## Changes
- Only send `X-Api-Key` header when using API key authentication
- For session-based auth (local and Jellyfin), avoid treating password as API key

## Technical Details
The `passwordOrApiKey` parameter is now conditionally used based on the authentication method. Only when `authMethod == SeerrAuthMethod.API_KEY` should it be passed to the `SeerrApiClient` constructor as an API key.

## Related issues
Replaces #734 

## AI/LLM usage
Claude + ChatGPT usage