### PR TITLE
Slightly optimize subtitles view & workaround possible crash

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -1,6 +1,7 @@
 package com.github.damontecres.wholphin.ui.playback
 
 import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.activity.compose.BackHandler
@@ -28,6 +29,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -35,12 +37,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
@@ -74,7 +76,6 @@ import com.github.damontecres.wholphin.ui.AspectRatios
 import com.github.damontecres.wholphin.ui.LocalImageUrlService
 import com.github.damontecres.wholphin.ui.components.ErrorMessage
 import com.github.damontecres.wholphin.ui.components.LoadingPage
-import com.github.damontecres.wholphin.ui.ifElse
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.playback.overlay.PauseIndicator
 import com.github.damontecres.wholphin.ui.playback.overlay.PlaybackAction
@@ -435,65 +436,74 @@ fun PlaybackPageContent(
                 remember(subtitleSettings) { subtitleSettings.imageSubtitleOpacity / 100f }
 
             // Subtitles
-            if (skipIndicatorDuration == 0L && currentItemPlayback.subtitleIndexEnabled && !presentationState.coverSurface) {
-                val maxSize by animateFloatAsState(if (controllerViewState.controlsVisible) .7f else 1f)
-                val isImageSubtitles = remember(cues) { cues.firstOrNull()?.bitmap != null }
-                AndroidView(
-                    factory = { context ->
-                        SubtitleView(context).apply {
-                            subtitleSettings.let {
-                                setStyle(it.toSubtitleStyle())
-                                setFixedTextSize(Dimension.SP, it.fontSize.toFloat())
-                                setBottomPaddingFraction(it.margin.toFloat() / 100f)
-                            }
-                            playerState.assHandler?.let { assHandler ->
-                                if (prefs.overrides.assPlaybackMode == AssPlaybackMode.ASS_LIBASS) {
-                                    Timber.v("Adding AssSubtitleView")
-                                    addView(
-                                        AssSubtitleView(context, assHandler).apply {
-                                            layoutParams =
-                                                FrameLayout
-                                                    .LayoutParams(
-                                                        ViewGroup.LayoutParams.MATCH_PARENT,
-                                                        ViewGroup.LayoutParams.MATCH_PARENT,
-                                                    ).apply { gravity = Gravity.CENTER }
-                                        },
-                                    )
-                                }
+            val subtitleMaxSize by animateFloatAsState(if (controllerViewState.controlsVisible) .7f else 1f)
+            val isImageSubtitles = remember(cues) { cues.firstOrNull()?.bitmap != null }
+            var cueCount by remember { mutableIntStateOf(0) }
+            AndroidView(
+                factory = { context ->
+                    SubtitleView(context).apply {
+                        subtitleSettings.let {
+                            setStyle(it.toSubtitleStyle())
+                            setFixedTextSize(Dimension.SP, it.fontSize.toFloat())
+                            setBottomPaddingFraction(it.margin.toFloat() / 100f)
+                        }
+                        playerState.assHandler?.let { assHandler ->
+                            if (prefs.overrides.assPlaybackMode == AssPlaybackMode.ASS_LIBASS) {
+                                Timber.v("Adding AssSubtitleView")
+                                addView(
+                                    AssSubtitleView(context, assHandler).apply {
+                                        layoutParams =
+                                            FrameLayout
+                                                .LayoutParams(
+                                                    ViewGroup.LayoutParams.MATCH_PARENT,
+                                                    ViewGroup.LayoutParams.MATCH_PARENT,
+                                                ).apply { gravity = Gravity.CENTER }
+                                    },
+                                )
                             }
                         }
-                    },
-                    update = {
-                        it.setCues(cues)
+                    }
+                },
+                update = { subtitleView ->
+                    val subtitleVisible =
+                        skipIndicatorDuration == 0L && currentItemPlayback.subtitleIndexEnabled && !presentationState.coverSurface
+                    subtitleView.visibility = if (subtitleVisible) View.VISIBLE else View.INVISIBLE
+
+                    subtitleView.setCues(cues)
+                    if (cues.size > cueCount) {
+                        // The output creates a painter for each cue, so need to apply the changes when the number of cues increases
                         Media3SubtitleOverride(subtitleSettings.calculateEdgeSize(density))
-                            .apply(it)
-                        it.children.firstOrNull { it is AssSubtitleView }?.let {
-                            (it as? AssSubtitleView)?.apply {
-                                val resized =
-                                    layoutParams.let { it.width != playerSurfaceSize.width || it.height != playerSurfaceSize.height }
-                                if (resized) {
-                                    Timber.v("Resizing AssSubtitleView: $playerSurfaceSize")
-                                    layoutParams =
-                                        FrameLayout
-                                            .LayoutParams(
-                                                playerSurfaceSize.width,
-                                                playerSurfaceSize.height,
-                                            ).apply { gravity = Gravity.CENTER }
-                                }
+                            .apply(subtitleView)
+                        cueCount = cues.size
+                    }
+                    subtitleView.children.firstOrNull { it is AssSubtitleView }?.let {
+                        (it as? AssSubtitleView)?.apply {
+                            val resized =
+                                layoutParams.let { it.width != playerSurfaceSize.width || it.height != playerSurfaceSize.height }
+                            if (resized) {
+                                Timber.v("Resizing AssSubtitleView: %s", playerSurfaceSize)
+                                layoutParams =
+                                    FrameLayout
+                                        .LayoutParams(
+                                            playerSurfaceSize.width,
+                                            playerSurfaceSize.height,
+                                        ).apply { gravity = Gravity.CENTER }
                             }
                         }
-                    },
-                    onReset = {
-                        it.setCues(null)
-                    },
-                    modifier =
-                        Modifier
-                            .fillMaxSize(maxSize)
-                            .align(Alignment.TopCenter)
-                            .background(Color.Transparent)
-                            .ifElse(isImageSubtitles, Modifier.alpha(subtitleImageOpacity)),
-                )
-            }
+                    }
+                },
+                onReset = {
+                    it.setCues(null)
+                },
+                modifier =
+                    Modifier
+                        .fillMaxSize(subtitleMaxSize)
+                        .align(Alignment.TopCenter)
+                        .background(Color.Transparent)
+                        .graphicsLayer {
+                            alpha = if (isImageSubtitles) subtitleImageOpacity else 1f
+                        },
+            )
         }
 
         // Ask to skip intros, etc button


### PR DESCRIPTION
## Description
Instead of adding/removing the `SubtitleView` from composition sometimes, instead toggle its visibility. This is technically slightly more efficient. There's also a couple other minor tweaks that make the subtitles style a little more efficient.

This should also help prevent crash caused by possible a race condition in libass-android (https://github.com/peerless2012/libass-android/issues/75).

### Related issues
I think this fixes #1322

### Testing
Emulator mostly

## Screenshots
N/A

## AI or LLM usage
None