### PR TITLE
Fix glitchy nav drawer scrolling when opening

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/ApplicationContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/ApplicationContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.rememberSerializable
@@ -231,6 +232,7 @@ fun ApplicationContent(
                 )
             }
         }
+        val navDrawerListState = rememberLazyListState()
         NavDisplay(
             backStack = navigationManager.backStack,
             onBack = { navigationManager.goBack() },
@@ -257,6 +259,7 @@ fun ApplicationContent(
                             user = user,
                             server = server,
                             drawerState = drawerState,
+                            navDrawerListState = navDrawerListState,
                             onClearBackdrop = viewModel::clearBackdrop,
                             modifier = Modifier.fillMaxSize(),
                         )


### PR DESCRIPTION
## Description
The nav drawer would always glitch a little when it gained focus due it to trying to keep the selected page in view. #842 made this even worst.

This PR fixes that issue by hoisting the list scroll state up higher which ensures it is remembered between recompositions. This change also eliminates the need for workarounds to try and scroll it programmatically which is also a tiny performance boost.

### Related issues
Follow up to #842 

### Testing
Emulator & nvidia shield

## Screenshots
N/A

## AI or LLM usage
None