### PR TITLE
Use wholphin-extensions v0.1.1

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,6 +49,8 @@ Wholphin uses several native components for extra playback compatibility. This i
 
 If you want to include these in a local build, see the [instructions here](https://github.com/damontecres/wholphin-extensions?tab=readme-ov-file#usage) for configuring the repository.
 
+You can also build the extensions locally from https://github.com/damontecres/wholphin-extensions and include them in `app/libs`. The gradle build dependency resolution prefers these local files over fetching from the remote maven registry.
+
 ### App settings
 
 App settings are available with the `AppPreferences` object and defined by different `AppPreference` objects (note the `s` differences).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ kotlinxCoroutinesTest = "1.10.2"
 coreTesting = "2.2.0"
 openapi-generator = "7.21.0"
 runner = "1.7.0"
-wholphin-extensions = "0.1.0"
+wholphin-extensions = "0.1.1"
 
 [libraries]
 wholphin-extensions-mpv = { module = "com.github.damontecres.wholphin.mpv:wholphin-mpv", version.ref = "wholphin-extensions" }


### PR DESCRIPTION
## Description
Updates to use the latest wholphin-extensions which includes https://github.com/damontecres/wholphin-extensions/pull/2

The crash in #1239 occurs if "AV1 software decoding" is enabled and seemingly only if the app was installed via APK, including app stores.

### Related issues
Fixes #1239

### Testing
Emulator, nvidia shield

## Screenshots
N/A

## AI or LLM usage
None