### PR TITLE
Add stats HUD to player

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackControls.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackControls.kt
@@ -90,6 +90,8 @@ import kotlin.time.Duration.Companion.seconds
 sealed interface PlaybackAction {
     data object ShowDebug : PlaybackAction
 
+    data object ToggleStats : PlaybackAction
+
     data object ShowPlaylist : PlaybackAction
 
     data object ShowVideoFilterDialog : PlaybackAction

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackDialog.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackDialog.kt
@@ -51,6 +51,7 @@ enum class PlaybackDialogType {
 
 data class PlaybackSettings(
     val showDebugInfo: Boolean,
+    val showStats: Boolean,
     val audioIndex: Int?,
     val audioStreams: List<SimpleMediaStream>,
     val subtitleIndex: Int?,
@@ -85,10 +86,17 @@ fun PlaybackDialog(
     when (type) {
         PlaybackDialogType.MORE -> {
             val options =
-                buildList {
+                buildList<BottomDialogItem<PlaybackAction>> {
                     add(
                         BottomDialogItem(
-                            data = 0,
+                            data = PlaybackAction.ToggleStats,
+                            headline = stringResource(if (settings.showStats) R.string.hide_stats else R.string.show_stats),
+                            supporting = null,
+                        ),
+                    )
+                    add(
+                        BottomDialogItem(
+                            data = PlaybackAction.ShowDebug,
                             headline = stringResource(if (settings.showDebugInfo) R.string.hide_debug_info else R.string.show_debug_info),
                             supporting = null,
                         ),
@@ -101,7 +109,7 @@ fun PlaybackDialog(
 //                    focusRequester.tryRequestFocus()
                 },
                 onSelectChoice = { index, choice ->
-                    onPlaybackActionClick.invoke(PlaybackAction.ShowDebug)
+                    onPlaybackActionClick.invoke(choice.data)
                 },
                 gravity = Gravity.START,
             )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackOverlay.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackOverlay.kt
@@ -116,6 +116,8 @@ fun PlaybackOverlay(
     onClickPlaybackDialogType: (PlaybackDialogType) -> Unit,
     onSeekBarChange: (Long) -> Unit,
     showDebugInfo: Boolean,
+    showStats: Boolean = false,
+    player: Player? = null,
     currentPlayback: CurrentPlayback?,
     currentSegment: MediaSegmentDto?,
     modifier: Modifier = Modifier,
@@ -559,6 +561,21 @@ fun PlaybackOverlay(
                         .align(Alignment.TopStart)
                         .padding(8.dp)
                         .background(AppColors.TransparentBlack50),
+            )
+        }
+        // Stats HUD - visible even when controls are hidden
+        AnimatedVisibility(
+            visible = showStats,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier =
+                Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 16.dp, end = 16.dp),
+        ) {
+            PlaybackStatsHud(
+                currentPlayback = currentPlayback,
+                player = player,
             )
         }
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -164,6 +164,7 @@ fun PlaybackPageContent(
 
     val cues by viewModel.subtitleCues.observeAsState(listOf())
     var showDebugInfo by remember { mutableStateOf(prefs.showDebugInfo) }
+    var showStats by remember { mutableStateOf(false) }
 
     val nextUp by viewModel.nextUp.observeAsState(null)
     val playlist by viewModel.playlist.observeAsState(Playlist(listOf()))
@@ -258,6 +259,10 @@ fun PlaybackPageContent(
 
             PlaybackAction.ShowDebug -> {
                 showDebugInfo = !showDebugInfo
+            }
+
+            PlaybackAction.ToggleStats -> {
+                showStats = !showStats
             }
 
             PlaybackAction.ShowPlaylist -> {
@@ -392,6 +397,8 @@ fun PlaybackPageContent(
                 onClickPlaybackDialogType = { playbackDialog = it },
                 onSeekBarChange = seekBarState::onValueChange,
                 showDebugInfo = showDebugInfo,
+                showStats = showStats,
+                player = player,
                 currentPlayback = currentPlayback,
                 chapters = mediaInfo?.chapters ?: listOf(),
                 trickplayInfo = mediaInfo?.trickPlayInfo,
@@ -588,6 +595,7 @@ fun PlaybackPageContent(
             settings =
                 PlaybackSettings(
                     showDebugInfo = showDebugInfo,
+                    showStats = showStats,
                     audioIndex = currentItemPlayback?.audioIndex,
                     audioStreams = mediaInfo?.audioStreams.orEmpty(),
                     subtitleIndex = currentItemPlayback?.subtitleIndex,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackStatsHud.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackStatsHud.kt
@@ -1,0 +1,197 @@
+package com.github.damontecres.wholphin.ui.playback
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.media3.common.Player
+import androidx.tv.material3.Text
+import com.github.damontecres.wholphin.preferences.PlayerBackend
+import com.github.damontecres.wholphin.ui.formatBitrate
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import org.jellyfin.sdk.model.api.MediaStreamType
+import org.jellyfin.sdk.model.api.PlayMethod
+import kotlin.time.Duration.Companion.seconds
+
+private val HudGreen = Color(0xFF4CAF50)
+private val HudOrange = Color(0xFFFF9800)
+private val HudCyan = Color(0xFF00BCD4)
+private val HudWhite = Color.White
+private val HudDimWhite = Color.White.copy(alpha = 0.6f)
+private val HudBackground = Color.Black.copy(alpha = 0.55f)
+
+private val HudFontSize = 11.sp
+private val HudFont = FontFamily.Monospace
+
+@Composable
+fun PlaybackStatsHud(
+    currentPlayback: CurrentPlayback?,
+    player: Player?,
+    modifier: Modifier = Modifier,
+) {
+    if (currentPlayback == null) return
+
+    val bufferAheadSec by produceState(0L, player) {
+        while (isActive) {
+            val pos = player?.currentPosition ?: 0L
+            val buf = player?.bufferedPosition ?: 0L
+            value = ((buf - pos).coerceAtLeast(0L)) / 1000
+            delay(1.seconds)
+        }
+    }
+
+    val transcodeInfo = currentPlayback.transcodeInfo
+    val mediaStreams = currentPlayback.mediaSourceInfo.mediaStreams
+    val videoStream = mediaStreams?.firstOrNull { it.type == MediaStreamType.VIDEO }
+    val audioStream = mediaStreams?.firstOrNull { it.type == MediaStreamType.AUDIO }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(6.dp))
+                .background(HudBackground)
+                .padding(10.dp),
+    ) {
+        // Engine
+        val engineLabel =
+            when (currentPlayback.backend) {
+                PlayerBackend.EXO_PLAYER -> "ExoPlayer"
+                PlayerBackend.MPV -> "MPV"
+                else -> currentPlayback.backend.toString()
+            }
+        HudText(engineLabel, HudCyan)
+
+        // Video info
+        val videoLine =
+            buildString {
+                if (transcodeInfo != null) {
+                    transcodeInfo.videoCodec?.uppercase()?.let(::append)
+                    appendResolution(transcodeInfo.width, transcodeInfo.height)
+                } else {
+                    videoStream?.let { stream ->
+                        stream.codec?.uppercase()?.let(::append)
+                        appendResolution(stream.width, stream.height)
+                        stream.bitDepth?.let { append(" ${it}-bit") }
+                        stream.videoRange?.let { append(" $it") }
+                    }
+                }
+            }
+        if (videoLine.isNotBlank()) {
+            HudText(videoLine, HudWhite)
+        }
+
+        // Audio info
+        val audioLine =
+            buildString {
+                if (transcodeInfo != null) {
+                    transcodeInfo.audioCodec?.uppercase()?.let(::append)
+                    transcodeInfo.audioChannels?.let { append(" ${it}ch") }
+                } else {
+                    audioStream?.let { stream ->
+                        stream.codec?.uppercase()?.let(::append)
+                        stream.channelLayout?.let { append(" $it") }
+                        stream.bitRate?.let { append(" @ ${formatBitrate(it)}") }
+                    }
+                }
+            }
+        if (audioLine.isNotBlank()) {
+            HudText(audioLine, HudDimWhite)
+        }
+
+        // Play method
+        val (playMethodLabel, playMethodColor) =
+            when (currentPlayback.playMethod) {
+                PlayMethod.DIRECT_PLAY -> "DIRECT PLAY" to HudGreen
+                PlayMethod.DIRECT_STREAM -> "DIRECT STREAM" to HudGreen
+                PlayMethod.TRANSCODE -> "TRANSCODE" to HudOrange
+                else -> currentPlayback.playMethod.serialName.uppercase() to HudWhite
+            }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            HudText(playMethodLabel, playMethodColor, FontWeight.Bold)
+            currentPlayback.mediaSourceInfo.container?.uppercase()?.let {
+                HudText(it, HudDimWhite)
+            }
+        }
+
+        // Transcode details
+        if (currentPlayback.playMethod == PlayMethod.TRANSCODE && transcodeInfo != null) {
+            val reasons = transcodeInfo.transcodeReasons
+            if (reasons.isNotEmpty()) {
+                HudText("Reason: ${reasons.joinToString(", ")}", HudOrange.copy(alpha = 0.9f))
+            }
+            val directParts =
+                buildList {
+                    transcodeInfo.isVideoDirect?.let { add("Video: ${if (it) "direct" else "transcode"}") }
+                    transcodeInfo.isAudioDirect?.let { add("Audio: ${if (it) "direct" else "transcode"}") }
+                }
+            if (directParts.isNotEmpty()) {
+                HudText(directParts.joinToString(" · "), HudDimWhite)
+            }
+        }
+
+        // Bitrate
+        transcodeInfo?.bitrate?.let {
+            HudText("Bitrate: ${formatBitrate(it)}", HudDimWhite)
+        }
+
+        // Decoders (ExoPlayer only)
+        if (currentPlayback.backend == PlayerBackend.EXO_PLAYER) {
+            val decoderLine =
+                buildList {
+                    currentPlayback.videoDecoder?.let { add("V: $it") }
+                    currentPlayback.audioDecoder?.let { add("A: $it") }
+                }
+            if (decoderLine.isNotEmpty()) {
+                HudText(decoderLine.joinToString(" · "), HudDimWhite)
+            }
+        }
+
+        // Buffer
+        if (bufferAheadSec > 0) {
+            HudText("Buffer: ${bufferAheadSec}s ahead", HudDimWhite)
+        }
+    }
+}
+
+private fun StringBuilder.appendResolution(
+    width: Int?,
+    height: Int?,
+) {
+    if (width != null && height != null) {
+        append(" ${width}x${height}")
+    }
+}
+
+@Composable
+private fun HudText(
+    text: String,
+    color: Color,
+    fontWeight: FontWeight = FontWeight.Medium,
+) {
+    Text(
+        text = text,
+        color = color,
+        fontSize = HudFontSize,
+        fontFamily = HudFont,
+        fontWeight = fontWeight,
+        lineHeight = HudFontSize * 1.3f,
+    )
+}

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -130,6 +130,8 @@
     <string name="select_server">Sunucu Seç</string>
     <string name="select_user">Kullanıcı Seç</string>
     <string name="show_debug_info">Hata ayıklama bilgisini göster</string>
+    <string name="show_stats">İstatistikleri göster</string>
+    <string name="hide_stats">İstatistikleri gizle</string>
     <string name="show_next_up_when">Sıradakini göster</string>
     <string name="show">Göster</string>
     <string name="shuffle">Karıştır</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,8 @@
     <string name="select_server">Select Server</string>
     <string name="select_user">Select User</string>
     <string name="show_debug_info">Show debug info</string>
+    <string name="show_stats">Show stats</string>
+    <string name="hide_stats">Hide stats</string>
     <string name="show_next_up_when">Show next up</string>
     <string name="show">Show</string>
     <string name="shuffle">Shuffle</string>


### PR DESCRIPTION
Added a stats overlay to the player. You can toggle it from the more menu, it's a separate option from the existing debug info. It shows the basics: which player engine is being used, video/audio codec details, whether it's direct playing or transcoding, decoder info, and how much buffer you have.

No new API calls or dependencies, it just uses the playback info that's already there.

Disclosure: AI-assisted (Claude). I reviewed and tested all changes.