### PR TITLE
Fix crash when OS screensaver started before opening Wholphin

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
@@ -28,7 +28,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation3.runtime.NavBackStack
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import com.github.damontecres.wholphin.data.ServerRepository
-import com.github.damontecres.wholphin.preferences.AppPreference
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.PlayerBackend
 import com.github.damontecres.wholphin.services.AppUpgradeHandler
@@ -220,14 +219,7 @@ class MainActivity : AppCompatActivity() {
                     signInAuto = appPreferences.signInAutomatically
                 }
                 CoilConfig(
-                    diskCacheSizeBytes =
-                        appPreferences.advancedPreferences.imageDiskCacheSizeBytes.let {
-                            if (it < AppPreference.ImageDiskCacheSize.min * AppPreference.MEGA_BIT) {
-                                AppPreference.ImageDiskCacheSize.defaultValue * AppPreference.MEGA_BIT
-                            } else {
-                                it
-                            }
-                        },
+                    prefs = appPreferences,
                     okHttpClient = okHttpClient,
                     debugLogging = false,
                     enableCache = true,

--- a/app/src/main/java/com/github/damontecres/wholphin/WholphinDreamService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/WholphinDreamService.kt
@@ -23,6 +23,8 @@ import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.services.ScreensaverService
+import com.github.damontecres.wholphin.services.hilt.AuthOkHttpClient
+import com.github.damontecres.wholphin.ui.CoilConfig
 import com.github.damontecres.wholphin.ui.components.AppScreensaverContent
 import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.theme.WholphinTheme
@@ -30,6 +32,7 @@ import com.github.damontecres.wholphin.ui.util.ProvideLocalClock
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
+import okhttp3.OkHttpClient
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import timber.log.Timber
 import javax.inject.Inject
@@ -47,6 +50,10 @@ class WholphinDreamService :
 
     @Inject
     lateinit var preferencesDataStore: DataStore<AppPreferences>
+
+    @AuthOkHttpClient
+    @Inject
+    lateinit var okHttpClient: OkHttpClient
 
     private val lifecycleRegistry = LifecycleRegistry(this)
 
@@ -88,6 +95,12 @@ class WholphinDreamService :
                             preferencesDataStore.data.collectLatest { prefs = it }
                         }
                         prefs?.let { prefs ->
+                            CoilConfig(
+                                prefs = prefs,
+                                okHttpClient = okHttpClient,
+                                debugLogging = false,
+                                enableCache = true,
+                            )
                             WholphinTheme(appThemeColors = prefs.interfacePreferences.appThemeColors) {
                                 ProvideLocalClock {
                                     val screensaverPrefs = prefs.interfacePreferences.screensaverPreference

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/CoilConfig.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/CoilConfig.kt
@@ -16,9 +16,31 @@ import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.Options
 import coil3.request.crossfade
 import coil3.util.DebugLogger
+import com.github.damontecres.wholphin.preferences.AppPreference
+import com.github.damontecres.wholphin.preferences.AppPreferences
 import okhttp3.OkHttpClient
 import timber.log.Timber
 import kotlin.time.ExperimentalTime
+
+@Composable
+fun CoilConfig(
+    prefs: AppPreferences,
+    okHttpClient: OkHttpClient,
+    debugLogging: Boolean,
+    enableCache: Boolean = true,
+) = CoilConfig(
+    diskCacheSizeBytes =
+        prefs.advancedPreferences.imageDiskCacheSizeBytes.let {
+            if (it < AppPreference.ImageDiskCacheSize.min * AppPreference.MEGA_BIT) {
+                AppPreference.ImageDiskCacheSize.defaultValue * AppPreference.MEGA_BIT
+            } else {
+                it
+            }
+        },
+    okHttpClient = okHttpClient,
+    debugLogging = false,
+    enableCache = true,
+)
 
 /**
  * Configure Coil image loading


### PR DESCRIPTION
## Description
If the Wholphin OS screensaver starts before Wholphin (the app) is opened, a default image loader is used. Then when Wholphin is opened, it will crash when trying to set the app's image loader.

This PR adds configuring the image loader to the screensaver as well. It is safe to do this multiple times. It's only an error to try to replace the default image loader.

### Related issues
None

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None