### PR TITLE
Add spoiler-related options - hide unwatched item titles, overviews, and thumbnails

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/BaseItem.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/BaseItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.buildAnnotatedString
+import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.DateFormatter
 import com.github.damontecres.wholphin.ui.abbreviateNumber
 import com.github.damontecres.wholphin.ui.detail.CardGridItem
@@ -181,6 +182,41 @@ data class BaseItem(
                 }
             }
         return result
+    }
+
+    fun shouldHideOverview(preferences: UserPreferences): Boolean {
+        // If the item has been played, we never hide the description
+        if (played) return false
+
+        val isEpisode = type == BaseItemKind.EPISODE
+
+        // Check if we should hide descriptions for unwatched episodes
+        if (isEpisode && preferences.appPreferences.interfacePreferences.hideUnwatchedEpisodeOverviews) {
+            return true
+        }
+
+        val isMovie = type == BaseItemKind.MOVIE
+
+        // Check if we should hide descriptions for unwatched movies
+        if (isMovie && preferences.appPreferences.interfacePreferences.hideUnwatchedMovieOverviews) {
+            return true
+        }
+
+        return false
+    }
+
+    fun shouldHideTitle(preferences: UserPreferences): Boolean {
+        // If the item has been played, we never hide the title
+        if (played) return false
+
+        val isEpisode = type == BaseItemKind.EPISODE
+
+        // Check if we should hide titles for unwatched episodes
+        if (isEpisode && preferences.appPreferences.interfacePreferences.hideUnwatchedEpisodeTitles) {
+            return true
+        }
+
+        return false
     }
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -645,6 +645,55 @@ sealed interface AppPreference<Pref, T> {
                 setter = { prefs, _ -> prefs },
             )
 
+        val HideUnwatchedMovieOverviews =
+            AppSwitchPreference<AppPreferences>(
+                title = R.string.hide_unwatched_movie_overviews,
+                defaultValue = false,
+                getter = { it.interfacePreferences.hideUnwatchedMovieOverviews },
+                setter = { prefs, value ->
+                    prefs.updateInterfacePreferences { hideUnwatchedMovieOverviews = value }
+                },
+                summaryOn = R.string.enabled,
+                summaryOff = R.string.disabled,
+            )
+
+        val HideUnwatchedEpisodeOverviews =
+            AppSwitchPreference<AppPreferences>(
+                title = R.string.hide_unwatched_episode_overviews,
+                defaultValue = false,
+                getter = { it.interfacePreferences.hideUnwatchedEpisodeOverviews },
+                setter = { prefs, value ->
+                    prefs.updateInterfacePreferences { hideUnwatchedEpisodeOverviews = value }
+                },
+                summaryOn = R.string.enabled,
+                summaryOff = R.string.disabled,
+            )
+
+        val HideUnwatchedEpisodeTitles =
+            AppSwitchPreference<AppPreferences>(
+                title = R.string.hide_unwatched_episode_titles,
+                defaultValue = false,
+                getter = { it.interfacePreferences.hideUnwatchedEpisodeTitles },
+                setter = { prefs, value ->
+                    prefs.updateInterfacePreferences { hideUnwatchedEpisodeTitles = value }
+                },
+                summaryOn = R.string.enabled,
+                summaryOff = R.string.disabled,
+            )
+
+        val EpisodeThumbnailSpoilerModePref =
+            AppChoicePreference<AppPreferences, EpisodeThumbnailSpoilerMode>(
+                title = R.string.episode_thumbnail_spoiler_mode,
+                defaultValue = EpisodeThumbnailSpoilerMode.SPOILER_SHOW,
+                displayValues = R.array.episode_spoiler_options,
+                indexToValue = { index -> EpisodeThumbnailSpoilerMode.forNumber(index) ?: EpisodeThumbnailSpoilerMode.SPOILER_SHOW },
+                valueToIndex = { it.number },
+                getter = { it.interfacePreferences.episodeThumbnailSpoilerMode },
+                setter = { prefs, value ->
+                    prefs.updateInterfacePreferences { episodeThumbnailSpoilerMode = value }
+                },
+            )
+
         val NavDrawerSwitchOnFocus =
             AppSwitchPreference<AppPreferences>(
                 title = R.string.nav_drawer_switch_on_focus,
@@ -903,6 +952,11 @@ sealed interface AppPreference<Pref, T> {
                 getter = { },
                 setter = { prefs, _ -> prefs },
             )
+        val SpoilerSettings =
+            AppDestinationPreference<AppPreferences>(
+                title = R.string.spoiler_protection,
+                destination = Destination.Settings(PreferenceScreenOption.USER_INTERFACE),
+            )
     }
 }
 
