### PR TITLE
Refresh seasons on series details page

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
@@ -132,6 +132,14 @@ fun SeriesDetails(
     var showPlaylistDialog by remember { mutableStateOf<Optional<UUID>>(Optional.absent()) }
     var showDeleteDialog by remember { mutableStateOf<BaseItem?>(null) }
 
+    LifecycleResumeEffect(destination.itemId) {
+        viewModel.refresh()
+
+        onPauseOrDispose {
+            viewModel.release()
+        }
+    }
+
     when (val state = loading) {
         is LoadingState.Error -> {
             ErrorMessage(state, modifier)
@@ -148,9 +156,7 @@ fun SeriesDetails(
                 LifecycleResumeEffect(destination.itemId) {
                     viewModel.onResumePage()
 
-                    onPauseOrDispose {
-                        viewModel.release()
-                    }
+                    onPauseOrDispose {}
                 }
 
                 val played = item.data.userData?.played ?: false

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
@@ -271,14 +271,25 @@ class SeriesViewModel
         }
 
         fun onResumePage() {
-            viewModelScope.launchIO {
-                item.value?.let {
-                    backdropService.submit(it)
+            item.value?.let { item ->
+                viewModelScope.launchDefault { backdropService.submit(item) }
+                viewModelScope.launchIO {
                     val playThemeSongs =
                         userPreferencesService
                             .getCurrent()
                             .appPreferences.interfacePreferences.playThemeSongs
                     themeSongPlayer.playThemeFor(seriesId, playThemeSongs)
+                }
+            }
+        }
+
+        fun refresh() {
+            item.value?.let { item ->
+                if (loading.value == LoadingState.Success) {
+                    viewModelScope.launchIO {
+                        val seasons = getSeasons(item, null).await()
+                        this@SeriesViewModel.seasons.setValueOnMain(seasons)
+                    }
                 }
             }
         }
@@ -292,6 +303,7 @@ class SeriesViewModel
             seasonNum: Int?,
         ): Deferred<List<BaseItem?>> =
             viewModelScope.async(Dispatchers.IO) {
+                Timber.v("getSeasons for %s", series.id)
                 val request =
                     GetItemsRequest(
                         parentId = series.id,


### PR DESCRIPTION
## Description
Simply fetches the tv show's seasons when returning the details page. This ensures the unwatched counts are updated.

### Related issues
Mentioned as a bug in https://github.com/damontecres/Wholphin/issues/767#issuecomment-4071852502

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None