### PR TITLE
Various fixes for home page customization

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
@@ -127,7 +127,7 @@ sealed interface HomeRowConfig {
     @Serializable
     @SerialName("TvPrograms")
     data class TvPrograms(
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions.liveTvDefault,
     ) : HomeRowConfig {
         override fun updateViewOptions(viewOptions: HomeRowViewOptions): TvPrograms = this.copy(viewOptions = viewOptions)
     }
@@ -138,7 +138,7 @@ sealed interface HomeRowConfig {
     @Serializable
     @SerialName("TvChannels")
     data class TvChannels(
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions.liveTvDefault,
     ) : HomeRowConfig {
         override fun updateViewOptions(viewOptions: HomeRowViewOptions): TvChannels = this.copy(viewOptions = viewOptions)
     }
@@ -213,12 +213,12 @@ const val SUPPORTED_HOME_PAGE_SETTINGS_VERSION = 1
 data class HomeRowViewOptions(
     val heightDp: Int = Cards.HEIGHT_2X3_DP,
     val spacing: Int = 16,
-    val contentScale: PrefContentScale = PrefContentScale.FIT,
+    val contentScale: PrefContentScale = PrefContentScale.FILL,
     val aspectRatio: AspectRatio = AspectRatio.TALL,
     val imageType: ViewOptionImageType = ViewOptionImageType.PRIMARY,
     val showTitles: Boolean = false,
     val useSeries: Boolean = true,
-    val episodeContentScale: PrefContentScale = PrefContentScale.FIT,
+    val episodeContentScale: PrefContentScale = PrefContentScale.FILL,
     val episodeAspectRatio: AspectRatio = AspectRatio.TALL,
     val episodeImageType: ViewOptionImageType = ViewOptionImageType.PRIMARY,
 ) {
@@ -229,10 +229,11 @@ data class HomeRowViewOptions(
                 aspectRatio = AspectRatio.WIDE,
             )
 
-        val channelsDefault =
+        val liveTvDefault =
             HomeRowViewOptions(
                 heightDp = 96,
                 aspectRatio = AspectRatio.WIDE,
+                contentScale = PrefContentScale.FIT,
             )
     }
 }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
@@ -859,8 +859,10 @@ class HomeSettingsService
                             userId = userDto.id,
                             fields = DefaultItemFields,
                             limit = limit,
-                            enableImages = true,
                             enableUserData = true,
+                            enableImages = true,
+                            enableImageTypes = listOf(ImageType.PRIMARY),
+                            imageTypeLimit = 1,
                         )
                     api.liveTvApi
                         .getRecommendedPrograms(request)

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/BannerCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/BannerCard.kt
@@ -124,7 +124,7 @@ fun BannerCard(
                 Text(
                     text = name ?: "",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.titleLarge,
+                    style = MaterialTheme.typography.titleMedium,
                     textAlign = TextAlign.Center,
                     modifier =
                         Modifier

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowPresets.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowPresets.kt
@@ -31,6 +31,7 @@ data class HomeRowPresets(
     val videoLibrary: HomeRowViewOptions,
     val photoLibrary: HomeRowViewOptions,
     val playlist: HomeRowViewOptions,
+    val liveTv: HomeRowViewOptions,
     val genreSize: Int,
 ) {
     fun getByCollectionType(collectionType: CollectionType): HomeRowViewOptions =
@@ -49,10 +50,11 @@ data class HomeRowPresets(
 
             CollectionType.PHOTOS -> photoLibrary
 
+            CollectionType.LIVETV -> liveTv
+
             CollectionType.UNKNOWN,
             CollectionType.MUSIC,
             CollectionType.BOOKS,
-            CollectionType.LIVETV,
             CollectionType.PLAYLISTS,
             CollectionType.FOLDERS,
             -> HomeRowViewOptions()
@@ -78,6 +80,7 @@ data class HomeRowPresets(
                         aspectRatio = AspectRatio.SQUARE,
                         contentScale = PrefContentScale.FIT,
                     ),
+                liveTv = HomeRowViewOptions.liveTvDefault,
                 genreSize = Cards.HEIGHT_2X3_DP,
             )
         }
@@ -115,6 +118,7 @@ data class HomeRowPresets(
                         aspectRatio = AspectRatio.SQUARE,
                         contentScale = PrefContentScale.FIT,
                     ),
+                liveTv = HomeRowViewOptions.liveTvDefault,
                 genreSize = epHeight,
             )
         }
@@ -156,6 +160,7 @@ data class HomeRowPresets(
                         aspectRatio = AspectRatio.SQUARE,
                         contentScale = PrefContentScale.FIT,
                     ),
+                liveTv = HomeRowViewOptions.liveTvDefault,
                 genreSize = epHeight,
             )
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowSettings.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowSettings.kt
@@ -197,7 +197,7 @@ internal object Options {
             title = R.string.global_content_scale,
             defaultValue = PrefContentScale.FIT,
             displayValues = R.array.content_scale,
-            getter = { it.contentScale },
+            getter = { it.episodeContentScale },
             setter = { viewOptions, value -> viewOptions.copy(episodeContentScale = value) },
             indexToValue = { PrefContentScale.forNumber(it) },
             valueToIndex = { it.number },
@@ -219,7 +219,7 @@ internal object Options {
             title = R.string.image_type,
             defaultValue = ViewOptionImageType.PRIMARY,
             displayValues = R.array.image_types,
-            getter = { it.imageType },
+            getter = { it.episodeImageType },
             setter = { viewOptions, value ->
                 val aspectRatio =
                     when (value) {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
@@ -306,7 +306,7 @@ class HomeSettingsViewModel
                                 title = title,
                                 config =
                                     HomeRowConfig.TvChannels(
-                                        viewOptions = HomeRowViewOptions.channelsDefault,
+                                        viewOptions = HomeRowViewOptions.liveTvDefault,
                                     ),
                             )
                         }
@@ -655,11 +655,11 @@ class HomeSettingsViewModel
                                 }
 
                                 is HomeRowConfig.TvPrograms -> {
-                                    it.config.updateViewOptions(preset.tvLibrary)
+                                    it.config.updateViewOptions(preset.liveTv)
                                 }
 
                                 is HomeRowConfig.TvChannels -> {
-                                    it.config
+                                    it.config.updateViewOptions(preset.liveTv)
                                 }
                             }
                         it.copy(config = newConfig)


### PR DESCRIPTION
## Description
Fixes several issues with home page customization such as
- Displaying wrong episode-specific display options
- Smaller text on cards without images
- Prefer fill scaling for posters, like the old home page

### Related issues
Related to #803 

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None