### PR TITLE
Fixes overscrolling on recommended tabs

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
@@ -37,9 +37,10 @@ import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.util.ApiRequestPager
 import com.github.damontecres.wholphin.util.HomeRowLoadingState
 import com.github.damontecres.wholphin.util.LoadingState
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 import org.jellyfin.sdk.model.api.MediaType
 import java.util.UUID
 
@@ -99,13 +100,13 @@ abstract class RecommendedViewModel(
     abstract fun update(
         @StringRes title: Int,
         row: HomeRowLoadingState,
-    )
+    ): HomeRowLoadingState
 
     fun update(
         @StringRes title: Int,
         block: suspend () -> List<BaseItem>,
-    ) {
-        viewModelScope.launch(Dispatchers.IO) {
+    ): Deferred<HomeRowLoadingState> =
+        viewModelScope.async(Dispatchers.IO) {
             val titleStr = context.getString(title)
             val row =
                 try {
@@ -115,7 +116,6 @@ abstract class RecommendedViewModel(
                 }
             update(title, row)
         }
-    }
 }
 
 @Composable

--- a/app/src/main/java/com/github/damontecres/wholphin/util/LoadingState.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/LoadingState.kt
@@ -48,6 +48,9 @@ sealed interface RowLoadingState {
 sealed interface HomeRowLoadingState {
     val title: String
 
+    val completed: Boolean
+        get() = this is Success || this is Error
+
     data class Pending(
         override val title: String,
     ) : HomeRowLoadingState


### PR DESCRIPTION
## Description
If the continue watching row is empty on recommended pages, it would scroll to the first successfully loaded row even if previous ones are still pending.

This PR fixes that so the page waits until the right first row is ready.

### Related issues
Fixes #839

### Testing
Emulator & shield 2019

## Screenshots
N/A

## AI or LLM usage
None
