### PR TITLE
Always use space for home page header

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
@@ -401,19 +401,17 @@ fun HomePageHeader(
     item: BaseItem?,
     modifier: Modifier = Modifier,
 ) {
-    item?.let {
-        val isEpisode = item.type == BaseItemKind.EPISODE
-        val dto = item.data
-        HomePageHeader(
-            title = item.title,
-            subtitle = if (isEpisode) dto.name else null,
-            overview = dto.overview,
-            overviewTwoLines = isEpisode,
-            quickDetails = item.ui.quickDetails,
-            timeRemaining = item.timeRemainingOrRuntime,
-            modifier = modifier,
-        )
-    }
+    val isEpisode = item?.type == BaseItemKind.EPISODE
+    val dto = item?.data
+    HomePageHeader(
+        title = item?.title,
+        subtitle = if (isEpisode) dto?.name else null,
+        overview = dto?.overview,
+        overviewTwoLines = isEpisode,
+        quickDetails = item?.ui?.quickDetails,
+        timeRemaining = item?.timeRemainingOrRuntime,
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -422,7 +420,7 @@ fun HomePageHeader(
     subtitle: String?,
     overview: String?,
     overviewTwoLines: Boolean,
-    quickDetails: AnnotatedString,
+    quickDetails: AnnotatedString?,
     timeRemaining: Duration?,
     modifier: Modifier = Modifier,
 ) {
@@ -450,7 +448,7 @@ fun HomePageHeader(
             subtitle?.let {
                 EpisodeName(it)
             }
-            QuickDetails(quickDetails, timeRemaining)
+            QuickDetails(quickDetails ?: AnnotatedString(""), timeRemaining)
             val overviewModifier =
                 Modifier
                     .padding(0.dp)


### PR DESCRIPTION
## Description
Always include the home page header even if no item is focused yet. This ensures the space is used while the rows load and there isn't a glitch when the header is added.

### Related issues
Fixes #805 

### Testing
Emulator