### PR TITLE
Fix trickplay image grid Y-coordinate calculation (#943)

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/CoilTrickplayTransformation.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/CoilTrickplayTransformation.kt
@@ -18,7 +18,7 @@ class CoilTrickplayTransformation(
     val index: Int,
 ) : Transformation() {
     private val x: Int = imageIndex % numColumns
-    private val y: Int = imageIndex / numRows
+    private val y: Int = imageIndex / numColumns
 
     override val cacheKey: String
         get() = "CoilTrickplayTransformation_$index,$x,$y"

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/SeekPreviewImage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/SeekPreviewImage.kt
@@ -107,7 +107,7 @@ fun SeekPreviewImage(
         val tileIndex =
             index % numberOfTilesPerImage // Index of tile within the current image
         val x = (tileIndex % trickPlayInfo.tileWidth) // x position within tile grid
-        val y = (tileIndex / trickPlayInfo.tileHeight) // y position
+        val y = (tileIndex / trickPlayInfo.tileWidth) // y position
         Box(
             modifier =
                 modifier


### PR DESCRIPTION
## Description
Issue 943 where trickplay images were misaligned with seek preview mages. I made a post in issues but figured i'd go ahead and make the pull request.

per gemini:
In SeekPreviewImage.kt, the code calculates which tile in the grid to display based on the current timestamp:

val x = (tileIndex % trickPlayInfo.tileWidth) // x position within tile grid
val y = (tileIndex / trickPlayInfo.tileHeight) // y position <-- BUG IS HERE
To find the correct row (y) in a grid, you are supposed to divide the current index by the width of the row (the number of columns), not the height.

Why this breaks: Let's assume a standard trickplay grid that is 10 images wide (tileWidth = 10) and 5 images tall (tileHeight = 5).

If you are looking at the 12th image (tileIndex = 11), it should be on Row 1 (the second row).

The code calculates y = 11 / 5 = 2. It skips to Row 2!

Because it divides by the smaller height value, the y coordinate increases much faster than it should. This causes the preview to visually "jump" down to future rows prematurely, and then snap back as the x coordinate resets, causing the exact "flashing back and forth" you saw with the credits and intros.

### Related issue
Fixes #943

### Testing
Tested in Android TV (Android 9) and it does indeed display proper seek previews using trickplay images.


## AI or LLM usage
Gemini Pro was used to find and fix this bug.
