### PR TITLE
Enable large heap

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,8 @@
         android:theme="@style/Theme.Wholphin"
         android:name=".WholphinApplication"
         android:usesCleartextTraffic="true"
-        android:networkSecurityConfig="@xml/network_security_config">
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:largeHeap="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Description
This PR simply enables the `largeHeap` flag to request more memory from the OS.

I am a bit embarrassed that I haven't added this before now, but I had read that using `largeHeap` was a bandaid, not a solution. So I assumed Wholphin was doing something incorrect memory-wise. But after crawling through many, many heap dumps to analyze Wholphin's memory usage, and after further research, enabling this does make sense for handling high bitrate, high resolution videos. Furthermore, many other Jellyfin clients and other video apps like Plex and Prime Video have this enabled.

So since I am pretty confident that Wholphin doesn't have any memory leaks, I feel good about enabling this.

### Related issues
I believe this will fix many of the bug reports about crashes during 4K playback, but it's not a cure-all since it is up the device & OS to allocate the max memory.
Fixes #333 
Fixes #826
Fixes #1189

### Testing
Shield 2019, Fire 4k Max

## Screenshots
N/A

## AI or LLM usage
None