### PR TITLE
Move skip segments settings to their own page

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -114,30 +114,6 @@ sealed interface AppPreference<Pref, T> {
                 },
             )
 
-//        val GridJumpButtons =
-//            AppSwitchPreference<AppPreferences>(
-//                title = R.string.show_grid_jump_buttons,
-//                defaultValue = true,
-//                getter = { it.interfacePreferences.showGridJumpButtons },
-//                setter = { prefs, value ->
-//                    prefs.updateInterfacePreferences { showGridJumpButtons = value }
-//                },
-//                summaryOn = R.string.enabled,
-//                summaryOff = R.string.disabled,
-//            )
-
-//        val ShowGridFooter =
-//            AppSwitchPreference<AppPreferences>(
-//                title = R.string.grid_position_footer,
-//                defaultValue = true,
-//                getter = { it.interfacePreferences.showPositionFooter },
-//                setter = { prefs, value ->
-//                    prefs.updateInterfacePreferences { showPositionFooter = value }
-//                },
-//                summaryOn = R.string.show,
-//                summaryOff = R.string.hide,
-//            )
-
         val ControllerTimeout =
             AppSliderPreference<AppPreferences>(
                 title = R.string.hide_controller_timeout,
@@ -628,6 +604,13 @@ sealed interface AppPreference<Pref, T> {
                 displayValues = R.array.skip_behaviors,
                 indexToValue = { SkipSegmentBehavior.forNumber(it) },
                 valueToIndex = { if (it != SkipSegmentBehavior.UNRECOGNIZED) it.number else 0 },
+            )
+
+        val SkipSegments =
+            AppDestinationPreference<AppPreferences>(
+                title = R.string.skip_behavior,
+                summary = R.string.skip_behavior_summary,
+                destination = Destination.Settings(PreferenceScreenOption.SKIP_SEGMENTS),
             )
 
         val GlobalContentScale =
@@ -1142,6 +1125,21 @@ val MpvPreferences =
         ),
     )
 
+val SkipSegmentPreferences =
+    listOf(
+        PreferenceGroup(
+            title = R.string.skip,
+            preferences =
+                listOf(
+                    AppPreference.SkipIntros,
+                    AppPreference.SkipOutros,
+                    AppPreference.SkipCommercials,
+                    AppPreference.SkipPreviews,
+                    AppPreference.SkipRecaps,
+                ),
+        ),
+    )
+
 val advancedPreferences =
     buildList {
         add(
@@ -1169,23 +1167,11 @@ val advancedPreferences =
                     listOf(
                         AppPreference.OneClickPause,
                         AppPreference.GlobalContentScale,
+                        AppPreference.SkipSegments,
                         AppPreference.MaxBitrate,
                         AppPreference.RefreshRateSwitching,
                         AppPreference.ResolutionSwitching,
                         AppPreference.PlaybackDebugInfo,
-                    ),
-            ),
-        )
-        add(
-            PreferenceGroup(
-                title = R.string.skip,
-                preferences =
-                    listOf(
-                        AppPreference.SkipIntros,
-                        AppPreference.SkipOutros,
-                        AppPreference.SkipCommercials,
-                        AppPreference.SkipPreviews,
-                        AppPreference.SkipRecaps,
                     ),
             ),
         )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferenceUtils.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferenceUtils.kt
@@ -36,6 +36,7 @@ enum class PreferenceScreenOption {
     EXO_PLAYER,
     MPV,
     SCREENSAVER,
+    SKIP_SEGMENTS,
     ;
 
     companion object {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
@@ -53,6 +53,7 @@ import com.github.damontecres.wholphin.preferences.ExoPlayerPreferences
 import com.github.damontecres.wholphin.preferences.MpvPreferences
 import com.github.damontecres.wholphin.preferences.PlayerBackend
 import com.github.damontecres.wholphin.preferences.ScreensaverPreference
+import com.github.damontecres.wholphin.preferences.SkipSegmentPreferences
 import com.github.damontecres.wholphin.preferences.advancedPreferences
 import com.github.damontecres.wholphin.preferences.basicPreferences
 import com.github.damontecres.wholphin.preferences.screensaverPreferences
@@ -142,6 +143,7 @@ fun PreferencesContent(
             PreferenceScreenOption.EXO_PLAYER -> ExoPlayerPreferences
             PreferenceScreenOption.MPV -> MpvPreferences
             PreferenceScreenOption.SCREENSAVER -> screensaverPreferences
+            PreferenceScreenOption.SKIP_SEGMENTS -> SkipSegmentPreferences
         }
     val screenTitle =
         when (preferenceScreenOption) {
@@ -150,6 +152,7 @@ fun PreferencesContent(
             PreferenceScreenOption.EXO_PLAYER -> R.string.exoplayer_options
             PreferenceScreenOption.MPV -> R.string.mpv_options
             PreferenceScreenOption.SCREENSAVER -> R.string.screensaver_settings
+            PreferenceScreenOption.SKIP_SEGMENTS -> R.string.skip_behavior
         }
 
     var visible by remember { mutableStateOf(false) }
@@ -707,6 +710,7 @@ fun PreferencesPage(
             PreferenceScreenOption.EXO_PLAYER,
             PreferenceScreenOption.MPV,
             PreferenceScreenOption.SCREENSAVER,
+            PreferenceScreenOption.SKIP_SEGMENTS,
             -> {
                 PreferencesContent(
                     initialPreferences,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -767,6 +767,8 @@
     <string name="ass_subtitle_mode_exoplayer">Direct play with ExoPlayer built-in</string>
     <string name="ass_subtitle_mode_transcode">Burn in/transcode on server</string>
     <string name="ass_subtitle_playback">SSA/ASS subtitle playback</string>
+    <string name="skip_behavior">Skip behavior</string>
+    <string name="skip_behavior_summary">For intros, credits, etc</string>
     <array name="ass_subtitle_modes">
         <item>@string/ass_subtitle_mode_libass</item>
         <item>@string/ass_subtitle_mode_exoplayer</item>


### PR DESCRIPTION
## Description
Moves the five skip segment settings to their own page. So there's now a single "Skip behavior" that you click to bring up the settings for the five. I doubt many people change these frequently, so moving them to a new page de-clutters the settings page.

### Related issues
N/A

### Testing
Emulator

## Screenshots

### Advanced settings
<img width="1280" height="720" alt="single_setting Large" src="https://github.com/user-attachments/assets/673555d5-109c-4c43-9073-f51572bb949d" />

### Skip segment specific settings
<img width="1280" height="720" alt="skip_settings Large" src="https://github.com/user-attachments/assets/dae9d0bd-7340-4731-b561-b7b4e74d9d4f" />

## AI or LLM usage
None
