### PR TITLE
Update rennovate settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,8 @@
       "groupName": "Jellyfin SDK",
       "matchPackageNames": [
         "org.jellyfin.sdk:**"
-      ]
+      ],
+      "enabled": false
     },
     {
       "groupName": "AGP",

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,13 @@
       "matchPackageNames": [
         "org.jetbrains.kotlin**"
       ]
+    },
+    {
+      "groupName": "Internal dependencies",
+      "matchPackageNames": [
+        "com.github.damontecres.wholphin**"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Description
Ignore dependencies from `wholphin-extensions` & the Jellyfin SDK. These dependencies should be updated manually.

### Related issues
N/A

### Testing
N/A

## Screenshots
N/A

## AI or LLM usage
None