### PR TITLE
Fixing seek text label overlap and visibility issues.

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackOverlay.kt
@@ -449,7 +449,7 @@ fun PlaybackOverlay(
                         modifier =
                             Modifier
                                 .background(Color.Black.copy(alpha = 0.6f), shape = RoundedCornerShape(4.dp))
-                                .padding(horizontal = 6.dp, vertical = 2.dp),
+                                .padding(horizontal = 8.dp, vertical = 4.dp),
                     )
                 }
             }


### PR DESCRIPTION
## Description
- Smoothly bumps up the title and subtitle text above the seek progress label when the seek bar is focused to prevent overlap.
- Adds a semi-transparent black backer to the text label that appears above the seek progress indicator. Helps with visibility when the image in the playback matches the color of the text. Note: the backer is black with Alpha of 0.6 for now because I felt that looked good for contrast across all themes. However, if you prefer it respect a particular theme color, I'd be willing to make that change.

### Related issues
In the playback screen, when focusing the seek bar on Android TVs (at least the ones I was able to test), the seek text above the seek bar will overlap with the media title. This is a purely cosmetic issue in the UI, but it seemed worth a fix. See before and after images in in the Screenshots section below

This problem is briefly mentioned in point number 2 of [#528 ](https://github.com/damontecres/Wholphin/issues/528)

### Testing
Tested manually on TCL model 50S434 running Android TV. Tested manually using AVD emulation on Television (1080p) and Television (4K) preset devices. Reproduced the problem on all 3 devices and confirmed that my fix works across all.

## Screenshots
Before:
<img width="2046" height="1184" alt="before" src="https://github.com/user-attachments/assets/64708e13-3fa4-4248-91e3-e203f8ac1f7d" />

After:
<img width="2046" height="1183" alt="after" src="https://github.com/user-attachments/assets/db9d1767-cf93-4153-b13a-9a18fbc89e0c" />

## AI or LLM usage
None
