### PR TITLE
Fix race condition when updating preferences

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/hilt/AppModule.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/hilt/AppModule.kt
@@ -171,7 +171,7 @@ object AppModule {
             if (preferences.appPreferences.interfacePreferences.rememberSelectedTab) {
                 scope.launch(ExceptionHandler()) {
                     appPreference.updateData {
-                        preferences.appPreferences.updateInterfacePreferences {
+                        it.updateInterfacePreferences {
                             putRememberedTabs(key(itemId), tabIndex)
                         }
                     }


### PR DESCRIPTION
## Description
Fixes a race condition saving preferences. It would be triggered if you have "Remember selected tabs" enabled and either: 1) changed settings while on a library grid page or 2) changed settings on a page navigated _from_ a library grid page and then returned to the grid

### Related issues
I think this will fix #1075

### Testing
Emulator following the steps above

## Screenshots
N/A

## AI or LLM usage
None