@@ -920,6 +974,7 @@ val basicPreferences =
                     AppPreference.RememberSelectedTab,
                     AppPreference.SubtitleStyle,
                     AppPreference.ThemeColors,
+                    AppPreference.SpoilerSettings,
                 ),
         ),
         PreferenceGroup(
@@ -969,7 +1024,21 @@ val basicPreferences =
         ),
     )
 
-val uiPreferences = listOf<PreferenceGroup>()
+val spoilerPreferences =
+    listOf(
+        PreferenceGroup(
+            title = R.string.spoiler_protection,
+            preferences =
+                listOf(
+                    AppPreference.HideUnwatchedMovieOverviews,
+                    AppPreference.HideUnwatchedEpisodeOverviews,
+                    AppPreference.HideUnwatchedEpisodeTitles,
+                    AppPreference.EpisodeThumbnailSpoilerModePref,
+                ),
+        ),
+    )
+
+val uiPreferences = spoilerPreferences
 
 private val ExoPlayerSettings =
     listOf(

--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreferencesSerializer.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreferencesSerializer.kt
@@ -113,6 +113,10 @@ class AppPreferencesSerializer
                                             colorCodePrograms =
                                                 AppPreference.LiveTvColorCodePrograms.defaultValue
                                         }.build()
+                                hideUnwatchedMovieOverviews = AppPreference.HideUnwatchedMovieOverviews.defaultValue
+                                hideUnwatchedEpisodeOverviews = AppPreference.HideUnwatchedEpisodeOverviews.defaultValue
+                                hideUnwatchedEpisodeTitles = AppPreference.HideUnwatchedEpisodeTitles.defaultValue
+                                episodeThumbnailSpoilerMode = AppPreference.EpisodeThumbnailSpoilerModePref.defaultValue
                             }.build()
 
                     advancedPreferences =

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/EpisodeCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/EpisodeCard.kt
@@ -27,7 +27,11 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.tv.material3.Text
+import com.github.damontecres.wholphin.R
+import com.github.damontecres.wholphin.preferences.EpisodeThumbnailSpoilerMode
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.ui.AppColors
 import com.github.damontecres.wholphin.ui.AspectRatios
