### PR TITLE
Take playback speed into account when calculating the video end time

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackOverlay.kt
@@ -555,16 +555,19 @@ fun Controller(
                     )
                 }
                 if (showClock) {
-                    var remaining by remember { mutableStateOf((playerControls.duration - playerControls.currentPosition).milliseconds) }
+                    var endTimeStr by remember { mutableStateOf("...") }
                     LaunchedEffect(playerControls) {
                         while (isActive) {
-                            remaining =
-                                (playerControls.duration - playerControls.currentPosition).milliseconds
+                            val remaining =
+                                (playerControls.duration - playerControls.currentPosition)
+                                    .div(playerControls.playbackParameters.speed)
+                                    .toLong()
+                                    .milliseconds
+                            val endTime = LocalTime.now().plusSeconds(remaining.inWholeSeconds)
+                            endTimeStr = TimeFormatter.format(endTime)
                             delay(1.seconds)
                         }
                     }
-                    val endTime = LocalTime.now().plusSeconds(remaining.inWholeSeconds)
-                    val endTimeStr = TimeFormatter.format(endTime)
                     Text(
                         text = "Ends $endTimeStr",
                         color = MaterialTheme.colorScheme.onSurface,


### PR DESCRIPTION
## Description
Small change so that the "Ends" time on the playback overlay takes the current playback speed into account.

### Related issues
Closes #836

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None
