### PR TITLE
LiveTV guide offset fix

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/LiveTvViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/LiveTvViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.damontecres.wholphin.ui.detail.livetv
 
 import android.content.Context
+import android.util.Log
 import androidx.compose.ui.graphics.Color
 import androidx.datastore.core.DataStore
 import androidx.lifecycle.MutableLiveData
@@ -50,6 +51,8 @@ import org.jellyfin.sdk.model.api.request.GetLiveTvChannelsRequest
 import org.jellyfin.sdk.model.extensions.ticks
 import timber.log.Timber
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 import javax.inject.Inject
@@ -106,7 +109,8 @@ class LiveTvViewModel
         }
 
         fun init() {
-            guideStart = LocalDateTime.now().truncatedTo(ChronoUnit.HOURS)
+            guideStart = LocalDateTime.now()
+                .truncatedTo(ChronoUnit.HOURS)
             viewModelScope.launch(
                 Dispatchers.IO +
                     LoadingExceptionHandler(
@@ -179,8 +183,15 @@ class LiveTvViewModel
             channels: List<TvChannel>,
             range: IntRange,
         ) = mutex.withLock {
-            val maxStartDate = guideStart.plusHours(MAX_HOURS).minusMinutes(1)
-            val minEndDate = guideStart.plusMinutes(1L)
+            val zone = ZoneId.systemDefault() // Get device's timezone
+            val guideStartUtc = guideStart
+                .atZone(zone) // This 17:00 is actually 17:00 CURRENT ZONE time
+                .withZoneSameInstant(ZoneOffset.UTC) // Convert to UTC ( for example UTC+2 -> 15:00)
+                .toLocalDateTime() // Strip the zone info
+
+            val maxStartDate = guideStartUtc.plusHours(MAX_HOURS).minusMinutes(1)
+            val minEndDate = guideStartUtc.plusMinutes(1L)
+
             val channelsToFetch = channels.subList(range.first, range.last + 1)
             Timber.v("Fetching programs for $range channels ${channelsToFetch.size}")
             val request =


### PR DESCRIPTION
<!-- By submitting this pull request, you acknowledge that you have read the [contributing guide](https://github.com/damontecres/Wholphin/blob/main/CONTRIBUTING.md, including the AI/LLM policy, and [developer's guide](https://github.com/damontecres/Wholphin/blob/main/DEVELOPMENT.md) -->

## Description
<!-- Describe the changes in detail -->
Fixes a timezone misalignment in the LiveTV guide.

The guide start time (guideStart) was interpreted using the device’s local timezone (e.g. UTC+2), while the backend guide data is based on UTC. This caused the guide window to shift forward by the local offset, effectively hiding the first ~2 hours of programming for users in UTC+2 (and similarly affecting other non-UTC timezones).

This ensures the guide window aligns correctly with backend UTC data and prevents missing early-hour entries.

### Related issues
<!-- If this is a new feature or a change, there must be a discussion in an issue first, reference the issue here -->
<!-- If fixing a bug, reference the bug issue here, or describe the bug, including steps to reproduce -->
Bug: LiveTV guide skips the first hours of programming when the device timezone is not UTC (e.g. UTC+2).

Steps to reproduce:
1. Set device timezone to UTC+2.
2. Open LiveTV guide.
3. Observe that the first ~2 hours of programming are missing.

### Testing
<!-- Describe how this change was tested and on what device(s) -->
Emulator + Android TV 15
