### PR TITLE
Temporarily restore ExoPlayer as the default player

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -746,7 +746,7 @@ sealed interface AppPreference<Pref, T> {
         val PlayerBackendPref =
             AppChoicePreference<AppPreferences, PlayerBackend>(
                 title = R.string.player_backend,
-                defaultValue = PlayerBackend.PREFER_MPV,
+                defaultValue = PlayerBackend.EXO_PLAYER,
                 getter = { it.playbackPreferences.playerBackend },
                 setter = { prefs, value ->
                     prefs.updatePlaybackPreferences { playerBackend = value }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/AppUpgradeHandler.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/AppUpgradeHandler.kt
@@ -2,26 +2,21 @@ package com.github.damontecres.wholphin.services
 
 import android.content.Context
 import android.os.Build
-import android.widget.Toast
 import androidx.core.content.edit
 import androidx.datastore.core.DataStore
 import androidx.preference.PreferenceManager
-import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.WholphinApplication
 import com.github.damontecres.wholphin.preferences.AppPreference
 import com.github.damontecres.wholphin.preferences.AppPreferences
-import com.github.damontecres.wholphin.preferences.PlayerBackend
 import com.github.damontecres.wholphin.preferences.update
 import com.github.damontecres.wholphin.preferences.updateAdvancedPreferences
 import com.github.damontecres.wholphin.preferences.updateInterfacePreferences
 import com.github.damontecres.wholphin.preferences.updateLiveTvPreferences
 import com.github.damontecres.wholphin.preferences.updateMpvOptions
 import com.github.damontecres.wholphin.preferences.updatePlaybackOverrides
-import com.github.damontecres.wholphin.preferences.updatePlaybackPreferences
 import com.github.damontecres.wholphin.preferences.updateSubtitlePreferences
 import com.github.damontecres.wholphin.ui.preferences.PreferencesViewModel
 import com.github.damontecres.wholphin.ui.preferences.subtitle.SubtitleSettings
-import com.github.damontecres.wholphin.ui.showToast
 import com.github.damontecres.wholphin.util.Version
 import dagger.hilt.android.qualifiers.ApplicationContext
 import timber.log.Timber
@@ -203,12 +198,13 @@ suspend fun upgradeApp(
         }
     }
 
-    if (previous.isEqualOrBefore(Version.fromString("0.4.0-1-g0"))) {
-        appPreferences.updateData {
-            it.updatePlaybackPreferences { playerBackend = PlayerBackend.PREFER_MPV }
-        }
-        showToast(context, context.getString(R.string.upgrade_mpv_toast), Toast.LENGTH_LONG)
-    }
+    // TODO temporarily disabled until some MPV bugs are fixed
+//    if (previous.isEqualOrBefore(Version.fromString("0.4.0-1-g0"))) {
+//        appPreferences.updateData {
+//            it.updatePlaybackPreferences { playerBackend = PlayerBackend.PREFER_MPV }
+//        }
+//        showToast(context, context.getString(R.string.upgrade_mpv_toast), Toast.LENGTH_LONG)
+//    }
 
     if (previous.isEqualOrBefore(Version.fromString("0.4.0-2-g0"))) {
         appPreferences.updateData {


### PR DESCRIPTION
## Description
Due a few more MPV bugs showing up, this PR reverts the part of #736 that made "Prefer MPV" the default player option.

User can still manually switch to "Prefer MPV" and its full functional remains. It's just not set to be the default anymore.