### PR TITLE
Don't recursively query collections on home page

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
@@ -162,7 +162,7 @@ sealed interface HomeRowConfig {
     @SerialName("ByParent")
     data class ByParent(
         val parentId: UUID,
-        val recursive: Boolean,
+        val recursive: Boolean = false,
         val sort: SortAndDirection? = null,
         override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
     ) : HomeRowConfig {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
@@ -414,7 +414,7 @@ class HomeSettingsViewModel
                     config =
                         HomeRowConfig.ByParent(
                             parentId = parent.id,
-                            recursive = true,
+                            recursive = false,
                         ),
                 )
             updateState {


### PR DESCRIPTION
## Description
Don't recursively query collections for the home page rows. This prevents episodes within tv shows from being shown.

### Related issues
Fixes https://github.com/damontecres/Wholphin/issues/1148
Fixes #1147

### Testing
Emulator & API

## Screenshots
N/A

## AI or LLM usage
None