### PR TITLE
Fix slideshow images not resizing properly

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/slideshow/SlideshowPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/slideshow/SlideshowPage.kt
@@ -395,8 +395,9 @@ fun SlideshowPage(
                             ImageRequest
                                 .Builder(LocalContext.current)
                                 .data(imageState.url)
-                                .size(Size.ORIGINAL)
-                                .transitionFactory(CrossFadeFactory(750.milliseconds))
+                                .apply {
+                                    if (isZoomed) size(Size.ORIGINAL)
+                                }.transitionFactory(CrossFadeFactory(750.milliseconds))
                                 .useExistingImageAsPlaceholder(true)
                                 .build(),
                         contentDescription = null,


### PR DESCRIPTION
## Description
During a slideshow of images, the viewpoint would resize to largest image resolution and images with smaller dimensions would be scaled down and centered with black bars.

This might be a Coil bug, but I'm not 100% sure yet. This PR works around the issue by scaling all images to the display resolution instead of using `Size.ORIGINAL`.

However, we want `Size.ORIGINAL` while zooming so it doesn't pixelate if the original image's resolution is larger than the display's.

### Related issues
Fixes https://github.com/damontecres/Wholphin/issues/835#issuecomment-4035005433

### Testing
Emulator with 1920x1080 & 800x1600 images

## Screenshots
N/A

## AI or LLM usage
None