### PR TITLE
Simplify series overview page refresh

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverview.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverview.kt
@@ -125,20 +125,6 @@ fun SeriesOverview(
     var rowFocused by rememberInt()
     var showDeleteDialog by remember { mutableStateOf<BaseItem?>(null) }
 
-    LaunchedEffect(episodes) {
-        episodes?.let { episodes ->
-            if (episodes is EpisodeList.Success) {
-                if (episodes.episodes.isNotEmpty()) {
-                    // TODO focus on first episode when changing seasons?
-//            firstItemFocusRequester.requestFocus()
-                    episodes.episodes.getOrNull(position.episodeRowIndex)?.let {
-                        viewModel.refreshEpisode(it.id, position.episodeRowIndex)
-                    }
-                }
-            }
-        }
-    }
-
     LaunchedEffect(position, episodes) {
         val focusedEpisode =
             (episodes as? EpisodeList.Success)

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
@@ -387,12 +387,6 @@ class SeriesViewModel
                 withContext(Dispatchers.Main) {
                     this@SeriesViewModel.episodes.value = episodes
                 }
-                if (currentEpisodes == null || currentEpisodes.seasonId != seasonId) {
-                    (episodes as? EpisodeList.Success)
-                        ?.let {
-                            it.episodes.getOrNull(it.initialEpisodeIndex)
-                        }?.let { lookupPeopleInEpisode(it) }
-                }
             }
         }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/util/ApiRequestPager.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/ApiRequestPager.kt
@@ -146,17 +146,17 @@ class ApiRequestPager<T>(
         position: Int,
         itemId: UUID,
     ) {
-        val item =
-            api.userLibraryApi.getItem(itemId).content.let {
-                BaseItem.from(
-                    it,
-                    api,
-                    useSeriesForPrimary,
-                )
-            }
-        val pageNumber = position / pageSize
-        val index = position - pageNumber * pageSize
         mutex.withLock {
+            val item =
+                api.userLibraryApi.getItem(itemId).content.let {
+                    BaseItem.from(
+                        it,
+                        api,
+                        useSeriesForPrimary,
+                    )
+                }
+            val pageNumber = position / pageSize
+            val index = position - pageNumber * pageSize
             val page = cachedPages.getIfPresent(pageNumber)
             if (page != null && index in page.indices) {
                 page[index] = item


### PR DESCRIPTION
## Description
This PR simplifies refreshing the episode data when returning to the series overview page and reduces the number of queries.

Also fixes a race condition when refreshing a single item in the an `ApiRequestPager`.

### Related issues
Related to #767

### Testing
Emulator, but will need more testing during actual usage

## Screenshots
N/A

## AI or LLM usage
None