### PR TITLE
Better animation to show/hide headers on grid pages

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
@@ -2,10 +2,8 @@ package com.github.damontecres.wholphin.ui.components
 
 import android.content.Context
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.LocalBringIntoViewSpec
@@ -802,8 +800,8 @@ fun CollectionFolderGridContent(
         ) {
             AnimatedVisibility(
                 showHeader || loadingState !is DataLoadingState.Success,
-                enter = slideInVertically() + fadeIn(),
-                exit = slideOutVertically() + fadeOut(),
+                enter = expandVertically(),
+                exit = shrinkVertically(),
             ) {
                 Column(
                     verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderLiveTv.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderLiveTv.kt
@@ -1,10 +1,8 @@
 package com.github.damontecres.wholphin.ui.detail
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -127,8 +125,8 @@ fun CollectionFolderLiveTv(
     ) {
         AnimatedVisibility(
             showHeader,
-            enter = slideInVertically() + fadeIn(),
-            exit = slideOutVertically() + fadeOut(),
+            enter = expandVertically(),
+            exit = shrinkVertically(),
         ) {
             TabRow(
                 selectedTabIndex = selectedTabIndex,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderMovie.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderMovie.kt
@@ -1,10 +1,8 @@
 package com.github.damontecres.wholphin.ui.detail
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -76,8 +74,8 @@ fun CollectionFolderMovie(
     ) {
         AnimatedVisibility(
             showHeader,
-            enter = slideInVertically() + fadeIn(),
-            exit = slideOutVertically() + fadeOut(),
+            enter = expandVertically(),
+            exit = shrinkVertically(),
         ) {
             TabRow(
                 selectedTabIndex = selectedTabIndex,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderTv.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CollectionFolderTv.kt
@@ -1,10 +1,8 @@
 package com.github.damontecres.wholphin.ui.detail
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -80,8 +78,8 @@ fun CollectionFolderTv(
     ) {
         AnimatedVisibility(
             showHeader,
-            enter = slideInVertically() + fadeIn(),
-            exit = slideOutVertically() + fadeOut(),
+            enter = expandVertically(),
+            exit = shrinkVertically(),
         ) {
             TabRow(
                 selectedTabIndex = selectedTabIndex,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/FavoritesPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/FavoritesPage.kt
@@ -1,10 +1,8 @@
 package com.github.damontecres.wholphin.ui.detail
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -98,8 +96,8 @@ fun FavoritesPage(
     ) {
         AnimatedVisibility(
             showHeader,
-            enter = slideInVertically() + fadeIn(),
-            exit = slideOutVertically() + fadeOut(),
+            enter = expandVertically(),
+            exit = shrinkVertically(),
         ) {
             TabRow(
                 selectedTabIndex = selectedTabIndex,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/TvGuideGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/TvGuideGrid.kt
@@ -3,6 +3,8 @@ package com.github.damontecres.wholphin.ui.detail.livetv
 import android.text.format.DateUtils
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
@@ -140,7 +142,11 @@ fun TvGuideGrid(
                                     .fillMaxHeight(.30f),
                         )
                     }
-                    AnimatedVisibility(focusedPosition.row < 1) {
+                    AnimatedVisibility(
+                        focusedPosition.row < 1,
+                        enter = expandVertically(),
+                        exit = shrinkVertically(),
+                    ) {
                         ExpandableFaButton(
                             title = R.string.view_options,
                             iconStringRes = R.string.fa_sliders,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverPage.kt
@@ -1,10 +1,8 @@
 package com.github.damontecres.wholphin.ui.discover
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -60,8 +58,8 @@ fun DiscoverPage(
     ) {
         AnimatedVisibility(
             showHeader,
-            enter = slideInVertically() + fadeIn(),
-            exit = slideOutVertically() + fadeOut(),
+            enter = expandVertically(),
+            exit = shrinkVertically(),
         ) {
             TabRow(
                 selectedTabIndex = selectedTabIndex,


### PR DESCRIPTION
## Description
Changes the animation for showing/hiding the header title/buttons on grid pages.

This eliminates the awkward jump the grid does to fill the screen. Instead it smoothly resizes.

### Related issues
Fixes the second item in #221

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None