### PR TITLE
Fixes the skip segment button appearance behavior

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/Extensions.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/Extensions.kt
@@ -392,6 +392,15 @@ fun CoroutineScope.launchIO(
 ): Job = launch(context = Dispatchers.IO + context, start = start, block = block)
 
 /**
+ * Launches a coroutine with [Dispatchers.Default] plus the provided [CoroutineContext] defaulting to using [ExceptionHandler]
+ */
+fun CoroutineScope.launchDefault(
+    context: CoroutineContext = ExceptionHandler(),
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    block: suspend CoroutineScope.() -> Unit,
+): Job = launch(context = Dispatchers.Default + context, start = start, block = block)
+
+/**
  * Converts a UUID to the format used server-side (ie without hyphens).
  *
  * This is the inverse of [org.jellyfin.sdk.model.serializer.toUUID]

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -86,7 +86,6 @@ import com.github.damontecres.wholphin.util.mpv.MpvPlayer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.jellyfin.sdk.model.extensions.ticks
 import timber.log.Timber
 import java.util.UUID
 import kotlin.time.Duration
@@ -163,8 +162,7 @@ fun PlaybackPageContent(
             itemId = UUID.randomUUID(),
         ),
     )
-    val currentSegment by viewModel.currentSegment.observeAsState(null)
-    var segmentCancelled by remember(currentSegment?.id) { mutableStateOf(false) }
+    val currentSegment by viewModel.currentSegment.collectAsState()
 
     val cues by viewModel.subtitleCues.observeAsState(listOf())
     var showDebugInfo by remember { mutableStateOf(prefs.showDebugInfo) }
@@ -302,10 +300,10 @@ fun PlaybackPageContent(
     }
 
     val showSegment =
-        !segmentCancelled && currentSegment != null &&
+        currentSegment?.interacted == false &&
             nextUp == null && !controllerViewState.controlsVisible && skipIndicatorDuration == 0L
     BackHandler(showSegment) {
-        segmentCancelled = true
+        viewModel.updateSegment(currentSegment?.segment?.id, true)
     }
 
     Box(
@@ -400,7 +398,7 @@ fun PlaybackPageContent(
                     onClickPlaylist = {
                         viewModel.playItemInPlaylist(it)
                     },
-                    currentSegment = currentSegment,
+                    currentSegment = currentSegment?.segment,
                     showClock = preferences.appPreferences.interfacePreferences.showClock,
                 )
             }
@@ -462,13 +460,12 @@ fun PlaybackPageContent(
                 LaunchedEffect(Unit) {
                     focusRequester.tryRequestFocus()
                     delay(10.seconds)
-                    segmentCancelled = true
+                    viewModel.updateSegment(segment.segment.id, true)
                 }
                 TextButton(
-                    stringRes = segment.type.skipStringRes,
+                    stringRes = segment.segment.type.skipStringRes,
                     onClick = {
-                        segmentCancelled = true
-                        player.seekTo(segment.endTicks.ticks.inWholeMilliseconds)
+                        viewModel.updateSegment(segment.segment.id, false)
                     },
                     modifier = Modifier.focusRequester(focusRequester),
                 )


### PR DESCRIPTION
## Description
Fixes the segment (intro, credits, etc) skip button appearance behavior

For the button shown on the video: if the button for a given segment is clicked, dismissed by the back button, or times out after 10 seconds, it will never appear again even if you rewind the video.

However, the current non-ignored segment will always show a button on the playback controls though so it's possible to still use it.

### Related issues
Fixes #875

### Testing
Tested a bunch of scenarios on the emulator

## Screenshots
N/A

## AI or LLM usage
None