### PR TITLE
Fix server discovery reporting localhost instead of real IP

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/LocalServerDiscovery.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/LocalServerDiscovery.kt
@@ -1,0 +1,97 @@
+package com.github.damontecres.wholphin.services
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import org.json.JSONObject
+import timber.log.Timber
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.net.SocketTimeoutException
+import java.net.URL
+import java.util.UUID
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Discovers Jellyfin servers on the local network via UDP broadcast (port 7359).
+ *
+ * Uses the sender's actual IP from the UDP packet instead of the server-reported
+ * address, which avoids the common localhost/127.0.0.1 issue.
+ */
+class LocalServerDiscovery(
+    private val dispatcher: CoroutineContext,
+) {
+    data class Result(
+        val id: UUID,
+        val name: String,
+        val address: String,
+    )
+
+    fun discover(timeoutMs: Int = 3000): Flow<Result> =
+        flow {
+            val seen = mutableSetOf<String>()
+
+            DatagramSocket().use { socket ->
+                socket.broadcast = true
+                socket.soTimeout = timeoutMs
+
+                socket.send(
+                    DatagramPacket(
+                        BROADCAST_MSG,
+                        BROADCAST_MSG.size,
+                        InetAddress.getByName("255.255.255.255"),
+                        PORT,
+                    ),
+                )
+
+                val buf = ByteArray(4096)
+                val deadline = System.currentTimeMillis() + timeoutMs
+
+                while (System.currentTimeMillis() < deadline) {
+                    try {
+                        val pkt = DatagramPacket(buf, buf.size)
+                        socket.receive(pkt)
+                        val result = parse(pkt) ?: continue
+                        if (seen.add(result.address)) emit(result)
+                    } catch (_: SocketTimeoutException) {
+                        break
+                    }
+                }
+            }
+        }.flowOn(dispatcher)
+
+    private fun parse(pkt: DatagramPacket): Result? =
+        try {
+            val json = JSONObject(String(pkt.data, 0, pkt.length).trim())
+            val senderIp = pkt.address.hostAddress ?: throw IllegalStateException("No sender IP")
+            val port = json.optString("Address").extractPort()
+
+            Result(
+                id =
+                    try {
+                        UUID.fromString(json.optString("Id"))
+                    } catch (_: Exception) {
+                        UUID.randomUUID()
+                    },
+                name = json.optString("Name", "Jellyfin Server"),
+                address = "http://$senderIp:$port",
+            )
+        } catch (e: Exception) {
+            Timber.d(e, "Failed to parse discovery response")
+            null
+        }
+
+    private fun String.extractPort(): Int =
+        try {
+            URL(this).port.takeIf { it > 0 } ?: DEFAULT_PORT
+        } catch (_: Exception) {
+            DEFAULT_PORT
+        }
+
+    companion object {
+        private const val PORT = 7359
+        private const val DEFAULT_PORT = 8096
+        private val BROADCAST_MSG = "Who is JellyfinServer?".toByteArray()
+    }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/setup/SwitchServerViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/setup/SwitchServerViewModel.kt
@@ -9,6 +9,7 @@ import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.JellyfinServerDao
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.model.JellyfinServer
+import com.github.damontecres.wholphin.services.LocalServerDiscovery
 import com.github.damontecres.wholphin.services.SetupDestination
 import com.github.damontecres.wholphin.services.SetupNavigationManager
 import com.github.damontecres.wholphin.services.hilt.DefaultDispatcher
@@ -261,22 +262,12 @@ class SwitchServerViewModel
 
         fun discoverServers() {
             viewModelScope.launchIO {
-                jellyfin.discovery.discoverLocalServers().collect { server ->
-                    val newServerList =
-                        discoveredServers.value!!
-                            .toMutableList()
-                            .apply {
-                                add(
-                                    JellyfinServer(
-                                        server.id.toUUID(),
-                                        server.name,
-                                        server.address,
-                                        null,
-                                    ),
-                                )
-                            }
-                    withContext(Dispatchers.Main) {
-                        discoveredServers.value = newServerList
+                LocalServerDiscovery(ioDispatcher).discover().collect { result ->
+                    val current = discoveredServers.value.orEmpty()
+                    if (current.none { it.url == result.address }) {
+                        discoveredServers.setValueOnMain(
+                            current + JellyfinServer(result.id, result.name, result.address, null),
+                        )
                     }
                 }
             }


### PR DESCRIPTION
When discovering servers on the local network, the app shows localhost or 127.0.0.1 because the Jellyfin SDK reads the Address field from the server's UDP response. Many Jellyfin setups report their loopback address there.

I added a LocalServerDiscovery class that does the same UDP broadcast but uses the actual source IP from the incoming packet. Updated SwitchServerViewModel to use it.

Tested on a network where the server was reporting http://localhost:8096 — now correctly shows http://192.168.0.5:8096.

AI/LLM disclosure: Claude was used to assist with this code change.