### PR TITLE
Override H264/AVC High 10 Profile Level 5.2 support for some devices

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/util/profile/DeviceProfileUtils.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/profile/DeviceProfileUtils.kt
@@ -2,7 +2,9 @@ package com.github.damontecres.wholphin.util.profile
 
 // Adapted from https://github.com/jellyfin/jellyfin-androidtv/blob/v0.19.4/app/src/main/java/org/jellyfin/androidtv/util/profile/deviceProfile.kt
 
+import android.media.MediaCodecInfo
 import androidx.media3.common.MimeTypes
+import com.github.damontecres.wholphin.util.profile.KnownDefects.supportsHi10P52
 import org.jellyfin.sdk.model.api.CodecType
 import org.jellyfin.sdk.model.api.DlnaProfileType
 import org.jellyfin.sdk.model.api.EncodingContext
@@ -92,9 +94,14 @@ fun createDeviceProfile(
     val hevcMainLevel = mediaTest.getHevcMainLevel()
     val hevcMain10Level = mediaTest.getHevcMain10Level()
     val supportsAVC = mediaTest.supportsAVC()
-    val supportsAVCHigh10 = mediaTest.supportsAVCHigh10()
+    val supportsAVCHigh10 = mediaTest.supportsAVCHigh10() || supportsHi10P52
     val avcMainLevel = mediaTest.getAVCMainLevel()
-    val avcHigh10Level = mediaTest.getAVCHigh10Level()
+    val avcHigh10Level =
+        if (supportsHi10P52) {
+            MediaCodecInfo.CodecProfileLevel.AVCLevel52
+        } else {
+            mediaTest.getAVCHigh10Level()
+        }
     val supportsAV1 = mediaTest.supportsAV1()
     val supportsAV1Main10 = mediaTest.supportsAV1Main10()
     val supportsVC1 = mediaTest.supportsVc1()

--- a/app/src/main/java/com/github/damontecres/wholphin/util/profile/KnownDefects.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/profile/KnownDefects.kt
@@ -5,7 +5,7 @@ package com.github.damontecres.wholphin.util.profile
 import android.os.Build
 
 /**
- * List of devie models with known HEVC DoVi/HDR10+ playback issues.
+ * List of device models with known HEVC DoVi/HDR10+ playback issues.
  */
 private val modelsWithDoViHdr10PlusBug =
     listOf(
@@ -14,6 +14,21 @@ private val modelsWithDoViHdr10PlusBug =
         "AFTKM", // Amazon Fire TV 4K (2nd Gen)
     )
 
+/**
+ * List of device models that support H264 Hi10P 5.2, but don't advertise it
+ *
+ * Amazon devices from https://developer.amazon.com/docs/device-specs/device-specifications-fire-tv-streaming-media-player.html
+ */
+private val modelsWithHi10P52Support =
+    listOf(
+        "AFTMA08C15", // Fire TV Stick 4K Plus (2025)
+        "AFTKRT", // Amazon Fire TV 4K Max (2nd Gen)
+        "AFTKA", // Amazon Fire TV 4K Max (1st Gen)
+        "AFTKM", // Amazon Fire TV 4K (2nd Gen)
+        "AFTMM", // Fire TV Stick 4K - 1st Gen (2018)
+    )
+
 object KnownDefects {
     val hevcDoviHdr10PlusBug = Build.MODEL in modelsWithDoViHdr10PlusBug
+    val supportsHi10P52 = Build.MODEL in modelsWithHi10P52Support
 }


### PR DESCRIPTION
## Description
Several Fire TV devices natively support H264/AVC High 10 Profile Level 5.2 according to [their specs](https://developer.amazon.com/docs/device-specs/device-specifications-fire-tv-streaming-media-player.html), but the `MediaCodecInfo` doesn't return this support.

So this PR adds an override for the known devices that support this which prevents unnecessary transcoding.

### Related issues
Closes #786

### Testing
Verified on a Fire TV 4k Max 2nd Gen

## Screenshots
N/A

## AI or LLM usage
None