### PR TITLE
Add option to never show next up episodes

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -826,8 +826,8 @@ sealed interface AppPreference<Pref, T> {
                 },
                 displayValues = R.array.player_backend_options,
                 subtitles = R.array.player_backend_options_subtitles,
-                indexToValue = { PlayerBackend.forNumber(it) },
-                valueToIndex = { it.number },
+                indexToValue = { PlayerBackend.forNumber(it) ?: PlayerBackend.EXO_PLAYER },
+                valueToIndex = { if (it != PlayerBackend.UNRECOGNIZED) it.number else PlayerBackend.EXO_PLAYER.number },
             )
 
         val ExoPlayerSettings =

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -337,8 +337,10 @@ class PlaybackViewModel
                                 navigationManager.goBack()
                                 return
                             }
-                            withContext(Dispatchers.Main) {
-                                this@PlaybackViewModel.playlist.value = r.playlist
+                            if (preferences.appPreferences.playbackPreferences.showNextUpWhen != ShowNextUpWhen.NEXT_UP_NEVER) {
+                                withContext(Dispatchers.Main) {
+                                    this@PlaybackViewModel.playlist.value = r.playlist
+                                }
                             }
                             r.playlist.items
                                 .first()
@@ -363,7 +365,7 @@ class PlaybackViewModel
                 playNextUp()
             }
 
-            if (!isPlaylist) {
+            if (!isPlaylist && preferences.appPreferences.playbackPreferences.showNextUpWhen != ShowNextUpWhen.NEXT_UP_NEVER) {
                 val result = playlistCreator.createFrom(queriedItem)
                 if (result is PlaylistCreationResult.Success && result.playlist.items.isNotEmpty()) {
                     withContext(Dispatchers.Main) {

--- a/app/src/main/proto/WholphinDataStore.proto
+++ b/app/src/main/proto/WholphinDataStore.proto
@@ -6,6 +6,7 @@ option java_multiple_files = true;
 enum ShowNextUpWhen{
   END_OF_PLAYBACK = 0;
   DURING_CREDITS = 1;
+  NEXT_UP_NEVER = 2;
 }
 
 enum SkipSegmentBehavior{

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -615,9 +615,11 @@
 
     <string name="next_up_playback_end">At the end of playback</string>
     <string name="next_up_outro">During end credits/outro</string>
+    <string name="next_up_never">Never</string>
     <string-array name="show_next_up_when_options">
         <item>@string/next_up_playback_end</item>
         <item>@string/next_up_outro</item>
+        <item>@string/next_up_never</item>
     </string-array>
 
     <string name="white">White</string>


### PR DESCRIPTION
## Description
Adds an option to never show next up. This means when an episode completes, the app always returns to the previous page instead of suggesting the next episode.

### Related issues
Closes #1100

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None