### PR TITLE
Fix error reporting & crash during Jellyseerr login

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/WholphinApplication.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/WholphinApplication.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.ExperimentalComposeRuntimeApi
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import okhttp3.OkHttp
 import org.acra.ACRA
 import org.acra.ReportField
 import org.acra.config.dialog
@@ -63,6 +64,7 @@ class WholphinApplication :
 
     override fun onCreate() {
         super.onCreate()
+        OkHttp.initialize(this)
         initAcra {
             buildConfigClass = BuildConfig::class.java
             reportFormat = StringFormat.JSON

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
@@ -88,6 +88,7 @@ fun PreferencesContent(
     val state = rememberLazyListState()
     var preferences by remember { mutableStateOf(initialPreferences) }
     val currentUser by viewModel.currentUser.observeAsState()
+    val currentServer by seerrVm.currentSeerrServer.collectAsState(null)
     var showPinFlow by remember { mutableStateOf(false) }
 
     val navDrawerPins by viewModel.navDrawerPins.observeAsState(mapOf())
@@ -481,7 +482,7 @@ fun PreferencesContent(
             SeerrDialogMode.Remove -> {
                 ConfirmDialog(
                     title = stringResource(R.string.remove_seerr_server),
-                    body = "",
+                    body = currentServer?.url ?: "",
                     onCancel = { seerrDialogMode = SeerrDialogMode.None },
                     onConfirm = {
                         seerrVm.removeServer()

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/setup/seerr/SwitchSeerrViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/setup/seerr/SwitchSeerrViewModel.kt
@@ -30,6 +30,7 @@ class SwitchSeerrViewModel
         private val serverRepository: ServerRepository,
     ) : ViewModel() {
         val currentUser = serverRepository.currentUser
+        val currentSeerrServer = seerrServerRepository.currentServer
 
         val serverConnectionStatus = MutableStateFlow<LoadingState>(LoadingState.Pending)
 
@@ -61,15 +62,16 @@ class SwitchSeerrViewModel
                                 passwordOrApiKey = passwordOrApiKey,
                             )
                         } catch (ex: ClientException) {
-                            Timber.w(ex, "Error logging in")
+                            Timber.w(ex, "ClientException logging in")
                             if (ex.statusCode == 401 || ex.statusCode == 403) {
                                 showToast(context, "Invalid credentials")
-                                LoadingState.Error("Invalid credentials", ex)
+                                result = LoadingState.Error("Invalid credentials", ex)
                                 break
                             } else {
                                 LoadingState.Error("Could not connect with URL")
                             }
                         } catch (ex: Exception) {
+                            Timber.w(ex, "Exception logging in")
                             LoadingState.Error(ex)
                         }
                     if (result is LoadingState.Success) {


### PR DESCRIPTION
## Description
Makes sure the invalid credentials error is propagated up instead of displaying "No URL" as the error message.

Makes sure `OkHttp` is initialized since the startup initialization provider is disabled. This fixes a possible crash if `OkHttp` needs to access its assets.

Also, shows the URL when removing the Jellyseerr server.