### PR TITLE
Quality: JNI class/method lookups are unchecked, allowing null IDs to be cached and crash later

### DIFF
--- a/app/src/main/jni/jni_utils.cpp
+++ b/app/src/main/jni/jni_utils.cpp
@@ -16,37 +16,79 @@ bool acquire_jni_env(JavaVM *vm, JNIEnv **env)
 // Apparently it's considered slow to FindClass and GetMethodID every time we need them,
 // so let's have a nice cache here.
 
+static bool clear_pending_exception(JNIEnv *env)
+{
+    if (!env->ExceptionCheck())
+        return false;
+
+    env->ExceptionDescribe();
+    env->ExceptionClear();
+    return true;
+}
+
 void init_methods_cache(JNIEnv *env)
 {
     static bool methods_initialized = false;
     if (methods_initialized)
         return;
 
-    #define FIND_CLASS(name) reinterpret_cast<jclass>(env->NewGlobalRef(env->FindClass(name)))
-    java_Integer = FIND_CLASS("java/lang/Integer");
-    java_Integer_init = env->GetMethodID(java_Integer, "<init>", "(I)V");
-    java_Double = FIND_CLASS("java/lang/Double");
-    java_Double_init = env->GetMethodID(java_Double, "<init>", "(D)V");
-    java_Boolean = FIND_CLASS("java/lang/Boolean");
-    java_Boolean_init = env->GetMethodID(java_Boolean, "<init>", "(Z)V");
+    #define FIND_CLASS(dst, name) \
+        do { \
+            jclass localClass = env->FindClass(name); \
+            if (localClass == nullptr || clear_pending_exception(env)) \
+                return; \
+            dst = reinterpret_cast<jclass>(env->NewGlobalRef(localClass)); \
+            env->DeleteLocalRef(localClass); \
+            if (dst == nullptr || clear_pending_exception(env)) \
+                return; \
+        } while (0)
+    #define GET_METHOD_ID(dst, clazz, name, signature) \
+        do { \
+            dst = env->GetMethodID(clazz, name, signature); \
+            if (dst == nullptr || clear_pending_exception(env)) \
+                return; \
+        } while (0)
+    #define GET_STATIC_METHOD_ID(dst, clazz, name, signature) \
+        do { \
+            dst = env->GetStaticMethodID(clazz, name, signature); \
+            if (dst == nullptr || clear_pending_exception(env)) \
+                return; \
+        } while (0)
+    #define GET_STATIC_FIELD_ID(dst, clazz, name, signature) \
+        do { \
+            dst = env->GetStaticFieldID(clazz, name, signature); \
+            if (dst == nullptr || clear_pending_exception(env)) \
+                return; \
+        } while (0)
 
-    android_graphics_Bitmap = FIND_CLASS("android/graphics/Bitmap");
+    FIND_CLASS(java_Integer, "java/lang/Integer");
+    GET_METHOD_ID(java_Integer_init, java_Integer, "<init>", "(I)V");
+    FIND_CLASS(java_Double, "java/lang/Double");
+    GET_METHOD_ID(java_Double_init, java_Double, "<init>", "(D)V");
+    FIND_CLASS(java_Boolean, "java/lang/Boolean");
+    GET_METHOD_ID(java_Boolean_init, java_Boolean, "<init>", "(Z)V");
+
+    FIND_CLASS(android_graphics_Bitmap, "android/graphics/Bitmap");
     // createBitmap(int[], int, int, android.graphics.Bitmap$Config)
-    android_graphics_Bitmap_createBitmap = env->GetStaticMethodID(android_graphics_Bitmap, "createBitmap", "([IIILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;");
-    android_graphics_Bitmap_Config = FIND_CLASS("android/graphics/Bitmap$Config");
+    GET_STATIC_METHOD_ID(android_graphics_Bitmap_createBitmap, android_graphics_Bitmap, "createBitmap", "([IIILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;");
+    FIND_CLASS(android_graphics_Bitmap_Config, "android/graphics/Bitmap$Config");
     // static final android.graphics.Bitmap$Config ARGB_8888
-    android_graphics_Bitmap_Config_ARGB_8888 = env->GetStaticFieldID(android_graphics_Bitmap_Config, "ARGB_8888", "Landroid/graphics/Bitmap$Config;");
+    GET_STATIC_FIELD_ID(android_graphics_Bitmap_Config_ARGB_8888, android_graphics_Bitmap_Config, "ARGB_8888", "Landroid/graphics/Bitmap$Config;");
 
-    mpv_MPVLib = FIND_CLASS("com/github/damontecres/wholphin/util/mpv/MPVLib");
-    mpv_MPVLib_eventProperty_S  = env->GetStaticMethodID(mpv_MPVLib, "eventProperty", "(Ljava/lang/String;)V"); // eventProperty(String)
-    mpv_MPVLib_eventProperty_Sb = env->GetStaticMethodID(mpv_MPVLib, "eventProperty", "(Ljava/lang/String;Z)V"); // eventProperty(String, boolean)
-    mpv_MPVLib_eventProperty_Sl = env->GetStaticMethodID(mpv_MPVLib, "eventProperty", "(Ljava/lang/String;J)V"); // eventProperty(String, long)
-    mpv_MPVLib_eventProperty_Sd = env->GetStaticMethodID(mpv_MPVLib, "eventProperty", "(Ljava/lang/String;D)V"); // eventProperty(String, double)
-    mpv_MPVLib_eventProperty_SS = env->GetStaticMethodID(mpv_MPVLib, "eventProperty", "(Ljava/lang/String;Ljava/lang/String;)V"); // eventProperty(String, String)
-    mpv_MPVLib_event = env->GetStaticMethodID(mpv_MPVLib, "event", "(I)V"); // event(int)
-    mpv_MPVLib_end_file_event = env->GetStaticMethodID(mpv_MPVLib, "eventEndFile", "(II)V"); // eventEndFile(int, int)
-    mpv_MPVLib_logMessage_SiS = env->GetStaticMethodID(mpv_MPVLib, "logMessage", "(Ljava/lang/String;ILjava/lang/String;)V"); // logMessage(String, int, String)
+    FIND_CLASS(mpv_MPVLib, "com/github/damontecres/wholphin/util/mpv/MPVLib");
+    GET_STATIC_METHOD_ID(mpv_MPVLib_eventProperty_S, mpv_MPVLib, "eventProperty", "(Ljava/lang/String;)V"); // eventProperty(String)
+    GET_STATIC_METHOD_ID(mpv_MPVLib_eventProperty_Sb, mpv_MPVLib, "eventProperty", "(Ljava/lang/String;Z)V"); // eventProperty(String, boolean)
+    GET_STATIC_METHOD_ID(mpv_MPVLib_eventProperty_Sl, mpv_MPVLib, "eventProperty", "(Ljava/lang/String;J)V"); // eventProperty(String, long)
+    GET_STATIC_METHOD_ID(mpv_MPVLib_eventProperty_Sd, mpv_MPVLib, "eventProperty", "(Ljava/lang/String;D)V"); // eventProperty(String, double)
+    GET_STATIC_METHOD_ID(mpv_MPVLib_eventProperty_SS, mpv_MPVLib, "eventProperty", "(Ljava/lang/String;Ljava/lang/String;)V"); // eventProperty(String, String)
+    GET_STATIC_METHOD_ID(mpv_MPVLib_event, mpv_MPVLib, "event", "(I)V"); // event(int)
+    GET_STATIC_METHOD_ID(mpv_MPVLib_end_file_event, mpv_MPVLib, "eventEndFile", "(II)V"); // eventEndFile(int, int)
+    GET_STATIC_METHOD_ID(mpv_MPVLib_logMessage_SiS, mpv_MPVLib, "logMessage", "(Ljava/lang/String;ILjava/lang/String;)V"); // logMessage(String, int, String)
+
     #undef FIND_CLASS
+    #undef GET_METHOD_ID
+    #undef GET_STATIC_METHOD_ID
+    #undef GET_STATIC_FIELD_ID
 
     methods_initialized = true;
 }


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`FindClass`, `GetMethodID`, and `GetStaticMethodID` results are assigned directly with no null checks and no handling of pending JNI exceptions. If any signature/class name is wrong (e.g., release minification/proguard mismatch, API changes), null handles are cached and used later, which typically crashes the process in subsequent JNI method invocations.


**Severity**: `high`
**File**: `app/src/main/jni/jni_utils.cpp`

### Solution
Validate each lookup immediately and fail initialization if any lookup returns null. Also clear or propagate JNI exceptions. For example, wrap each call: `if ((id = env->GetStaticMethodID(...)) == nullptr) { env->ExceptionDescribe(); env->ExceptionClear(); return false; }` and change `init_methods_cache` to return `bool` so callers can abort safely when initialization fails.


### Changes
- `app/src/main/jni/jni_utils.cpp` (modified)



## Description


### Related issues



### Testing


## Screenshots


## AI or LLM usage



Closes #1165