@@ -44,6 +48,8 @@ fun EpisodeCard(
     imageHeight: Dp = Dp.Unspecified,
     imageWidth: Dp = Dp.Unspecified,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    spoilerMode: EpisodeThumbnailSpoilerMode = EpisodeThumbnailSpoilerMode.SPOILER_SHOW,
+    isTitleHidden: Boolean = false,
 ) {
     val dto = item?.data
     val focused by interactionSource.collectIsFocusedAsState()
@@ -99,6 +105,7 @@ fun EpisodeCard(
                     watchedPercent = dto?.userData?.playedPercentage,
                     numberOfVersions = dto?.mediaSourceCount ?: 0,
                     useFallbackText = false,
+                    spoilerMode = spoilerMode,
                     modifier =
                         Modifier
                             .fillMaxSize(),
@@ -137,8 +144,9 @@ fun EpisodeCard(
                         .enableMarquee(focusedAfterDelay),
             )
             Text(
-                text = item?.name ?: "",
+                text = if (isTitleHidden) stringResource(R.string.title_hidden) else (item?.name ?: ""),
                 maxLines = 1,
+                fontStyle = if (isTitleHidden) FontStyle.Italic else FontStyle.Normal,
                 textAlign = TextAlign.Center,
                 modifier =
                     Modifier

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/GridCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/GridCard.kt
@@ -19,10 +19,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextAlign
+import com.github.damontecres.wholphin.R
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Card
+import com.github.damontecres.wholphin.preferences.EpisodeThumbnailSpoilerMode
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
@@ -46,6 +50,8 @@ fun GridCard(
     imageContentScale: ContentScale = ContentScale.Fit,
     imageType: ViewOptionImageType = ViewOptionImageType.PRIMARY,
     showTitle: Boolean = true,
+    spoilerMode: EpisodeThumbnailSpoilerMode = EpisodeThumbnailSpoilerMode.SPOILER_SHOW,
+    isTitleHidden: Boolean = false,
 ) {
     val dto = item?.data
     val focused by interactionSource.collectIsFocusedAsState()
@@ -94,6 +100,7 @@ fun GridCard(
                 numberOfVersions = dto?.mediaSourceCount ?: 0,
                 useFallbackText = false,
                 contentScale = imageContentScale,
+                spoilerMode = spoilerMode,
                 modifier =
                     Modifier
                         .fillMaxWidth()
@@ -110,8 +117,9 @@ fun GridCard(
                         .fillMaxWidth(),
             ) {
                 Text(
-                    text = item?.title ?: "",
+                    text = if (isTitleHidden) stringResource(R.string.title_hidden) else (item?.title ?: ""),
                     maxLines = 1,
+                    fontStyle = if (isTitleHidden) FontStyle.Italic else FontStyle.Normal,
                     textAlign = TextAlign.Center,
                     overflow = TextOverflow.Ellipsis,
                     modifier =

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
@@ -892,6 +892,7 @@ fun CollectionFolderGridContent(
             AnimatedVisibility(viewOptions.showDetails) {
                 HomePageHeader(
                     item = focusedItem,
+                    preferences = preferences,
                     modifier =
                         Modifier
                             .fillMaxWidth()
@@ -937,6 +938,8 @@ fun CollectionFolderGridContent(
                                 imageAspectRatio = viewOptions.aspectRatio.ratio,
                                 imageType = viewOptions.imageType,
                                 showTitle = viewOptions.showTitles,
+                                spoilerMode = preferences.appPreferences.interfacePreferences.episodeThumbnailSpoilerMode,
+                                isTitleHidden = preferences.appPreferences.interfacePreferences.hideUnwatchedEpisodeTitles && item?.type == BaseItemKind.EPISODE && item?.played == false,
                                 modifier = mod,
                             )
                         },

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/ItemGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/ItemGrid.kt
@@ -19,7 +19,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.data.model.BaseItem
+import org.jellyfin.sdk.model.api.BaseItemKind
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.ui.AspectRatios
 import com.github.damontecres.wholphin.ui.cards.GridCard
@@ -84,6 +86,7 @@ class ItemGridViewModel
 
 @Composable
 fun ItemGrid(
+    preferences: UserPreferences,
     destination: Destination.ItemGrid,
     modifier: Modifier = Modifier,
     viewModel: ItemGridViewModel =
@@ -135,6 +138,8 @@ fun ItemGrid(
                             item = item,
                             onClick = onClick,
                             onLongClick = onLongClick,
+                            spoilerMode = preferences.appPreferences.interfacePreferences.episodeThumbnailSpoilerMode,
+                            isTitleHidden = preferences.appPreferences.interfacePreferences.hideUnwatchedEpisodeTitles && item?.type == BaseItemKind.EPISODE && item?.played == false,
                             modifier = mod,
                             imageAspectRatio = AspectRatios.WIDE, // TODO
                         )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/OverviewText.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/OverviewText.kt
@@ -14,12 +14,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
+import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.ui.playOnClickSound
 import com.github.damontecres.wholphin.ui.playSoundOnFocus
 
@@ -27,11 +30,12 @@ import com.github.damontecres.wholphin.ui.playSoundOnFocus
 fun OverviewText(
     overview: String,
     maxLines: Int,
-    onClick: () -> Unit,
+    onClick: () -> Unit = {},
     modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textBoxHeight: Dp = maxLines * 20.dp,
     enabled: Boolean = true,
+    isHidden: Boolean = false,
 ) {
     val context = LocalContext.current
     val isFocused = interactionSource.collectIsFocusedAsState().value
@@ -56,8 +60,16 @@ fun OverviewText(
                 },
     ) {
         Text(
-            text = overview,
+            text =
+                if (overview.isBlank()) {
+                    stringResource(R.string.no_overview)
+                } else if (isHidden) {
+                    stringResource(R.string.unwatched_spoiler_hidden)
+                } else {
+                    overview
+                },
             style = MaterialTheme.typography.bodyMedium,
+            fontStyle = if (isHidden || overview.isBlank()) FontStyle.Italic else FontStyle.Normal,
             color = MaterialTheme.colorScheme.onSurface,
             maxLines = maxLines,
             overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
@@ -159,7 +159,7 @@ fun RecommendedContent(
                     viewModel.navigationManager.navigateTo(Destination.Playback(item))
                 },
                 onFocusPosition = onFocusPosition,
-                showClock = preferences.appPreferences.interfacePreferences.showClock,
+                preferences = preferences,
                 onUpdateBackdrop = viewModel::updateBackdrop,
                 modifier = modifier,
             )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/SeriesComponents.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/SeriesComponents.kt
@@ -2,6 +2,8 @@ package com.github.damontecres.wholphin.ui.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
@@ -29,11 +31,13 @@ fun SeriesName(
 fun EpisodeName(
     episodeName: String?,
     modifier: Modifier = Modifier,
+    isHidden: Boolean = false,
 ) {
     Text(
-        text = episodeName ?: "",
+        text = if (isHidden) stringResource(com.github.damontecres.wholphin.R.string.title_hidden) else (episodeName ?: ""),
         color = MaterialTheme.colorScheme.onSurface,
         style = MaterialTheme.typography.headlineSmall,
+        fontStyle = if (isHidden) FontStyle.Italic else FontStyle.Normal,
         fontSize = 20.sp,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
@@ -45,4 +49,5 @@ fun EpisodeName(
 fun EpisodeName(
     episode: BaseItemDto?,
     modifier: Modifier = Modifier,
-) = EpisodeName(episode?.episodeTitle ?: episode?.name, modifier)
+    isHidden: Boolean = false,
+) = EpisodeName(episode?.episodeTitle ?: episode?.name, modifier, isHidden)

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/episode/EpisodeDetailsHeader.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/episode/EpisodeDetailsHeader.kt
@@ -47,8 +47,9 @@ fun EpisodeDetailsHeader(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier,
     ) {
+        val isTitleHidden = ep.shouldHideTitle(preferences)
         SeriesName(dto.seriesName, Modifier.fillMaxWidth(.75f))
-        EpisodeName(dto, Modifier.fillMaxWidth(.75f))
+        EpisodeName(dto, Modifier.fillMaxWidth(.75f), isHidden = isTitleHidden)
 
         Column(
             verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -78,12 +79,14 @@ fun EpisodeDetailsHeader(
                 LaunchedEffect(focused) {
                     if (focused) bringIntoViewRequester.bringIntoView()
                 }
+                val isOverviewHidden = ep.shouldHideOverview(preferences)
                 OverviewText(
                     overview = overview,
                     maxLines = 3,
                     onClick = overviewOnClick,
                     textBoxHeight = Dp.Unspecified,
                     interactionSource = interactionSource,
+                    isHidden = isOverviewHidden,
                 )
             }
             ep.data.people

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/movie/MovieDetailsHeader.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/movie/MovieDetailsHeader.kt
@@ -22,6 +22,7 @@ import androidx.tv.material3.Text
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.ChosenStreams
 import com.github.damontecres.wholphin.data.model.BaseItem
+
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.GenreText
 import com.github.damontecres.wholphin.ui.components.OverviewText
@@ -91,11 +92,13 @@ fun MovieDetailsHeader(
 
             // Description
             dto.overview?.let { overview ->
+                val isOverviewHidden = movie.shouldHideOverview(preferences)
                 OverviewText(
                     overview = overview,
                     maxLines = 3,
                     onClick = overviewOnClick,
                     textBoxHeight = Dp.Unspecified,
+                    isHidden = isOverviewHidden,
                     modifier =
                         Modifier.onFocusChanged {
                             if (it.isFocused) {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/FocusedEpisodeHeader.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/FocusedEpisodeHeader.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.github.damontecres.wholphin.data.ChosenStreams
 import com.github.damontecres.wholphin.data.model.BaseItem
+
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.EpisodeName
 import com.github.damontecres.wholphin.ui.components.OverviewText
@@ -27,11 +28,13 @@ fun FocusedEpisodeHeader(
 ) {
     val context = LocalContext.current
     val dto = ep?.data
+    val isOverviewHidden = ep?.shouldHideOverview(preferences) ?: false
+    val isTitleHidden = ep?.shouldHideTitle(preferences) ?: false
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier,
     ) {
-        EpisodeName(dto, modifier = Modifier)
+        EpisodeName(dto, isHidden = isTitleHidden, modifier = Modifier)
 
         ep?.ui?.quickDetails?.let {
             QuickDetails(it, ep.timeRemainingOrRuntime)
@@ -48,6 +51,7 @@ fun FocusedEpisodeHeader(
             overview = dto?.overview ?: "",
             maxLines = 3,
             onClick = overviewOnClick,
+            isHidden = isOverviewHidden,
             modifier = Modifier.onFocusChanged(overviewOnFocus),
         )
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
@@ -43,6 +43,7 @@ import com.github.damontecres.wholphin.data.ExtrasItem
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.DiscoverItem
 import com.github.damontecres.wholphin.data.model.Person
+
 import com.github.damontecres.wholphin.data.model.Trailer
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.services.TrailerService
@@ -342,6 +343,7 @@ fun SeriesDetailsContent(
             ) {
                 item {
                     SeriesDetailsHeader(
+                        preferences = preferences,
                         series = series,
                         overviewOnClick = overviewOnClick,
                         modifier =
@@ -592,6 +594,7 @@ fun SeriesDetailsContent(
 
 @Composable
 fun SeriesDetailsHeader(
+    preferences: UserPreferences,
     series: BaseItem,
     overviewOnClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -618,11 +621,13 @@ fun SeriesDetailsHeader(
                 GenreText(it)
             }
             dto.overview?.let { overview ->
+                val isOverviewHidden = series.shouldHideOverview(preferences)
                 OverviewText(
                     overview = overview,
                     maxLines = 3,
                     onClick = overviewOnClick,
                     textBoxHeight = Dp.Unspecified,
+                    isHidden = isOverviewHidden,
                 )
             }
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.ChosenStreams
 import com.github.damontecres.wholphin.data.model.BaseItem
+
 import com.github.damontecres.wholphin.data.model.Person
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.AspectRatios
@@ -266,6 +267,8 @@ fun SeriesOverviewContent(
                                             },
                                     interactionSource = interactionSource,
                                     cardHeight = 120.dp,
+                                    spoilerMode = preferences.appPreferences.interfacePreferences.episodeThumbnailSpoilerMode,
+                                    isTitleHidden = preferences.appPreferences.interfacePreferences.hideUnwatchedEpisodeTitles && episode?.played == false,
                                 )
                             }
                         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/SeerrDiscoverPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/SeerrDiscoverPage.kt
@@ -242,6 +242,8 @@ fun SeerrDiscoverPage(
             subtitle = focusedItem?.subtitle,
             overview = focusedItem?.overview,
             overviewTwoLines = true,
+            isOverviewHidden = false,
+            isTitleHidden = false,
             quickDetails = details,
             timeRemaining = null,
             modifier =

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/SearchPage.kt
@@ -405,6 +405,8 @@ fun SearchPage(
                     },
                     onLongClick = onLongClick,
                     imageHeight = 140.dp,
+                    spoilerMode = userPreferences.appPreferences.interfacePreferences.episodeThumbnailSpoilerMode,
+                    isTitleHidden = userPreferences.appPreferences.interfacePreferences.hideUnwatchedEpisodeTitles && (item?.played == false),
                     modifier = mod.padding(horizontal = 8.dp),
                 )
             },

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
@@ -136,6 +136,7 @@ fun DestinationContent(
                 BaseItemKind.PLAYLIST -> {
                     LaunchedEffect(Unit) { onClearBackdrop.invoke() }
                     PlaylistDetails(
+                        preferences = preferences,
                         destination = destination,
                         modifier = modifier,
                     )
@@ -220,6 +221,7 @@ fun DestinationContent(
         is Destination.ItemGrid -> {
             LaunchedEffect(Unit) { onClearBackdrop.invoke() }
             ItemGrid(
+                preferences,
                 destination,
                 modifier,
             )

--- a/app/src/main/proto/WholphinDataStore.proto
+++ b/app/src/main/proto/WholphinDataStore.proto
@@ -142,6 +142,12 @@ enum BackdropStyle{
   BACKDROP_NONE = 2;
 }
 
+enum EpisodeThumbnailSpoilerMode {
+  SPOILER_SHOW = 0;
+  SPOILER_BLUR = 1;
+  SPOILER_SERIES_THUMBNAIL = 2;
+}
+
 message InterfacePreferences {
   ThemeSongVolume play_theme_songs = 1;
   bool remember_selected_tab = 2;
@@ -152,6 +158,10 @@ message InterfacePreferences {
   SubtitlePreferences subtitles_preferences = 7;
   LiveTvPreferences live_tv_preferences = 8;
   BackdropStyle backdrop_style = 9;
+  bool hide_unwatched_movie_overviews = 10;
+  bool hide_unwatched_episode_overviews = 11;
+  EpisodeThumbnailSpoilerMode episode_thumbnail_spoiler_mode = 12;
+  bool hide_unwatched_episode_titles = 13;
 }
 
 message AdvancedPreferences {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -370,6 +370,14 @@
     <string name="discard_change">Discard changes?</string>
     <string name="subtitle_margin">Margin</string>
     <string name="verbose_logging">Verbose logging</string>
+    <string name="hide_unwatched_movie_overviews">Hide unwatched movie overviews</string>
+    <string name="hide_unwatched_episode_overviews">Hide unwatched episode overviews</string>
+    <string name="hide_unwatched_episode_titles">Hide unwatched episode titles</string>
+    <string name="episode_thumbnail_spoiler_mode">Episode thumbnail protection</string>
+    <string name="spoiler_protection">Spoiler Protection</string>
+    <string name="unwatched_spoiler_hidden">Overview hidden</string>
+    <string name="title_hidden">Title hidden</string>
+    <string name="no_overview">No overview</string>
     <string name="enter_pin">Enter PIN</string>
     <string name="sign_in_auto">Sign in automatically</string>
     <string name="use_server_credentials">Login via server</string>
@@ -561,6 +569,11 @@
         <item>Image with dynamic color</item>
         <item>Image only</item>
         <item>None</item>
+    </string-array>
+    <string-array name="episode_spoiler_options">
+        <item>Show episode thumbnail</item>
+        <item>Blur episode thumbnail</item>
+        <item>Use series thumbnail</item>
     </string-array>
 
 </resources>


### PR DESCRIPTION
## Description
<!-- Describe the changes in detail -->

To prevent spoilers, I wanted to add an option to hide unwatched item overviews / descriptions. I also added the ability to hide unwatched episode thumbnails, either with a blur effect or by using the series thumbnail.

This also addresses items without an overview by giving them a "No overview" text.

I intentionally left the overview still visible when viewing an item's media information, so the user can still look at the overview if they really intend to dig deeper into the item.

### Related issues
<!-- If this is a new feature or a change, there must be a discussion in an issue first, then reference the issue here -->
<!-- If fixing a bug, reference the bug issue here, or describe the bug, including steps to reproduce -->
https://github.com/damontecres/Wholphin/issues/810
https://github.com/damontecres/Wholphin/issues/360

### Screenshots
<!-- Please include screenshots if the PR alters any UI elements -->

Menu items:

<img width="1920" height="1200" alt="Screenshot_20260201_181237" src="https://github.com/user-attachments/assets/82016737-9b45-4ac9-acfc-a0343242e1bb" />

Hidden overview, blurred thumbnail:

<img width="1920" height="1200" alt="Screenshot_20260201_181300" src="https://github.com/user-attachments/assets/6f7b370e-d561-4048-ad95-e92d53fcf1c7" />

Hidden overview, hidden title, series thumbnail:

<img width="1920" height="1200" alt="Screenshot_20260201_181222" src="https://github.com/user-attachments/assets/cd604288-d09a-442c-aa80-7f759b99c26c" />



### AI/LLM usage
<!-- If you used any AI/LLM assistance, please describe where in the code and how you tested it -->
I used Gemini to help with this PR. I've tested the code manually in Android Studio (how I generated the screenshots).