### PR TITLE
Update track selection logic for missing IDs

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/TrackSelectionUtils.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/TrackSelectionUtils.kt
@@ -2,18 +2,17 @@ package com.github.damontecres.wholphin.ui.playback
 
 import androidx.annotation.OptIn
 import androidx.media3.common.C
-import androidx.media3.common.Format
 import androidx.media3.common.TrackSelectionOverride
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
 import com.github.damontecres.wholphin.preferences.PlayerBackend
+import com.github.damontecres.wholphin.ui.indexOfFirstOrNull
 import org.jellyfin.sdk.model.api.MediaSourceInfo
 import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.MediaStreamType
 import org.jellyfin.sdk.model.api.SubtitleDeliveryMethod
 import timber.log.Timber
-import kotlin.math.max
 
 object TrackSelectionUtils {
     @OptIn(UnstableApi::class)
@@ -26,8 +25,8 @@ object TrackSelectionUtils {
         subtitleIndex: Int?,
         source: MediaSourceInfo,
     ): TrackSelectionResult {
-        val embeddedSubtitleCount = source.embeddedSubtitleCount
-        val externalSubtitleCount = source.externalSubtitlesCount
+        // This function's implementation assumes that indexes for each MediaStream in the MediaSourceInfo
+        // will be ordered as: external subtitles, video stream, audio stream, embedded subtitles
 
         val paramsBuilder = trackSelectionParams.buildUpon()
         val groups = tracks.groups
@@ -35,69 +34,62 @@ object TrackSelectionUtils {
         val subtitleSelected =
             if (subtitleIndex != null && subtitleIndex >= 0) {
                 val subtitleIsExternal = source.findExternalSubtitle(subtitleIndex) != null
-                if (subtitleIsExternal || supportsDirectPlay) {
-                    val chosenTrack =
-                        if (subtitleIsExternal && playerBackend == PlayerBackend.EXO_PLAYER) {
+                val chosenTrack =
+                    if (subtitleIsExternal) {
+                        // If external, only one external track should exist, so just find it
+                        val group =
                             groups.firstOrNull { group ->
                                 group.type == C.TRACK_TYPE_TEXT && group.isSupported &&
                                     (0..<group.mediaTrackGroup.length)
-                                        .mapNotNull {
-                                            group.getTrackFormat(it).id
-                                        }.any { it.endsWith("e:$subtitleIndex") }
+                                        .any {
+                                            group.getTrackFormat(0).id?.contains("e:") == true
+                                        }
                             }
-                        } else {
-                            val actualEmbeddedCount =
-                                groups
-                                    .filter { group ->
-                                        group.type == C.TRACK_TYPE_TEXT &&
-                                            (0..<group.mediaTrackGroup.length)
-                                                .mapNotNull {
-                                                    group.getTrackFormat(it).id
-                                                }.none { it.contains("e:") }
-                                    }.size
-                            val indexToFind =
-                                calculateIndexToFind(
-                                    subtitleIndex,
-                                    MediaStreamType.SUBTITLE,
-                                    playerBackend,
-                                    embeddedSubtitleCount,
-                                    externalSubtitleCount,
-                                    subtitleIsExternal,
-                                    actualEmbeddedCount,
-                                    source,
-                                )
-                            Timber.v("Chosen subtitle ($subtitleIndex/$indexToFind) track")
-                            // subtitleIndex - externalSubtitleCount + 1
-                            groups.firstOrNull { group ->
-                                group.type == C.TRACK_TYPE_TEXT && group.isSupported &&
-                                    (0..<group.mediaTrackGroup.length)
-                                        .filter {
-                                            if (subtitleIsExternal) {
+                        Timber.v(
+                            "Chosen external subtitle ($subtitleIndex/) track: %s",
+                            group,
+                        )
+                        group
+                    } else {
+                        // Not external
+                        // Find the first index of a embedded subtitle to use as an offset for desired subtitle index
+                        val firstEmbeddedSubtitleIndex =
+                            source.mediaStreams
+                                .orEmpty()
+                                .indexOfFirstOrNull {
+                                    it.type == MediaStreamType.SUBTITLE &&
+                                        !(it.deliveryMethod == SubtitleDeliveryMethod.EXTERNAL || it.isExternal)
+                                }
+                        if (firstEmbeddedSubtitleIndex != null) {
+                            val indexToFind = subtitleIndex - firstEmbeddedSubtitleIndex
+                            val subtitleTracks =
+                                groups.filter { group ->
+                                    group.type == C.TRACK_TYPE_TEXT && group.isSupported &&
+                                        (0..<group.mediaTrackGroup.length)
+                                            .none {
                                                 group.getTrackFormat(0).id?.contains("e:") == true
-                                            } else {
-                                                group.getTrackFormat(0).id?.contains("e:") == false
                                             }
-                                        }.map {
-                                            group.getTrackFormat(it).idAsInt
-                                        }.contains(indexToFind)
-                            }
-                        }
-
-                    Timber.v("Chosen subtitle ($subtitleIndex) track: $chosenTrack")
-                    chosenTrack?.let {
-                        paramsBuilder
-                            .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
-                            .setOverrideForType(
-                                TrackSelectionOverride(
-                                    chosenTrack.mediaTrackGroup,
-                                    0,
-                                ),
+                                }
+                            Timber.v(
+                                "Chosen eembedded subtitle ($subtitleIndex/$indexToFind) track: %s",
+                                subtitleTracks.getOrNull(indexToFind),
                             )
+                            subtitleTracks.getOrNull(indexToFind)
+                        } else {
+                            null
+                        }
                     }
-                    chosenTrack != null
-                } else {
-                    false
+                chosenTrack?.let {
+                    paramsBuilder
+                        .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
+                        .setOverrideForType(
+                            TrackSelectionOverride(
+                                chosenTrack.mediaTrackGroup,
+                                0,
+                            ),
+                        )
                 }
+                chosenTrack != null
             } else {
                 paramsBuilder
                     .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
@@ -106,26 +98,24 @@ object TrackSelectionUtils {
             }
         val audioSelected =
             if (audioIndex != null && supportsDirectPlay) {
-                val indexToFind =
-                    calculateIndexToFind(
-                        audioIndex,
-                        MediaStreamType.AUDIO,
-                        playerBackend,
-                        embeddedSubtitleCount,
-                        externalSubtitleCount,
-                        false,
-                        null,
-                        source,
-                    )
+                // Find the first index of an audio stream to use as an offset for desired index
+                val firstAudioIndex =
+                    source.mediaStreams
+                        .orEmpty()
+                        .indexOfFirstOrNull { it.type == MediaStreamType.AUDIO }
                 val chosenTrack =
-                    groups.firstOrNull { group ->
-                        group.type == C.TRACK_TYPE_AUDIO && group.isSupported &&
-                            (0..<group.mediaTrackGroup.length)
-                                .map {
-                                    group.getTrackFormat(it).idAsInt
-                                }.contains(indexToFind)
+                    if (firstAudioIndex != null) {
+                        val indexToFind = audioIndex - firstAudioIndex
+                        val audioGroups =
+                            groups.filter { group -> group.type == C.TRACK_TYPE_AUDIO && group.isSupported }
+                        Timber.v(
+                            "Chosen audio ($audioIndex/$indexToFind) track: %s",
+                            audioGroups.getOrNull(indexToFind),
+                        )
+                        audioGroups.getOrNull(indexToFind)
+                    } else {
+                        null
                     }
-                Timber.v("Chosen audio ($audioIndex/$indexToFind) track: $chosenTrack")
                 chosenTrack?.let {
                     paramsBuilder
                         .setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, false)
@@ -142,75 +132,7 @@ object TrackSelectionUtils {
             }
         return TrackSelectionResult(paramsBuilder.build(), audioSelected, subtitleSelected)
     }
-
-    /**
-     * Maps the server provided index to the track index based on the [PlayerBackend] and other stream information
-     */
-    private fun calculateIndexToFind(
-        serverIndex: Int,
-        type: MediaStreamType,
-        playerBackend: PlayerBackend,
-        embeddedSubtitleCount: Int,
-        externalSubtitleCount: Int,
-        subtitleIsExternal: Boolean,
-        actualEmbeddedCount: Int?,
-        source: MediaSourceInfo,
-    ): Int =
-        when (playerBackend) {
-            PlayerBackend.EXO_PLAYER,
-            PlayerBackend.UNRECOGNIZED,
-            -> {
-                serverIndex - externalSubtitleCount + 1
-            }
-
-            // TODO MPV could use literal indexes because they are stored in the track format ID
-            PlayerBackend.PREFER_MPV,
-            PlayerBackend.MPV,
-            -> {
-                when (type) {
-                    MediaStreamType.VIDEO -> {
-                        serverIndex - externalSubtitleCount + 1
-                    }
-
-                    MediaStreamType.AUDIO -> {
-                        val videoStreamsBeforeAudioCount =
-                            source.mediaStreams
-                                .orEmpty()
-                                .indexOfFirst { it.type == MediaStreamType.AUDIO } - externalSubtitleCount
-                        serverIndex - externalSubtitleCount - videoStreamsBeforeAudioCount + 1
-                    }
-
-                    MediaStreamType.SUBTITLE -> {
-                        if (subtitleIsExternal) {
-                            // Need to account for the actual embedded count because if the library
-                            // disables embedded subtitles, they still exist in the direct played file,
-                            // but not included in the MediaStreams list
-                            serverIndex + max(actualEmbeddedCount ?: 0, embeddedSubtitleCount) + 1
-                        } else {
-                            val videoStreamCount = source.videoStreamCount
-                            val audioStreamCount = source.audioStreamCount
-                            serverIndex - externalSubtitleCount - videoStreamCount - audioStreamCount + 1
-                        }
-                    }
-
-                    else -> {
-                        throw UnsupportedOperationException("Cannot calculate index for $type")
-                    }
-                }
-            }
-        }
 }
-
-val Format.idAsInt: Int?
-    @OptIn(UnstableApi::class)
-    get() =
-        id?.let {
-            if (it.contains(":")) {
-                it.split(":").last().toIntOrNull()
-            } else {
-                it.toIntOrNull()
-            }
-        }
 
 /**
  * Returns the number of external subtitle streams there are

--- a/app/src/main/java/com/github/damontecres/wholphin/util/TrackSupport.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/TrackSupport.kt
@@ -7,7 +7,6 @@ import androidx.media3.common.Format
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
-import com.github.damontecres.wholphin.ui.playback.idAsInt
 import timber.log.Timber
 import java.util.Locale
 
@@ -159,7 +158,7 @@ fun checkForSupport(tracks: Tracks): List<TrackSupport> =
                 val reason = TrackSupportReason.fromInt(it.getTrackSupport(i))
                 add(
                     TrackSupport(
-                        format.id + " (${format.idAsInt})",
+                        format.id,
                         type,
                         reason,
                         it.isSelected,


### PR DESCRIPTION
## Description
This is a major rewrite of the audio/subtitle track selection logic.

Instead of trying to match the server's index to a track's ID, the implementation now calculates the desired index's offset and uses that to select a track.

This means there is the assumption that that the indexes for each `MediaStream` in the `MediaSourceInfo` will be ordered as:
1. External subtitles
2. Video streams
3. Audio streams
4. Embedded subtitles

Note: this assumption is not new, the previous code assumed this as well, but wasn't as upfront about it.

Thus for a file with 1 external subtitle, 1 video, 2 audio, & 3 embedded subtitles and you want the second audo track (index=3):
1. Count everything before the first audio (2)
2. Subtract that from the desired index: 3-2=1
3. Find the 1 indexed audio track in the actual file, ie the second audio track

### Related issues
Maybes fixes #791

### Testing
Existing unit tests pass. Added additional test cases for a missing ID

I also crafted an mp4 and rewrote the track IDs so there was a gap in the IDs (none with ID=2). Before this PR, Wholphin was unable to switch audio tracks (the official app failed as well). With these change, it can.

I was unable to craft a similar mkv that played successfully and I believe this is because the mkv spec doesn't allow for missing IDs. This is why I'm unsure if #791 is fully resolved by this PR since the OP's issue occurs with a mkv.

<details>
<summary>Media info</summary>

```
Format                                   : MPEG-4
Format profile                           : Base Media
Codec ID                                 : isom (isom/iso2/avc1/mp41)
File size                                : 1 013 MiB
Duration                                 : 1 h 6 min
Overall bit rate                         : 2 134 kb/s
Frame rate                               : 29.970 FPS
Writing application                      : Lavf62.3.100

Video
ID                                       : 1
Format                                   : AVC
Format/Info                              : Advanced Video Codec
Format profile                           : High@L3
Format settings                          : CABAC / 4 Ref Frames
Format settings, CABAC                   : Yes
Format settings, Reference frames        : 4 frames
Codec ID                                 : avc1
Codec ID/Info                            : Advanced Video Coding
Duration                                 : 1 h 6 min
Bit rate                                 : 1 656 kb/s
Width                                    : 720 pixels
Height                                   : 480 pixels
Display aspect ratio                     : 16:9
Frame rate mode                          : Variable
Frame rate                               : 29.970 FPS
Minimum frame rate                       : 18.182 FPS
Maximum frame rate                       : 83.333 FPS
Standard                                 : NTSC
Color space                              : YUV
Chroma subsampling                       : 4:2:0
Bit depth                                : 8 bits
Scan type                                : Progressive
Bits/(Pixel*Frame)                       : 0.160
Stream size                              : 786 MiB (78%)
Writing library                          : x264 core 148
Encoding settings                        : cabac=1 / ref=2 / deblock=1:0:0 / analyse=0x3:0x113 / me=hex / subme=6 / psy=1 / psy_rd=1.00:0.00 / mixed_ref=1 / me_range=16 / chroma_me=1 / trellis=1 / 8x8dct=1 / cqm=0 / deadzone=21,11 / fast_pskip=1 / chroma_qp_offset=-2 / threads=12 / lookahead_threads=2 / sliced_threads=0 / nr=0 / decimate=1 / interlaced=0 / bluray_compat=0 / constrained_intra=0 / bframes=3 / b_pyramid=2 / b_adapt=1 / b_bias=0 / direct=1 / weightb=1 / open_gop=0 / weightp=1 / keyint=250 / keyint_min=25 / scenecut=40 / intra_refresh=0 / rc_lookahead=30 / rc=crf / mbtree=1 / crf=1.0 / qcomp=0.60 / qpmin=0 / qpmax=34 / qpstep=4 / vbv_maxrate=1666 / vbv_bufsize=3332 / crf_max=25.0 / nal_hrd=none / filler=0 / ip_ratio=1.40 / aq=1:1.00
Language                                 : English
Tagged date                              : 2026-02-07 20:08:08 UTC
Menus                                    : 5
mdhd_Duration                            : 3981065
Codec configuration box                  : avcC

Audio #1
ID                                       : 3
Format                                   : AAC LC
Format/Info                              : Advanced Audio Codec Low Complexity
Codec ID                                 : mp4a-40-2
Duration                                 : 1 h 6 min
Bit rate mode                            : Constant
Bit rate                                 : 341 kb/s
Channel(s)                               : 6 channels
Channel layout                           : C L R Ls Rs LFE
Sampling rate                            : 48.0 kHz
Frame rate                               : 46.875 FPS (1024 SPF)
Compression mode                         : Lossy
Stream size                              : 162 MiB (16%)
Title                                    : Surround 5.1
Language                                 : English
Default                                  : Yes
Alternate group                          : 1
Tagged date                              : 2026-02-07 20:08:08 UTC
Menus                                    : 5

Audio #2
ID                                       : 4
Format                                   : AAC LC
Format/Info                              : Advanced Audio Codec Low Complexity
Codec ID                                 : mp4a-40-2
Duration                                 : 1 h 6 min
Bit rate mode                            : Constant
Bit rate                                 : 132 kb/s
Channel(s)                               : 2 channels
Channel layout                           : L R
Sampling rate                            : 48.0 kHz
Frame rate                               : 46.875 FPS (1024 SPF)
Compression mode                         : Lossy
Stream size                              : 61.7 MiB (6%)
Title                                    : Stereo
Language                                 : Spanish
Default                                  : No
Alternate group                          : 1
Tagged date                              : 2026-02-07 20:08:08 UTC
Menus                                    : 5
```

</details>

## Screenshots
N/A

## AI or LLM usage
None