### PR TITLE
Add support for external player playback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -183,6 +183,10 @@ android {
             isIncludeAndroidResources = true
         }
     }
+
+    lint {
+        disable.add("MissingTranslation")
+    }
 }
 
 protobuf {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,10 @@
         <intent>
             <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="video/*" />
+        </intent>
     </queries>
 
     <application

--- a/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.preferences.AppPreference
 import com.github.damontecres.wholphin.preferences.AppPreferences
+import com.github.damontecres.wholphin.preferences.PlayerBackend
 import com.github.damontecres.wholphin.services.AppUpgradeHandler
 import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.DatePlayedInvalidationService
@@ -320,8 +321,7 @@ class MainActivity : AppCompatActivity() {
         outState.putString(KEY_BACK_STACK, str)
         val playerBackend =
             runBlocking { userPreferencesDataStore.data.firstOrNull() }?.playbackPreferences?.playerBackend
-        // TODO
-        outState.putBoolean(KEY_EXTERNAL_PLAYER, true)
+        outState.putBoolean(KEY_EXTERNAL_PLAYER, playerBackend == PlayerBackend.EXTERNAL_PLAYER)
     }
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {

--- a/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
@@ -70,6 +70,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
@@ -151,12 +152,15 @@ class MainActivity : AppCompatActivity() {
         if (backStackStr != null) {
             Timber.d("Restoring back stack")
             var backStack = json.decodeFromString<List<Destination>>(backStackStr)
-            val lastDest = backStack.lastOrNull()
-            if (lastDest is Destination.Playback ||
-                lastDest is Destination.PlaybackList ||
-                lastDest is Destination.Slideshow
-            ) {
-                backStack = backStack.toMutableList().apply { removeAt(lastIndex) }
+            if (!savedInstanceState.getBoolean(KEY_EXTERNAL_PLAYER)) {
+                val lastDest = backStack.lastOrNull()
+                if (lastDest is Destination.Playback ||
+                    lastDest is Destination.PlaybackList ||
+                    lastDest is Destination.Slideshow
+                ) {
+                    Timber.v("Restoring back stack with playback")
+                    backStack = backStack.toMutableList().apply { removeAt(lastIndex) }
+                }
             }
             navigationManager.backStack = NavBackStack(*backStack.toTypedArray())
         } else {
@@ -314,6 +318,10 @@ class MainActivity : AppCompatActivity() {
         Timber.d("onSaveInstanceState")
         val str = json.encodeToString(navigationManager.backStack.toList())
         outState.putString(KEY_BACK_STACK, str)
+        val playerBackend =
+            runBlocking { userPreferencesDataStore.data.firstOrNull() }?.playbackPreferences?.playerBackend
+        // TODO
+        outState.putBoolean(KEY_EXTERNAL_PLAYER, true)
     }
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
@@ -390,6 +398,7 @@ class MainActivity : AppCompatActivity() {
         const val INTENT_SEASON_ID = "seaId"
 
         private const val KEY_BACK_STACK = "backStack"
+        private const val KEY_EXTERNAL_PLAYER = "extPlayer"
 
         lateinit var instance: MainActivity
             private set

--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -828,6 +828,17 @@ sealed interface AppPreference<Pref, T> {
                 valueToIndex = { it.number },
             )
 
+        val ExternalPlayerApp =
+            AppStringPreference<AppPreferences>(
+                title = R.string.external_player,
+                defaultValue = "",
+                getter = { it.playbackPreferences.externalPlayer },
+                setter = { prefs, value ->
+                    prefs.updatePlaybackPreferences { externalPlayer = value }
+                },
+                summary = null,
+            )
+
         val ExoPlayerSettings =
             AppDestinationPreference<AppPreferences>(
                 title = R.string.exoplayer_options,
@@ -1196,6 +1207,10 @@ val advancedPreferences =
                                 AppPreference.ExoPlayerSettings,
                                 AppPreference.MpvSettings,
                             ),
+                        ),
+                        ConditionalPreferences(
+                            { it.playbackPreferences.playerBackend == PlayerBackend.EXTERNAL_PLAYER },
+                            listOf(AppPreference.ExternalPlayerApp),
                         ),
                     ),
             ),

--- a/app/src/main/java/com/github/damontecres/wholphin/services/PlaybackLifecycleObserver.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/PlaybackLifecycleObserver.kt
@@ -2,7 +2,6 @@ package com.github.damontecres.wholphin.services
 
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.github.damontecres.wholphin.ui.nav.Destination
 import dagger.hilt.android.scopes.ActivityRetainedScoped
 import javax.inject.Inject
 
@@ -20,13 +19,14 @@ class PlaybackLifecycleObserver
         private var wasPlaying: Boolean? = null
 
         override fun onStart(owner: LifecycleOwner) {
-            val lastDest = navigationManager.backStack.lastOrNull()
-            if (lastDest is Destination.Playback ||
-                lastDest is Destination.PlaybackList ||
-                lastDest is Destination.Slideshow
-            ) {
-                navigationManager.goBack()
-            }
+            // TODO
+//            val lastDest = navigationManager.backStack.lastOrNull()
+//            if (lastDest is Destination.Playback ||
+//                lastDest is Destination.PlaybackList ||
+//                lastDest is Destination.Slideshow
+//            ) {
+//                navigationManager.goBack()
+//            }
             wasPlaying = null
         }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/services/PlayerFactory.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/PlayerFactory.kt
@@ -95,6 +95,10 @@ class PlayerFactory
                                 playWhenReady = true
                             }
                     }
+
+                    PlayerBackend.EXTERNAL_PLAYER -> {
+                        throw IllegalStateException("Cannot create a player for external playback")
+                    }
                 }
             currentPlayer = newPlayer
             return newPlayer
@@ -141,6 +145,10 @@ class PlayerFactory
                                     .setEnableDecoderFallback(true)
                                     .setExtensionRendererMode(rendererMode),
                             ).build()
+                    }
+
+                    PlayerBackend.EXTERNAL_PLAYER -> {
+                        throw IllegalStateException("Cannot create a player for external playback")
                     }
                 }
             currentPlayer = newPlayer

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
@@ -40,7 +40,7 @@ import com.github.damontecres.wholphin.ui.discover.DiscoverRequestGrid
 import com.github.damontecres.wholphin.ui.main.HomePage
 import com.github.damontecres.wholphin.ui.main.SearchPage
 import com.github.damontecres.wholphin.ui.main.settings.HomeSettingsPage
-import com.github.damontecres.wholphin.ui.playback.PlaybackPage
+import com.github.damontecres.wholphin.ui.playback.PlayExternalPage
 import com.github.damontecres.wholphin.ui.preferences.PreferencesPage
 import com.github.damontecres.wholphin.ui.preferences.subtitle.SubtitleStylePage
 import com.github.damontecres.wholphin.ui.setup.InstallUpdatePage
