### PR TITLE
perfomance: Reduce recompositions in SeriesOverviewContent when navigating

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
@@ -260,14 +261,21 @@ fun SeriesOverviewContent(
                                             ).ifElse(
                                                 episodeIndex == epPosition,
                                                 Modifier.focusRequester(episodeRowFocusRequester),
-                                            ).ifElse(
-                                                episodeIndex != position.episodeRowIndex,
-                                                Modifier
-                                                    .background(
-                                                        Color.Black,
-                                                        shape = RoundedCornerShape(8.dp),
-                                                    ).alpha(dimming),
-                                            ).onFocusChanged {
+                                            ).background(
+                                                if (episodeIndex != position.episodeRowIndex) {
+                                                    Color.Black
+                                                } else {
+                                                    Color.Transparent
+                                                },
+                                                shape = RoundedCornerShape(8.dp),
+                                            ).graphicsLayer {
+                                                alpha =
+                                                    if (episodeIndex != position.episodeRowIndex) {
+                                                        dimming
+                                                    } else {
+                                                        1f
+                                                    }
+                                            }.onFocusChanged {
                                                 if (it.isFocused) {
                                                     scope.launch {
                                                         bringIntoViewRequester.bringIntoView()


### PR DESCRIPTION
<!-- By submitting this pull request, you acknowledge that you have read the [contributing guide](https://github.com/damontecres/Wholphin/blob/main/CONTRIBUTING.md, including the AI/LLM policy, and [developer's guide](https://github.com/damontecres/Wholphin/blob/main/DEVELOPMENT.md) -->

## Description
<!-- Describe the changes in detail -->
Make alpha channel and background change in Banner Card more recomposition friendly. 

Split from #1152

### Related issues
<!-- If this is a new feature or a change, there must be a discussion in an issue first, reference the issue here -->
<!-- If fixing a bug, reference the bug issue here, or describe the bug, including steps to reproduce -->

### Testing
<!-- Describe how this change was tested and on what device(s) -->
Tested on a emulator
It's observed when moving from TV series episode card to EpisodeFooter and back
## Screenshots
<!-- Please include screenshots if the PR alters any UI elements -->
| Pre | Post |
|--------|--------|
| <img width="395" height="152" alt="Screenshot 2026-04-02 at 08 41 40" src="https://github.com/user-attachments/assets/b6554425-8af5-4e29-a866-3e4f6a7be473" /> | <img width="406" height="296" alt="Screenshot 2026-04-02 at 08 44 56" src="https://github.com/user-attachments/assets/511fc6df-c860-47eb-aec8-57c400dba83c" /> |


## AI or LLM usage
<!-- If you used any AI or LLM assistance, please list where in the code and how you tested it -->
Gemini in AS was used for repetitive code completion 