### PR TITLE
Improve series overview loading speed

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/BaseItem.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/BaseItem.kt
@@ -72,8 +72,7 @@ data class BaseItem(
     @Transient
     val aspectRatio: Float? = data.primaryImageAspectRatio?.toFloat()?.takeIf { it > 0 }
 
-    @Transient
-    val indexNumber = data.indexNumber ?: dateAsIndex()
+    val indexNumber get() = data.indexNumber
 
     val playbackPosition get() = data.userData?.playbackPositionTicks?.ticks ?: Duration.ZERO
 


### PR DESCRIPTION
## Description
Improves loading speed for the series overview page (one with list of episodes). This is mostly accomplished by querying for the cast/crew in the episodes on demand instead of during the initial query.

Also stops using the date as a replacement for the episode index. Using this caused an extra unnecessary (long) query.

Going from home to the 109th of a 230 episode season is ~2x faster with this change on my test server.


### Related issues
Closes #599