@@ -77,7 +77,13 @@ fun DestinationContent(
         is Destination.PlaybackList,
         is Destination.Playback,
         -> {
-            PlaybackPage(
+            // TODO if external
+//            PlaybackPage(
+//                preferences = preferences,
+//                destination = destination,
+//                modifier = modifier,
+//            )
+            PlayExternalPage(
                 preferences = preferences,
                 destination = destination,
                 modifier = modifier,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
@@ -8,6 +8,7 @@ import androidx.tv.material3.Text
 import com.github.damontecres.wholphin.data.filter.DefaultForGenresFilterOptions
 import com.github.damontecres.wholphin.data.filter.DefaultForStudiosFilterOptions
 import com.github.damontecres.wholphin.data.model.SeerrItemType
+import com.github.damontecres.wholphin.preferences.PlayerBackend
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.ItemGrid
 import com.github.damontecres.wholphin.ui.components.LicenseInfo
@@ -41,6 +42,7 @@ import com.github.damontecres.wholphin.ui.main.HomePage
 import com.github.damontecres.wholphin.ui.main.SearchPage
 import com.github.damontecres.wholphin.ui.main.settings.HomeSettingsPage
 import com.github.damontecres.wholphin.ui.playback.PlayExternalPage
+import com.github.damontecres.wholphin.ui.playback.PlaybackPage
 import com.github.damontecres.wholphin.ui.preferences.PreferencesPage
 import com.github.damontecres.wholphin.ui.preferences.subtitle.SubtitleStylePage
 import com.github.damontecres.wholphin.ui.setup.InstallUpdatePage
@@ -77,17 +79,19 @@ fun DestinationContent(
         is Destination.PlaybackList,
         is Destination.Playback,
         -> {
-            // TODO if external
-//            PlaybackPage(
-//                preferences = preferences,
-//                destination = destination,
-//                modifier = modifier,
-//            )
-            PlayExternalPage(
-                preferences = preferences,
-                destination = destination,
-                modifier = modifier,
-            )
+            if (preferences.appPreferences.playbackPreferences.playerBackend == PlayerBackend.EXTERNAL_PLAYER) {
+                PlayExternalPage(
+                    preferences = preferences,
+                    destination = destination,
+                    modifier = modifier,
+                )
+            } else {
+                PlaybackPage(
+                    preferences = preferences,
+                    destination = destination,
+                    modifier = modifier,
+                )
+            }
         }
 
         is Destination.Settings -> {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
@@ -45,6 +45,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import org.jellyfin.sdk.api.client.ApiClient
@@ -270,71 +271,79 @@ class PlayExternalViewModel
         fun onResult(result: ActivityResult) {
             viewModelScope.launchDefault {
                 val itemId = savedStateHandle.get<UUID?>(KEY_ID)
-                val mediaSourceId = savedStateHandle.get<String?>(KEY_MEDIA_ID)
-                if (itemId == null) {
-                    Timber.w("itemId is null")
-                    return@launchDefault
-                }
-                Timber.v(
-                    "Result: result=%s, itemId=%s action=%s",
-                    result.resultCode,
-                    itemId,
-                    result.data?.action,
-                )
-                if (result.resultCode == Activity.RESULT_OK || result.resultCode == Activity.RESULT_CANCELED ||
-                    // Vimu return 1 for video completion
-                    (result.data?.action == "net.gtvbox.videoplayer.result" && result.resultCode == 1)
-                ) {
-                    val position: Long?
-                    val data = result.data
-                    when (data?.action) {
-                        // VLC: https://wiki.videolan.org/Android_Player_Intents/
-                        "org.videolan.vlc.player.result" -> {
-                            position =
-                                data
-                                    .getLongExtra("extra_position", Long.MIN_VALUE)
-                                    .takeIf { it >= 0 }
-                        }
-
-                        // mpv-android: https://mpv-android.github.io/mpv-android/intent.html
-                        "is.xyz.mpv.MPVActivity.result",
-                        // MX player: https://mx.j2inter.com/api
-                        "com.mxtech.intent.result.VIEW",
-                        // VIMU: https://vimu.tv/player-api/
-                        "net.gtvbox.videoplayer.result",
-                        -> {
-                            position =
-                                data
-                                    .getIntExtra("position", Int.MIN_VALUE)
-                                    .toLong()
-                                    .takeIf { it >= 0 }
-                        }
-
-                        else -> {
-                            // Unsupported app
-                            val posInt =
-                                data
-                                    ?.getIntExtra("position", Int.MIN_VALUE)
-                                    ?.takeIf { it >= 0 }
-                                    ?.toLong()
-                            position =
-                                posInt ?: data?.getLongExtra("position", -1L)?.takeIf { it >= 0 }
-                        }
+                try {
+                    val mediaSourceId = savedStateHandle.get<String?>(KEY_MEDIA_ID)
+                    if (itemId == null) {
+                        Timber.w("itemId is null")
+                        return@launchDefault
                     }
-                    Timber.v("Result position: %s", position?.milliseconds)
-                    api.playStateApi.reportPlaybackStopped(
-                        PlaybackStopInfo(
-                            itemId = itemId,
-                            mediaSourceId = mediaSourceId,
-                            positionTicks = position?.milliseconds?.inWholeTicks,
-                            failed = false,
-                        ),
+                    Timber.v(
+                        "Result: result=%s, itemId=%s action=%s",
+                        result.resultCode,
+                        itemId,
+                        result.data?.action,
                     )
-                } else {
-                    Timber.w("Activity result: %s", result.resultCode)
-                    showToast(context, "Unknown result from external player")
+                    if (result.resultCode == Activity.RESULT_OK || result.resultCode == Activity.RESULT_CANCELED ||
+                        // Vimu return 1 for video completion
+                        (result.data?.action == "net.gtvbox.videoplayer.result" && result.resultCode == 1)
+                    ) {
+                        val position: Long?
+                        val data = result.data
+                        when (data?.action) {
+                            // VLC: https://wiki.videolan.org/Android_Player_Intents/
+                            "org.videolan.vlc.player.result" -> {
+                                position =
+                                    data
+                                        .getLongExtra("extra_position", Long.MIN_VALUE)
+                                        .takeIf { it >= 0 }
+                            }
+
+                            // mpv-android: https://mpv-android.github.io/mpv-android/intent.html
+                            "is.xyz.mpv.MPVActivity.result",
+                            // MX player: https://mx.j2inter.com/api
+                            "com.mxtech.intent.result.VIEW",
+                            // VIMU: https://vimu.tv/player-api/
+                            "net.gtvbox.videoplayer.result",
+                            -> {
+                                position =
+                                    data
+                                        .getIntExtra("position", Int.MIN_VALUE)
+                                        .toLong()
+                                        .takeIf { it >= 0 }
+                            }
+
+                            else -> {
+                                // Unsupported app
+                                val posInt =
+                                    data
+                                        ?.getIntExtra("position", Int.MIN_VALUE)
+                                        ?.takeIf { it >= 0 }
+                                        ?.toLong()
+                                position =
+                                    posInt ?: data
+                                        ?.getLongExtra("position", -1L)
+                                        ?.takeIf { it >= 0 }
+                            }
+                        }
+                        Timber.v("Result position: %s", position?.milliseconds)
+                        api.playStateApi.reportPlaybackStopped(
+                            PlaybackStopInfo(
+                                itemId = itemId,
+                                mediaSourceId = mediaSourceId,
+                                positionTicks = position?.milliseconds?.inWholeTicks,
+                                failed = false,
+                            ),
+                        )
+                    } else {
+                        Timber.w("Activity result: %s", result.resultCode)
+                        showToast(context, "Unknown result from external player")
+                    }
+                    navigationManager.goBack()
+                } catch (_: CancellationException) {
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Error during external playback of %s", itemId)
+                    state.update { it.copy(loading = LoadingState.Error(ex)) }
                 }
-                navigationManager.goBack()
             }
         }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
@@ -9,6 +9,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -80,11 +81,9 @@ class PlayExternalViewModel
             fun create(destination: Destination): PlayExternalViewModel
         }
 
-        private lateinit var item: BaseItem
-
         val state = MutableStateFlow(PlayExternalState())
 
-        init {
+        fun init() {
             viewModelScope.launchDefault {
                 val prefs = userPreferencesService.getCurrent()
                 val positionMs: Long
@@ -143,8 +142,7 @@ class PlayExternalViewModel
                         } else {
                             throw IllegalArgumentException("Item is not playable and not PlaybackList: ${queriedItem.type}")
                         }
-                    savedStateHandle["itemId"] = base.id
-                    this@PlayExternalViewModel.item = BaseItem(base, false)
+                    val item = BaseItem(base, false)
                     val playbackConfig =
                         serverRepository.currentUser.value?.let { user ->
                             itemPlaybackDao.getItem(user, base.id)?.let {
@@ -162,6 +160,8 @@ class PlayExternalViewModel
                         Timber.w("Media source is null")
                         return@launchDefault
                     }
+                    savedStateHandle[KEY_ID] = base.id
+                    savedStateHandle[KEY_MEDIA_ID] = mediaSource.id
                     val subtitleIndex =
                         streamChoiceService
                             .chooseSubtitleStream(
@@ -210,9 +210,9 @@ class PlayExternalViewModel
                     val intent =
                         Intent(Intent.ACTION_VIEW).apply {
                             setComponent(component)
-                            setDataAndType(uri, "video/*")
+                            setDataAndTypeAndNormalize(uri, "video/*")
                             putExtra("title", "${item.title} ${item.subtitleLong}")
-                            putExtra("position", positionMs)
+                            putExtra("position", positionMs.toInt())
 
                             // MX/mpv
                             putExtra("return_result", true)
@@ -258,26 +258,40 @@ class PlayExternalViewModel
 
         fun onResult(result: ActivityResult) {
             viewModelScope.launchDefault {
-                val itemId = savedStateHandle.get<UUID?>("itemId")
-                Timber.v("Result: itemId=%s action=%s", itemId, result.data?.action)
-                if (result.resultCode == Activity.RESULT_OK) {
-                    Timber.i("Activity result OK")
-                    val position: Long
+                val itemId = savedStateHandle.get<UUID?>(KEY_ID)
+                val mediaSourceId = savedStateHandle.get<String?>(KEY_MEDIA_ID)
+                if (itemId == null) {
+                    Timber.w("itemId is null")
+                    return@launchDefault
+                }
+                Timber.v(
+                    "Result: result=%s, itemId=%s action=%s",
+                    result.resultCode,
+                    itemId,
+                    result.data?.action,
+                )
+                if (result.resultCode == Activity.RESULT_OK || result.resultCode == Activity.RESULT_CANCELED) {
+                    val position: Long?
                     val data = result.data
                     when (data?.action) {
+                        // VLC: https://wiki.videolan.org/Android_Player_Intents/
                         "org.videolan.vlc.player.result" -> {
-                            // VLC: https://wiki.videolan.org/Android_Player_Intents/
-                            position = data.getLongExtra("extra_position", -1)
+                            position =
+                                data
+                                    .getLongExtra("extra_position", Long.MIN_VALUE)
+                                    .takeIf { it >= 0 }
                         }
 
-                        "is.xyz.mpv.MPVActivity.result" -> {
-                            // mpv-android: https://mpv-android.github.io/mpv-android/intent.html
-                            position = data.getIntExtra("position", -2).toLong()
-                        }
-
-                        "com.mxtech.intent.result.VIEW" -> {
-                            // MX player: https://mx.j2inter.com/api
-                            position = data.getIntExtra("position", -2).toLong()
+                        // mpv-android: https://mpv-android.github.io/mpv-android/intent.html
+                        "is.xyz.mpv.MPVActivity.result",
+                        // MX player: https://mx.j2inter.com/api
+                        "com.mxtech.intent.result.VIEW",
+                        -> {
+                            position =
+                                data
+                                    .getIntExtra("position", Int.MIN_VALUE)
+                                    .toLong()
+                                    .takeIf { it >= 0 }
                         }
 
                         else -> {
@@ -285,25 +299,21 @@ class PlayExternalViewModel
                             val posInt =
                                 data
                                     ?.getIntExtra("position", Int.MIN_VALUE)
-                                    ?.takeIf { it != Int.MIN_VALUE }
+                                    ?.takeIf { it >= 0 }
                                     ?.toLong()
                             position =
-                                posInt ?: (data?.getLongExtra("position", -1L) ?: -1L)
+                                posInt ?: data?.getLongExtra("position", -1L)?.takeIf { it >= 0 }
                         }
                     }
-                    Timber.v("Result position: %s", position.milliseconds)
-                    if (position == -2L) {
-                        // TODO, check if watched
-                    } else if (position >= 0 && itemId != null) {
-                        api.playStateApi.reportPlaybackStopped(
-                            PlaybackStopInfo(
-                                itemId = itemId,
-                                mediaSourceId = null, // TODO
-                                positionTicks = position.milliseconds.inWholeTicks,
-                                failed = false,
-                            ),
-                        )
-                    }
+                    Timber.v("Result position: %s", position?.milliseconds)
+                    api.playStateApi.reportPlaybackStopped(
+                        PlaybackStopInfo(
+                            itemId = itemId,
+                            mediaSourceId = mediaSourceId,
+                            positionTicks = position?.milliseconds?.inWholeTicks,
+                            failed = false,
+                        ),
+                    )
                 } else {
                     Timber.w("Activity result: %s", result.resultCode)
                     showToast(context, "Unknown result from external player")
@@ -315,6 +325,11 @@ class PlayExternalViewModel
         fun reportException(ex: Exception) {
             Timber.e(ex, "Error launching activity")
             state.update { it.copy(loading = LoadingState.Error(ex)) }
+        }
+
+        companion object {
+            private const val KEY_ID = "itemId"
+            private const val KEY_MEDIA_ID = "mediaId"
         }
     }
 
@@ -341,6 +356,11 @@ fun PlayExternalPage(
 
     val state by viewModel.state.collectAsState()
     var launched by rememberSaveable { mutableStateOf(false) }
+    if (!launched) {
+        LaunchedEffect(Unit) {
+            viewModel.init()
+        }
+    }
 
     when (val l = state.loading) {
         LoadingState.Pending,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
@@ -1,29 +1,36 @@
 package com.github.damontecres.wholphin.ui.playback
 
 import android.app.Activity
-import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
-import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.viewModelScope
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.PlaylistCreationResult
 import com.github.damontecres.wholphin.services.PlaylistCreator
+import com.github.damontecres.wholphin.ui.components.ErrorMessage
+import com.github.damontecres.wholphin.ui.components.LoadingPage
+import com.github.damontecres.wholphin.ui.findActivity
 import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.showToast
 import com.github.damontecres.wholphin.util.LoadingState
 import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -34,7 +41,7 @@ import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
 import timber.log.Timber
 
-@HiltViewModel
+@HiltViewModel(assistedFactory = PlayExternalViewModel.Factory::class)
 class PlayExternalViewModel
     @AssistedInject
     constructor(
@@ -44,9 +51,14 @@ class PlayExternalViewModel
         private val navigationManager: NavigationManager,
         @Assisted val destination: Destination,
     ) : ViewModel() {
+        @AssistedFactory
+        interface Factory {
+            fun create(destination: Destination): PlayExternalViewModel
+        }
+
         private lateinit var item: BaseItem
 
-        val loading = MutableStateFlow<LoadingState>(LoadingState.Loading)
+        val state = MutableStateFlow(PlayExternalState())
 
         init {
             viewModelScope.launchDefault {
@@ -84,7 +96,11 @@ class PlayExternalViewModel
                                 )
                             when (val r = playlistResult) {
                                 is PlaylistCreationResult.Error -> {
-                                    loading.update { LoadingState.Error(r.message, r.ex) }
+                                    state.update {
+                                        it.copy(
+                                            loading = LoadingState.Error(r.message, r.ex),
+                                        )
+                                    }
                                     return@launchDefault
                                 }
 
@@ -103,30 +119,21 @@ class PlayExternalViewModel
                             throw IllegalArgumentException("Item is not playable and not PlaybackList: ${queriedItem.type}")
                         }
                     this@PlayExternalViewModel.item = BaseItem(base, false)
-                    loading.update { LoadingState.Success }
-                } catch (ex: Exception) {
-                    Timber.e(ex, "Error for destination %s", destination)
-                    loading.update { LoadingState.Error(ex) }
-                }
-            }
-        }
+                    val uri =
+                        api.videosApi
+                            .getVideoStreamUrl(
+                                itemId = item.id,
+                                mediaSourceId = null, // TODO
+                                static = true,
+                            ).toUri()
+                    val intent =
+                        Intent(Intent.ACTION_VIEW).apply {
+                            setDataAndType(uri, "video/*")
+                            putExtra("title", "${item.title} ${item.subtitleLong}")
 
-        fun launch(activity: Activity) {
-            val uri =
-                api.videosApi
-                    .getVideoStreamUrl(
-                        itemId = item.id,
-                        mediaSourceId = null, // TODO
-                        static = true,
-                    ).toUri()
-
-            val intent =
-                Intent(Intent.ACTION_VIEW).apply {
-                    setDataAndType(uri, "video/*")
-                    putExtra("title", "${item.title} ${item.subtitleLong}")
-
-                    // VLC intents: https://wiki.videolan.org/Android_Player_Intents/
-                    // mxplayer intents: https://mx.j2inter.com/api
+                            // VLC intents: https://wiki.videolan.org/Android_Player_Intents/
+                            // mxplayer intents: https://mx.j2inter.com/api
+                            // mpv-android intents: https://mpv-android.github.io/mpv-android/intent.html
 //                    if (externalSubtitles) {
 //                        // VLC
 //                        // TODO doesn't work?
@@ -137,34 +144,84 @@ class PlayExternalViewModel
 //                        putExtra("subs", subs)
 //                        putExtra("subs.name", subNames)
 //                    }
-                    // VLC
-                    // TODO
-                    // putExtra("extra_duration", duration)
+                            // VLC
+                            // TODO
+                            // putExtra("extra_duration", duration)
 
-                    // TODO starting position?
+                            // TODO starting position?
+                        }
+
+                    state.update {
+                        PlayExternalState(
+                            loading = LoadingState.Success,
+                            intent = intent,
+                        )
+                    }
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Error for destination %s", destination)
+                    state.update {
+                        it.copy(loading = LoadingState.Error(ex))
+                    }
                 }
-            try {
-                (activity as ComponentActivity).registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-                }
-                activity.startActivity(intent)
-                activity.startActivityForResult(intent, 0)
-            } catch (_: ActivityNotFoundException) {
-                Toast
-                    .makeText(
-                        activity,
-                        "No external player found!",
-                        Toast.LENGTH_SHORT,
-                    ).show()
             }
         }
     }
+
+data class PlayExternalState(
+    val loading: LoadingState = LoadingState.Loading,
+    val intent: Intent = Intent(),
+)
 
 @Composable
 fun PlayExternalPage(
     preferences: UserPreferences,
     destination: Destination,
     modifier: Modifier = Modifier,
-    viewModel: PlayExternalViewModel = hiltViewModel(),
+    viewModel: PlayExternalViewModel =
+        hiltViewModel<PlayExternalViewModel, PlayExternalViewModel.Factory>(
+            creationCallback = { it.create(destination) },
+        ),
 ) {
     val context = LocalContext.current
+    val activity = remember(context) { context.findActivity() }
+
+    val state by viewModel.state.collectAsState()
+
+    if (activity != null) {
+        when (val l = state.loading) {
+            LoadingState.Pending,
+            LoadingState.Loading,
+            -> {
+                LoadingPage(modifier)
+            }
+
+            is LoadingState.Error -> {
+                ErrorMessage(l, modifier)
+            }
+
+            LoadingState.Success -> {
+                LoadingPage(modifier)
+                val launcher =
+                    rememberLauncherForActivityResult(
+                        contract = ActivityResultContracts.StartActivityForResult(),
+                    ) { result ->
+                        if (result.resultCode == Activity.RESULT_OK) {
+                            Timber.i("Activity result OK")
+                        } else {
+                            Timber.w("Activity result: %s", result.resultCode)
+                        }
+                    }
+                LifecycleStartEffect(Unit) {
+                    launcher.launch(state.intent)
+                    onStopOrDispose { }
+                }
+            }
+        }
+    } else {
+        ErrorMessage(
+            message = "Unknown error",
+            exception = null,
+            modifier = modifier,
+        )
+    }
 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
@@ -1,0 +1,170 @@
+package com.github.damontecres.wholphin.ui.playback
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.net.toUri
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.damontecres.wholphin.data.model.BaseItem
+import com.github.damontecres.wholphin.preferences.UserPreferences
+import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.PlaylistCreationResult
+import com.github.damontecres.wholphin.services.PlaylistCreator
+import com.github.damontecres.wholphin.ui.launchDefault
+import com.github.damontecres.wholphin.ui.nav.Destination
+import com.github.damontecres.wholphin.ui.showToast
+import com.github.damontecres.wholphin.util.LoadingState
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.userLibraryApi
+import org.jellyfin.sdk.api.client.extensions.videosApi
+import timber.log.Timber
+
+@HiltViewModel
+class PlayExternalViewModel
+    @AssistedInject
+    constructor(
+        @param:ApplicationContext private val context: Context,
+        private val api: ApiClient,
+        private val playlistCreator: PlaylistCreator,
+        private val navigationManager: NavigationManager,
+        @Assisted val destination: Destination,
+    ) : ViewModel() {
+        private lateinit var item: BaseItem
+
+        val loading = MutableStateFlow<LoadingState>(LoadingState.Loading)
+
+        init {
+            viewModelScope.launchDefault {
+                val positionMs: Long
+                val itemId =
+                    when (val d = destination) {
+                        is Destination.Playback -> {
+                            positionMs = d.positionMs
+                            d.itemId
+                        }
+
+                        is Destination.PlaybackList -> {
+                            positionMs = 0
+                            d.itemId
+                        }
+
+                        else -> {
+                            throw IllegalArgumentException("Destination not supported: $destination")
+                        }
+                    }
+                try {
+                    val queriedItem = api.userLibraryApi.getItem(itemId).content
+                    val base =
+                        if (queriedItem.type.playable) {
+                            queriedItem
+                        } else if (destination is Destination.PlaybackList) {
+                            val playlistResult =
+                                playlistCreator.createFrom(
+                                    item = queriedItem,
+                                    startIndex = destination.startIndex ?: 0,
+                                    sortAndDirection = destination.sortAndDirection,
+                                    shuffled = destination.shuffle,
+                                    recursive = destination.recursive,
+                                    filter = destination.filter,
+                                )
+                            when (val r = playlistResult) {
+                                is PlaylistCreationResult.Error -> {
+                                    loading.update { LoadingState.Error(r.message, r.ex) }
+                                    return@launchDefault
+                                }
+
+                                is PlaylistCreationResult.Success -> {
+                                    if (r.playlist.items.isEmpty()) {
+                                        showToast(context, "Playlist is empty", Toast.LENGTH_SHORT)
+                                        navigationManager.goBack()
+                                        return@launchDefault
+                                    }
+                                    r.playlist.items
+                                        .first()
+                                        .data
+                                }
+                            }
+                        } else {
+                            throw IllegalArgumentException("Item is not playable and not PlaybackList: ${queriedItem.type}")
+                        }
+                    this@PlayExternalViewModel.item = BaseItem(base, false)
+                    loading.update { LoadingState.Success }
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Error for destination %s", destination)
+                    loading.update { LoadingState.Error(ex) }
+                }
+            }
+        }
+
+        fun launch(activity: Activity) {
+            val uri =
+                api.videosApi
+                    .getVideoStreamUrl(
+                        itemId = item.id,
+                        mediaSourceId = null, // TODO
+                        static = true,
+                    ).toUri()
+
+            val intent =
+                Intent(Intent.ACTION_VIEW).apply {
+                    setDataAndType(uri, "video/*")
+                    putExtra("title", "${item.title} ${item.subtitleLong}")
+
+                    // VLC intents: https://wiki.videolan.org/Android_Player_Intents/
+                    // mxplayer intents: https://mx.j2inter.com/api
+//                    if (externalSubtitles) {
+//                        // VLC
+//                        // TODO doesn't work?
+//                        putExtra("subtitles_location", subUrl)
+//
+//                        // MX
+//                        // TODO arrays of strings
+//                        putExtra("subs", subs)
+//                        putExtra("subs.name", subNames)
+//                    }
+                    // VLC
+                    // TODO
+                    // putExtra("extra_duration", duration)
+
+                    // TODO starting position?
+                }
+            try {
+                (activity as ComponentActivity).registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+                }
+                activity.startActivity(intent)
+                activity.startActivityForResult(intent, 0)
+            } catch (_: ActivityNotFoundException) {
+                Toast
+                    .makeText(
+                        activity,
+                        "No external player found!",
+                        Toast.LENGTH_SHORT,
+                    ).show()
+            }
+        }
+    }
+
+@Composable
+fun PlayExternalPage(
+    preferences: UserPreferences,
+    destination: Destination,
+    modifier: Modifier = Modifier,
+    viewModel: PlayExternalViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
@@ -1,6 +1,7 @@
 package com.github.damontecres.wholphin.ui.playback
 
 import android.app.Activity
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
@@ -25,10 +26,13 @@ import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.PlaylistCreationResult
 import com.github.damontecres.wholphin.services.PlaylistCreator
+import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.ui.components.ErrorMessage
 import com.github.damontecres.wholphin.ui.components.LoadingPage
+import com.github.damontecres.wholphin.ui.isNotNullOrBlank
 import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.nav.Destination
+import com.github.damontecres.wholphin.ui.preferences.getExternalPlayers
 import com.github.damontecres.wholphin.ui.showToast
 import com.github.damontecres.wholphin.util.LoadingState
 import dagger.assisted.Assisted
@@ -57,6 +61,7 @@ class PlayExternalViewModel
         private val api: ApiClient,
         private val playlistCreator: PlaylistCreator,
         private val navigationManager: NavigationManager,
+        private val userPreferencesService: UserPreferencesService,
         @Assisted val destination: Destination,
     ) : ViewModel() {
         @AssistedFactory
@@ -135,8 +140,23 @@ class PlayExternalViewModel
                                 mediaSourceId = null, // TODO
                                 static = true,
                             ).toUri()
+                    val playerId =
+                        userPreferencesService
+                            .getCurrent()
+                            .appPreferences.playbackPreferences.externalPlayer
+                    // Make sure player is available, user could have uninstalled it
+                    val foundPlayer =
+                        getExternalPlayers(context).firstOrNull { it.identifier == playerId } != null
+                    val component =
+                        if (playerId.isNotNullOrBlank() && foundPlayer) {
+                            ComponentName.unflattenFromString(playerId)
+                        } else {
+                            null
+                        }
+                    Timber.v("playerId=%s, component=%s", playerId, component)
                     val intent =
                         Intent(Intent.ACTION_VIEW).apply {
+                            setComponent(component)
                             setDataAndType(uri, "video/*")
                             putExtra("title", "${item.title} ${item.subtitleLong}")
 
@@ -230,6 +250,11 @@ class PlayExternalViewModel
                 navigationManager.goBack()
             }
         }
+
+        fun reportException(ex: Exception) {
+            Timber.e(ex, "Error launching activity")
+            state.update { it.copy(loading = LoadingState.Error(ex)) }
+        }
     }
 
 data class PlayExternalState(
@@ -273,7 +298,11 @@ fun PlayExternalPage(
                 LifecycleStartEffect(Unit) {
                     Timber.i("Launching external playback")
                     launched = true
-                    launcher.launch(state.intent)
+                    try {
+                        launcher.launch(state.intent)
+                    } catch (ex: Exception) {
+                        viewModel.reportException(ex)
+                    }
                     onStopOrDispose { }
                 }
             }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
@@ -11,11 +11,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
@@ -29,7 +27,6 @@ import com.github.damontecres.wholphin.services.PlaylistCreationResult
 import com.github.damontecres.wholphin.services.PlaylistCreator
 import com.github.damontecres.wholphin.ui.components.ErrorMessage
 import com.github.damontecres.wholphin.ui.components.LoadingPage
-import com.github.damontecres.wholphin.ui.findActivity
 import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.showToast
@@ -45,6 +42,7 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.playStateApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
+import org.jellyfin.sdk.model.api.PlaybackStopInfo
 import org.jellyfin.sdk.model.extensions.inWholeTicks
 import timber.log.Timber
 import java.util.UUID
@@ -180,7 +178,7 @@ class PlayExternalViewModel
         fun onResult(result: ActivityResult) {
             viewModelScope.launchDefault {
                 val itemId = savedStateHandle.get<UUID?>("itemId")
-                Timber.v("Result action: %s", result.data?.action)
+                Timber.v("Result: itemId=%s action=%s", itemId, result.data?.action)
                 if (result.resultCode == Activity.RESULT_OK) {
                     Timber.i("Activity result OK")
                     val position: Long
@@ -203,21 +201,31 @@ class PlayExternalViewModel
 
                         else -> {
                             // Unsupported app
-                            position = -1L
+                            val posInt =
+                                data
+                                    ?.getIntExtra("position", Int.MIN_VALUE)
+                                    ?.takeIf { it != Int.MIN_VALUE }
+                                    ?.toLong()
+                            position =
+                                posInt ?: (data?.getLongExtra("position", -1L) ?: -1L)
                         }
                     }
                     Timber.v("Result position: %s", position.milliseconds)
                     if (position == -2L) {
                         // TODO, check if watched
                     } else if (position >= 0 && itemId != null) {
-                        api.playStateApi.onPlaybackProgress(
-                            itemId = itemId,
-                            mediaSourceId = null, // TODO
-                            positionTicks = position.milliseconds.inWholeTicks,
+                        api.playStateApi.reportPlaybackStopped(
+                            PlaybackStopInfo(
+                                itemId = itemId,
+                                mediaSourceId = null, // TODO
+                                positionTicks = position.milliseconds.inWholeTicks,
+                                failed = false,
+                            ),
                         )
                     }
                 } else {
                     Timber.w("Activity result: %s", result.resultCode)
+                    showToast(context, "Unknown result from external player")
                 }
                 navigationManager.goBack()
             }
@@ -239,8 +247,6 @@ fun PlayExternalPage(
             creationCallback = { it.create(destination) },
         ),
 ) {
-    val context = LocalContext.current
-    val activity = remember(context) { context.findActivity() }
     val launcher =
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.StartActivityForResult(),
@@ -250,35 +256,27 @@ fun PlayExternalPage(
     val state by viewModel.state.collectAsState()
     var launched by rememberSaveable { mutableStateOf(false) }
 
-    if (activity != null) {
-        when (val l = state.loading) {
-            LoadingState.Pending,
-            LoadingState.Loading,
-            -> {
-                LoadingPage(modifier)
-            }
+    when (val l = state.loading) {
+        LoadingState.Pending,
+        LoadingState.Loading,
+        -> {
+            LoadingPage(modifier)
+        }
 
-            is LoadingState.Error -> {
-                ErrorMessage(l, modifier)
-            }
+        is LoadingState.Error -> {
+            ErrorMessage(l, modifier)
+        }
 
-            LoadingState.Success -> {
-                LoadingPage(modifier)
-                if (!launched) {
-                    LifecycleStartEffect(Unit) {
-                        Timber.i("Launching external playback")
-                        launched = true
-                        launcher.launch(state.intent)
-                        onStopOrDispose { }
-                    }
+        LoadingState.Success -> {
+            LoadingPage(modifier)
+            if (!launched) {
+                LifecycleStartEffect(Unit) {
+                    Timber.i("Launching external playback")
+                    launched = true
+                    launcher.launch(state.intent)
+                    onStopOrDispose { }
                 }
             }
         }
-    } else {
-        ErrorMessage(
-            message = "Unknown error",
-            exception = null,
-            modifier = modifier,
-        )
     }
 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
@@ -5,15 +5,20 @@ import android.content.Context
 import android.content.Intent
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.viewModelScope
@@ -37,14 +42,19 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.playStateApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
+import org.jellyfin.sdk.model.extensions.inWholeTicks
 import timber.log.Timber
+import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
 
 @HiltViewModel(assistedFactory = PlayExternalViewModel.Factory::class)
 class PlayExternalViewModel
     @AssistedInject
     constructor(
+        private val savedStateHandle: SavedStateHandle,
         @param:ApplicationContext private val context: Context,
         private val api: ApiClient,
         private val playlistCreator: PlaylistCreator,
@@ -118,6 +128,7 @@ class PlayExternalViewModel
                         } else {
                             throw IllegalArgumentException("Item is not playable and not PlaybackList: ${queriedItem.type}")
                         }
+                    savedStateHandle["itemId"] = base.id
                     this@PlayExternalViewModel.item = BaseItem(base, false)
                     val uri =
                         api.videosApi
@@ -165,6 +176,52 @@ class PlayExternalViewModel
                 }
             }
         }
+
+        fun onResult(result: ActivityResult) {
+            viewModelScope.launchDefault {
+                val itemId = savedStateHandle.get<UUID?>("itemId")
+                Timber.v("Result action: %s", result.data?.action)
+                if (result.resultCode == Activity.RESULT_OK) {
+                    Timber.i("Activity result OK")
+                    val position: Long
+                    val data = result.data
+                    when (data?.action) {
+                        "org.videolan.vlc.player.result" -> {
+                            // VLC: https://wiki.videolan.org/Android_Player_Intents/
+                            position = data.getLongExtra("extra_position", -1)
+                        }
+
+                        "is.xyz.mpv.MPVActivity.result" -> {
+                            // mpv-android: https://mpv-android.github.io/mpv-android/intent.html
+                            position = data.getIntExtra("position", -2).toLong()
+                        }
+
+                        "com.mxtech.intent.result.VIEW" -> {
+                            // MX player: https://mx.j2inter.com/api
+                            position = data.getIntExtra("position", -2).toLong()
+                        }
+
+                        else -> {
+                            // Unsupported app
+                            position = -1L
+                        }
+                    }
+                    Timber.v("Result position: %s", position.milliseconds)
+                    if (position == -2L) {
+                        // TODO, check if watched
+                    } else if (position >= 0 && itemId != null) {
+                        api.playStateApi.onPlaybackProgress(
+                            itemId = itemId,
+                            mediaSourceId = null, // TODO
+                            positionTicks = position.milliseconds.inWholeTicks,
+                        )
+                    }
+                } else {
+                    Timber.w("Activity result: %s", result.resultCode)
+                }
+                navigationManager.goBack()
+            }
+        }
     }
 
 data class PlayExternalState(
@@ -184,8 +241,14 @@ fun PlayExternalPage(
 ) {
     val context = LocalContext.current
     val activity = remember(context) { context.findActivity() }
+    val launcher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.StartActivityForResult(),
+            onResult = viewModel::onResult,
+        )
 
     val state by viewModel.state.collectAsState()
+    var launched by rememberSaveable { mutableStateOf(false) }
 
     if (activity != null) {
         when (val l = state.loading) {
@@ -201,19 +264,13 @@ fun PlayExternalPage(
 
             LoadingState.Success -> {
                 LoadingPage(modifier)
-                val launcher =
-                    rememberLauncherForActivityResult(
-                        contract = ActivityResultContracts.StartActivityForResult(),
-                    ) { result ->
-                        if (result.resultCode == Activity.RESULT_OK) {
-                            Timber.i("Activity result OK")
-                        } else {
-                            Timber.w("Activity result: %s", result.resultCode)
-                        }
+                if (!launched) {
+                    LifecycleStartEffect(Unit) {
+                        Timber.i("Launching external playback")
+                        launched = true
+                        launcher.launch(state.intent)
+                        onStopOrDispose { }
                     }
-                LifecycleStartEffect(Unit) {
-                    launcher.launch(state.intent)
-                    onStopOrDispose { }
                 }
             }
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
@@ -207,11 +207,12 @@ class PlayExternalViewModel
                             null
                         }
                     Timber.v("playerId=%s, component=%s", playerId, component)
+                    val title = "${item.title} ${item.subtitleLong}"
                     val intent =
                         Intent(Intent.ACTION_VIEW).apply {
                             setComponent(component)
                             setDataAndTypeAndNormalize(uri, "video/*")
-                            putExtra("title", "${item.title} ${item.subtitleLong}")
+                            putExtra("title", title)
                             putExtra("position", positionMs.toInt())
 
                             // MX/mpv
@@ -239,6 +240,16 @@ class PlayExternalViewModel
                             mediaSource.runTimeTicks?.ticks?.inWholeMilliseconds?.let {
                                 putExtra("extra_duration", it)
                             }
+
+                            // Vimu - https://vimu.tv/player-api/
+                            putExtra("startfrom", positionMs.toInt())
+                            putExtra("forceresume", false)
+                            putExtra("forcename", title)
+                            externalSubtitles
+                                .indexOfFirstOrNull { it.index == subtitleIndex && it.codec == "srt" }
+                                ?.let {
+                                    putExtra("forcedsrt", subtitleUrls[it])
+                                }
                         }
 
                     state.update {
@@ -270,7 +281,10 @@ class PlayExternalViewModel
                     itemId,
                     result.data?.action,
                 )
-                if (result.resultCode == Activity.RESULT_OK || result.resultCode == Activity.RESULT_CANCELED) {
+                if (result.resultCode == Activity.RESULT_OK || result.resultCode == Activity.RESULT_CANCELED ||
+                    // Vimu return 1 for video completion
+                    (result.data?.action == "net.gtvbox.videoplayer.result" && result.resultCode == 1)
+                ) {
                     val position: Long?
                     val data = result.data
                     when (data?.action) {
@@ -286,6 +300,8 @@ class PlayExternalViewModel
                         "is.xyz.mpv.MPVActivity.result",
                         // MX player: https://mx.j2inter.com/api
                         "com.mxtech.intent.result.VIEW",
+                        // VIMU: https://vimu.tv/player-api/
+                        "net.gtvbox.videoplayer.result",
                         -> {
                             position =
                                 data

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlayExternalPage.kt
@@ -21,14 +21,18 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.viewModelScope
+import com.github.damontecres.wholphin.data.ItemPlaybackDao
+import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.PlaylistCreationResult
 import com.github.damontecres.wholphin.services.PlaylistCreator
+import com.github.damontecres.wholphin.services.StreamChoiceService
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.ui.components.ErrorMessage
 import com.github.damontecres.wholphin.ui.components.LoadingPage
+import com.github.damontecres.wholphin.ui.indexOfFirstOrNull
 import com.github.damontecres.wholphin.ui.isNotNullOrBlank
 import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.nav.Destination
@@ -44,11 +48,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.playStateApi
+import org.jellyfin.sdk.api.client.extensions.subtitleApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.client.extensions.videosApi
+import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.PlaybackStopInfo
 import org.jellyfin.sdk.model.extensions.inWholeTicks
+import org.jellyfin.sdk.model.extensions.ticks
 import timber.log.Timber
+import java.io.File
 import java.util.UUID
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -59,7 +67,10 @@ class PlayExternalViewModel
         private val savedStateHandle: SavedStateHandle,
         @param:ApplicationContext private val context: Context,
         private val api: ApiClient,
+        private val serverRepository: ServerRepository,
+        private val itemPlaybackDao: ItemPlaybackDao,
         private val playlistCreator: PlaylistCreator,
+        private val streamChoiceService: StreamChoiceService,
         private val navigationManager: NavigationManager,
         private val userPreferencesService: UserPreferencesService,
         @Assisted val destination: Destination,
@@ -75,6 +86,7 @@ class PlayExternalViewModel
 
         init {
             viewModelScope.launchDefault {
+                val prefs = userPreferencesService.getCurrent()
                 val positionMs: Long
                 val itemId =
                     when (val d = destination) {
@@ -133,17 +145,58 @@ class PlayExternalViewModel
                         }
                     savedStateHandle["itemId"] = base.id
                     this@PlayExternalViewModel.item = BaseItem(base, false)
+                    val playbackConfig =
+                        serverRepository.currentUser.value?.let { user ->
+                            itemPlaybackDao.getItem(user, base.id)?.let {
+                                Timber.v("Fetched itemPlayback from DB: %s", it)
+                                if (it.sourceId != null) {
+                                    it
+                                } else {
+                                    null
+                                }
+                            }
+                        }
+                    val mediaSource = streamChoiceService.chooseSource(base, playbackConfig)
+                    val plc = streamChoiceService.getPlaybackLanguageChoice(base)
+                    if (mediaSource == null) {
+                        Timber.w("Media source is null")
+                        return@launchDefault
+                    }
+                    val subtitleIndex =
+                        streamChoiceService
+                            .chooseSubtitleStream(
+                                source = mediaSource,
+                                audioStream = null,
+                                seriesId = base.seriesId,
+                                itemPlayback = playbackConfig,
+                                plc = plc,
+                                prefs = prefs,
+                            )?.index
+                    val externalSubtitles =
+                        mediaSource.mediaStreams
+                            ?.filter { it.isExternal }
+                            ?.sortedWith(compareBy<MediaStream> { it.index == subtitleIndex }.thenBy { it.isDefault })
+                            .orEmpty()
+                    val subtitleUrls =
+                        externalSubtitles.map {
+                            val format = it.path?.let { File(it).extension } ?: "srt"
+                            api.subtitleApi
+                                .getSubtitleUrl(
+                                    routeItemId = itemId,
+                                    routeMediaSourceId = mediaSource.id!!,
+                                    routeIndex = it.index,
+                                    routeFormat = format,
+                                ).toUri()
+                        }
+
                     val uri =
                         api.videosApi
                             .getVideoStreamUrl(
                                 itemId = item.id,
-                                mediaSourceId = null, // TODO
+                                mediaSourceId = mediaSource.id,
                                 static = true,
                             ).toUri()
-                    val playerId =
-                        userPreferencesService
-                            .getCurrent()
-                            .appPreferences.playbackPreferences.externalPlayer
+                    val playerId = prefs.appPreferences.playbackPreferences.externalPlayer
                     // Make sure player is available, user could have uninstalled it
                     val foundPlayer =
                         getExternalPlayers(context).firstOrNull { it.identifier == playerId } != null
@@ -159,25 +212,33 @@ class PlayExternalViewModel
                             setComponent(component)
                             setDataAndType(uri, "video/*")
                             putExtra("title", "${item.title} ${item.subtitleLong}")
+                            putExtra("position", positionMs)
 
-                            // VLC intents: https://wiki.videolan.org/Android_Player_Intents/
-                            // mxplayer intents: https://mx.j2inter.com/api
-                            // mpv-android intents: https://mpv-android.github.io/mpv-android/intent.html
-//                    if (externalSubtitles) {
-//                        // VLC
-//                        // TODO doesn't work?
-//                        putExtra("subtitles_location", subUrl)
-//
-//                        // MX
-//                        // TODO arrays of strings
-//                        putExtra("subs", subs)
-//                        putExtra("subs.name", subNames)
-//                    }
+                            // MX/mpv
+                            putExtra("return_result", true)
+                            putExtra("secure_uri", true)
+                            putExtra("subs", subtitleUrls.toTypedArray())
+                            putExtra(
+                                "subs.name",
+                                externalSubtitles
+                                    .map { it.displayTitle ?: it.index.toString() }
+                                    .toTypedArray(),
+                            )
+                            if (subtitleIndex != null) {
+                                externalSubtitles
+                                    .indexOfFirstOrNull { it.index == subtitleIndex }
+                                    ?.let {
+                                        putExtra("subs.enable", arrayOf(subtitleUrls[it]))
+                                    }
+                            }
+
                             // VLC
-                            // TODO
-                            // putExtra("extra_duration", duration)
-
-                            // TODO starting position?
+                            if (subtitleUrls.isNotEmpty()) {
+                                putExtra("subtitles_location", subtitleUrls.first().toString())
+                            }
+                            mediaSource.runTimeTicks?.ticks?.inWholeMilliseconds?.let {
+                                putExtra("extra_duration", it)
+                            }
                         }
 
                     state.update {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -231,6 +231,8 @@ class PlaybackViewModel
                     PlayerBackend.MPV -> PlayerBackend.MPV
 
                     PlayerBackend.PREFER_MPV -> if (isHdr || (is4k && softwareDecoding)) PlayerBackend.EXO_PLAYER else PlayerBackend.MPV
+
+                    PlayerBackend.EXTERNAL_PLAYER -> throw IllegalStateException("Cannot use this for external playback")
                 }
 
             Timber.d("Selected backend: %s", playerBackend)

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -184,7 +184,7 @@ class PlaybackViewModel
         private val jobs = mutableListOf<Job>()
 
         val nextUp = MutableLiveData<BaseItem?>()
-        private var isPlaylist = false
+        private val isPlaylist = destination is Destination.PlaybackList
 
         val playlist = MutableLiveData<Playlist>(Playlist(listOf()))
         val subtitleSearchStatus = MutableLiveData<SubtitleSearchStatus?>(null)
@@ -312,7 +312,6 @@ class PlaybackViewModel
                 if (queriedItem.type.playable) {
                     queriedItem
                 } else if (destination is Destination.PlaybackList) {
-                    isPlaylist = true
                     val playlistResult =
                         playlistCreator.createFrom(
                             item = queriedItem,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/TrackSelectionUtils.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/TrackSelectionUtils.kt
@@ -201,6 +201,10 @@ object TrackSelectionUtils {
                     }
                 }
             }
+
+            PlayerBackend.EXTERNAL_PLAYER -> {
+                throw IllegalStateException("Cannot calculate tracks external playback")
+            }
         }
 }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/ChoicePreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/ChoicePreference.kt
@@ -1,0 +1,69 @@
+package com.github.damontecres.wholphin.ui.preferences
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.tv.material3.Text
+import com.github.damontecres.wholphin.ui.components.DialogItem
+import com.github.damontecres.wholphin.ui.components.DialogParams
+import com.github.damontecres.wholphin.ui.components.DialogPopup
+import com.github.damontecres.wholphin.ui.components.SelectedLeadingContent
+
+@Composable
+fun <T> ChoicePreference(
+    title: String,
+    summary: String?,
+    possibleValues: List<T>,
+    selectedIndex: Int,
+    onValueChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    valueDisplay: @Composable (index: Int, item: T) -> Unit = { _, item -> Text(item.toString()) },
+    subtitleDisplay: (index: Int, item: T) -> @Composable (() -> Unit)? = { _, _ -> null },
+) {
+    var dialogParams by remember { mutableStateOf<DialogParams?>(null) }
+    ClickPreference(
+        title = title,
+        summary = summary,
+        onClick = {
+            dialogParams =
+                DialogParams(
+                    title = title,
+                    fromLongClick = false,
+                    items =
+                        possibleValues.mapIndexed { index, item ->
+                            DialogItem(
+                                headlineContent = { valueDisplay.invoke(index, item) },
+                                leadingContent = {
+                                    SelectedLeadingContent(index == selectedIndex)
+                                },
+                                supportingContent = subtitleDisplay.invoke(index, item),
+                                onClick = {
+                                    onValueChange.invoke(index)
+                                    dialogParams = null
+                                },
+                            )
+                        },
+                )
+        },
+        interactionSource = interactionSource,
+        modifier = modifier,
+    )
+    AnimatedVisibility(dialogParams != null) {
+        dialogParams?.let {
+            DialogPopup(
+                showDialog = true,
+                title = it.title,
+                dialogItems = it.items,
+                onDismissRequest = { dialogParams = null },
+                waitToLoad = false,
+                dismissOnClick = false,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/ComposablePreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/ComposablePreference.kt
@@ -3,8 +3,6 @@ package com.github.damontecres.wholphin.ui.preferences
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
@@ -23,7 +21,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import androidx.tv.material3.surfaceColorAtElevation
@@ -35,7 +32,6 @@ import com.github.damontecres.wholphin.preferences.AppPreference
 import com.github.damontecres.wholphin.preferences.AppSliderPreference
 import com.github.damontecres.wholphin.preferences.AppStringPreference
 import com.github.damontecres.wholphin.preferences.AppSwitchPreference
-import com.github.damontecres.wholphin.ui.components.DialogItem
 import com.github.damontecres.wholphin.ui.components.DialogParams
 import com.github.damontecres.wholphin.ui.components.DialogPopup
 import com.github.damontecres.wholphin.ui.isNotNullOrBlank
@@ -181,46 +177,23 @@ fun <T> ComposablePreference(
                         .valueToIndex(value as T)
                         .let { values[it] }
             val selectedIndex = remember(value) { preference.valueToIndex.invoke(value as T) }
-            ClickPreference(
+            ChoicePreference(
                 title = title,
                 summary = summary,
-                onClick = {
-                    dialogParams =
-                        DialogParams(
-                            title = title,
-                            fromLongClick = false,
-                            items =
-                                values.mapIndexed { index, it ->
-                                    DialogItem(
-                                        headlineContent = {
-                                            Text(it)
-                                        },
-                                        leadingContent = {
-                                            if (index == selectedIndex) {
-                                                Icon(
-                                                    imageVector = Icons.Default.Done,
-                                                    contentDescription = "selected",
-                                                )
-                                            }
-                                        },
-                                        supportingContent = {
-                                            subtitles?.let {
-                                                val text = subtitles[index]
-                                                if (text.isNotNullOrBlank()) {
-                                                    Text(text)
-                                                }
-                                            }
-                                        },
-                                        onClick = {
-                                            onValueChange(preference.indexToValue(index))
-                                            dialogParams = null
-                                        },
-                                    )
-                                },
-                        )
+                possibleValues = values,
+                selectedIndex = selectedIndex,
+                onValueChange = { index ->
+                    onValueChange(preference.indexToValue(index))
                 },
-                interactionSource = interactionSource,
                 modifier = modifier,
+                interactionSource = interactionSource,
+                subtitleDisplay = { index, _ ->
+                    subtitles?.getOrNull(index)?.takeIf { it.isNotNullOrBlank() }?.let {
+                        {
+                            Text(text = it)
+                        }
+                    }
+                },
             )
         }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
@@ -103,6 +103,7 @@ fun PreferencesContent(
     val currentServer by seerrVm.currentSeerrServer.collectAsState(null)
     var showPinFlow by remember { mutableStateOf(false) }
     var showVersionDialog by remember { mutableStateOf(false) }
+    val players by viewModel.externalPlayers.collectAsState()
 
     var cacheUsage by remember { mutableStateOf(CacheUsage(0, 0, 0)) }
     val seerrConnection by viewModel.seerrConnection.collectAsState()
@@ -477,7 +478,6 @@ fun PreferencesContent(
 
                                 AppPreference.ExternalPlayerApp -> {
                                     val value = pref.getter.invoke(preferences).toString()
-                                    val players by viewModel.externalPlayers.collectAsState()
                                     val selectedIndex =
                                         remember(value, players) {
                                             players.indexOfFirstOrNull { it.identifier == value }
@@ -487,19 +487,28 @@ fun PreferencesContent(
                                         summary = players[selectedIndex].name,
                                         possibleValues = players,
                                         selectedIndex = selectedIndex,
-                                        onValueChange = {
-                                            // TODO
+                                        onValueChange = { index ->
+                                            scope.launch(ExceptionHandler()) {
+                                                val newValue =
+                                                    players.getOrNull(index)?.identifier ?: ""
+                                                preferences =
+                                                    viewModel.preferenceDataStore.updateData { prefs ->
+                                                        pref.setter.invoke(prefs, newValue)
+                                                    }
+                                            }
                                         },
                                         valueDisplay = { index, item ->
                                             Row(
                                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                                 verticalAlignment = Alignment.CenterVertically,
                                             ) {
-                                                Image(
-                                                    bitmap = item.icon,
-                                                    contentDescription = null,
-                                                    modifier = Modifier.width(40.dp),
-                                                )
+                                                if (item.icon != null) {
+                                                    Image(
+                                                        bitmap = item.icon,
+                                                        contentDescription = null,
+                                                        modifier = Modifier.width(40.dp),
+                                                    )
+                                                }
                                                 Text(item.name)
                                             }
                                         },

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -13,10 +14,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
@@ -62,6 +65,7 @@ import com.github.damontecres.wholphin.ui.components.ErrorMessage
 import com.github.damontecres.wholphin.ui.components.LoadingPage
 import com.github.damontecres.wholphin.ui.components.ScrollableDialog
 import com.github.damontecres.wholphin.ui.ifElse
+import com.github.damontecres.wholphin.ui.indexOfFirstOrNull
 import com.github.damontecres.wholphin.ui.isNotNullOrBlank
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.playOnClickSound
@@ -468,6 +472,37 @@ fun PreferencesContent(
                                         summary = pref.summary(context, null),
                                         onLongClick = {},
                                         interactionSource = interactionSource,
+                                    )
+                                }
+
+                                AppPreference.ExternalPlayerApp -> {
+                                    val value = pref.getter.invoke(preferences).toString()
+                                    val players by viewModel.externalPlayers.collectAsState()
+                                    val selectedIndex =
+                                        remember(value, players) {
+                                            players.indexOfFirstOrNull { it.identifier == value }
+                                        } ?: 0
+                                    ChoicePreference(
+                                        title = stringResource(pref.title),
+                                        summary = players[selectedIndex].name,
+                                        possibleValues = players,
+                                        selectedIndex = selectedIndex,
+                                        onValueChange = {
+                                            // TODO
+                                        },
+                                        valueDisplay = { index, item ->
+                                            Row(
+                                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                                verticalAlignment = Alignment.CenterVertically,
+                                            ) {
+                                                Image(
+                                                    bitmap = item.icon,
+                                                    contentDescription = null,
+                                                    modifier = Modifier.width(40.dp),
+                                                )
+                                                Text(item.name)
+                                            }
+                                        },
                                     )
                                 }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesViewModel.kt
@@ -1,6 +1,13 @@
 package com.github.damontecres.wholphin.ui.preferences
 
+import android.content.ComponentName
 import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.core.graphics.drawable.toBitmap
+import androidx.core.net.toUri
 import androidx.datastore.core.DataStore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -59,11 +66,36 @@ class PreferencesViewModel
 
         val releaseNotes = MutableStateFlow<DataLoadingState<Release>>(DataLoadingState.Pending)
 
+        val externalPlayers = MutableStateFlow<List<ExternalPlayerApp>>(emptyList())
+
         init {
             viewModelScope.launchIO {
-                serverRepository.currentUser.value?.let { user ->
-//                    fetchNavDrawerPins(user)
-                }
+                val fakeIntent =
+                    Intent(Intent.ACTION_VIEW).apply {
+                        setDataAndType("https://damontecres.com/video.mp4".toUri(), "video/*")
+                    }
+                val externalPlayers =
+                    context.packageManager
+                        .queryIntentActivities(fakeIntent, PackageManager.MATCH_ALL)
+                        .filter { it.priority >= 0 }
+                        .map {
+                            val component =
+                                ComponentName(
+                                    it.activityInfo.packageName,
+                                    it.activityInfo.name,
+                                )
+                            ExternalPlayerApp(
+                                name = it.loadLabel(context.packageManager).toString(),
+                                icon =
+                                    it
+                                        .loadIcon(context.packageManager)
+                                        .toBitmap()
+                                        .asImageBitmap(),
+                                component = component,
+                                identifier = component.flattenToString(),
+                            ).also { Timber.v("Found %s", it) }
+                        }
+                this@PreferencesViewModel.externalPlayers.update { externalPlayers }
             }
         }
 
@@ -134,3 +166,10 @@ class PreferencesViewModel
             }
         }
     }
+
+data class ExternalPlayerApp(
+    val name: String,
+    val icon: ImageBitmap,
+    val component: ComponentName,
+    val identifier: String,
+)

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesViewModel.kt
@@ -11,6 +11,7 @@ import androidx.core.net.toUri
 import androidx.datastore.core.DataStore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.model.JellyfinUser
 import com.github.damontecres.wholphin.preferences.AppPreferences
@@ -74,28 +75,14 @@ class PreferencesViewModel
                     Intent(Intent.ACTION_VIEW).apply {
                         setDataAndType("https://damontecres.com/video.mp4".toUri(), "video/*")
                     }
-                val externalPlayers =
-                    context.packageManager
-                        .queryIntentActivities(fakeIntent, PackageManager.MATCH_ALL)
-                        .filter { it.priority >= 0 }
-                        .map {
-                            val component =
-                                ComponentName(
-                                    it.activityInfo.packageName,
-                                    it.activityInfo.name,
-                                )
-                            ExternalPlayerApp(
-                                name = it.loadLabel(context.packageManager).toString(),
-                                icon =
-                                    it
-                                        .loadIcon(context.packageManager)
-                                        .toBitmap()
-                                        .asImageBitmap(),
-                                component = component,
-                                identifier = component.flattenToString(),
-                            ).also { Timber.v("Found %s", it) }
-                        }
-                this@PreferencesViewModel.externalPlayers.update { externalPlayers }
+                val externalPlayers = getExternalPlayers(context)
+                val systemDefault =
+                    ExternalPlayerApp(
+                        name = context.getString(R.string.system_default),
+                        icon = null,
+                        identifier = "",
+                    )
+                this@PreferencesViewModel.externalPlayers.update { listOf(systemDefault) + externalPlayers }
             }
         }
 
@@ -169,7 +156,34 @@ class PreferencesViewModel
 
 data class ExternalPlayerApp(
     val name: String,
-    val icon: ImageBitmap,
-    val component: ComponentName,
+    val icon: ImageBitmap?,
     val identifier: String,
 )
+
+fun getExternalPlayers(context: Context): List<ExternalPlayerApp> {
+    val fakeIntent =
+        Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType("https://damontecres.com/video.mp4".toUri(), "video/*")
+        }
+    val externalPlayers =
+        context.packageManager
+            .queryIntentActivities(fakeIntent, PackageManager.MATCH_ALL)
+            .filter { it.priority >= 0 }
+            .map {
+                val component =
+                    ComponentName(
+                        it.activityInfo.packageName,
+                        it.activityInfo.name,
+                    )
+                ExternalPlayerApp(
+                    name = it.loadLabel(context.packageManager).toString(),
+                    icon =
+                        it
+                            .loadIcon(context.packageManager)
+                            .toBitmap()
+                            .asImageBitmap(),
+                    identifier = component.flattenToString(),
+                )
+            }
+    return externalPlayers
+}

--- a/app/src/main/proto/WholphinDataStore.proto
+++ b/app/src/main/proto/WholphinDataStore.proto
@@ -33,6 +33,7 @@ enum PlayerBackend{
   EXO_PLAYER = 0;
   MPV = 1;
   PREFER_MPV = 2;
+  EXTERNAL_PLAYER = 3;
 }
 
 message MpvOptions{
@@ -76,6 +77,7 @@ message PlaybackPreferences {
   MpvOptions mpv_options = 21;
   bool refresh_rate_switching = 22;
   bool resolution_switching = 23;
+  string external_player = 24;
 }
 
 message HomePagePreferences{

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -658,10 +658,12 @@
     <string name="exoplayer" translatable="false">ExoPlayer</string>
     <string name="mpv" translatable="false">MPV</string>
     <string name="prefer_mpv">Prefer MPV</string>
+    <string name="external_player">External Player</string>
     <string-array name="player_backend_options">
         <item>@string/exoplayer</item>
         <item>@string/mpv</item>
         <item>@string/prefer_mpv</item>
+        <item>@string/external_player</item>
     </string-array>
 
     <string name="player_backend_options_subtitles_prefer_mpv">Use ExoPlayer for HDR playback</string>
@@ -669,6 +671,7 @@
         <item /><!-- Intentionally blank -->
         <item /><!-- Intentionally blank -->
         <item>@string/player_backend_options_subtitles_prefer_mpv</item>
+        <item /><!-- Intentionally blank -->
     </string-array>
 
     <string name="aspect_ratios_poster">Poster (2:3)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -759,5 +759,6 @@
     <string name="discover_tv">Discover TV Shows</string>
     <string name="discover_movies">Discover Movies</string>
     <string name="studios_in">Studios in %1$s</string>
+    <string name="system_default">System default</string>
 
 </resources>


### PR DESCRIPTION
## Description
Adds a new playback "backend" to play media in another app such as VLC.

By default, Wholphin will use the system default app. Typically if you haven't chosen one, a dialog will show to pick which app. You can also set a specific external app to use in Wholphin independent of the system default.

Currently, this only support single item playback, ie playing next up episodes is not supported yet.

Also since there is no standardized way to send resume position, external subtitle info, etc, Wholphin makes a best effort. VLC, mpv-android, & MX-Player are specifically tested/supported.

### Related issues
Closes #85

### Testing
Emulator & nvidia shield w/ VLC, mpv-android, & MX-player

## Screenshots
<img width="543" height="407" alt="image" src="https://github.com/user-attachments/assets/ab37d41e-2909-40ed-b537-191ebb54d979" />

## AI or LLM usage
None