### PR TITLE
Fix bug where changing subtitles during playback doesn't work

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/Destination.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/Destination.kt
@@ -8,7 +8,6 @@ import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.CollectionFolderFilter
 import com.github.damontecres.wholphin.data.model.DiscoverItem
 import com.github.damontecres.wholphin.data.model.GetItemsFilter
-import com.github.damontecres.wholphin.data.model.ItemPlayback
 import com.github.damontecres.wholphin.preferences.PlayerBackend
 import com.github.damontecres.wholphin.ui.data.SortAndDirection
 import com.github.damontecres.wholphin.ui.detail.series.SeasonEpisodeIds
@@ -79,7 +78,6 @@ sealed class Destination(
     data class Playback(
         val itemId: UUID,
         val positionMs: Long,
-        val itemPlayback: ItemPlayback? = null,
         val forceTranscoding: Boolean = false,
         val backend: PlayerBackend? = null,
     ) : Destination(true) {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -298,21 +298,18 @@ class PlaybackViewModel
             this.forceTranscoding =
                 (destination as? Destination.Playback)?.forceTranscoding ?: false
             val positionMs: Long
-            val itemPlayback: ItemPlayback?
             val forceTranscoding: Boolean
 
             val itemId =
                 when (val d = destination) {
                     is Destination.Playback -> {
                         positionMs = d.positionMs
-                        itemPlayback = d.itemPlayback
                         forceTranscoding = d.forceTranscoding
                         d.itemId
                     }
 
                     is Destination.PlaybackList -> {
                         positionMs = 0
-                        itemPlayback = null
                         forceTranscoding = false
                         d.itemId
                     }
@@ -395,7 +392,6 @@ class PlaybackViewModel
                 play(
                     firstItem,
                     positionMs,
-                    itemPlayback,
                     forceTranscoding,
                 )
             if (!played) {
@@ -427,7 +423,6 @@ class PlaybackViewModel
         private suspend fun play(
             playlistItem: PlaylistItem,
             positionMs: Long,
-            itemPlayback: ItemPlayback? = null,
             forceTranscoding: Boolean = this.forceTranscoding,
         ): Boolean =
             withContext(Dispatchers.IO) {
@@ -463,19 +458,18 @@ class PlaybackViewModel
                 val base = item.data
 
                 // Use the provided playback parameters or else check if the database has some
-                val playbackConfig =
-                    itemPlayback
-                        ?: serverRepository.currentUser.value?.let { user ->
-                            itemPlaybackDao.getItem(user, base.id)?.let {
-                                Timber.v("Fetched itemPlayback from DB: %s", it)
-                                if (it.sourceId != null) {
-                                    it
-                                } else {
-                                    null
-                                }
+                val itemPlayback =
+                    serverRepository.currentUser.value?.let { user ->
+                        itemPlaybackDao.getItem(user, base.id)?.let {
+                            Timber.v("Fetched itemPlayback from DB: %s", it)
+                            if (it.sourceId != null) {
+                                it
+                            } else {
+                                null
                             }
                         }
-                val mediaSource = streamChoiceService.chooseSource(base, playbackConfig)
+                    }
+                val mediaSource = streamChoiceService.chooseSource(base, itemPlayback)
                 val plc = streamChoiceService.getPlaybackLanguageChoice(base)
 
                 if (mediaSource == null) {
@@ -531,7 +525,7 @@ class PlaybackViewModel
                         .chooseAudioStream(
                             source = mediaSource,
                             seriesId = base.seriesId,
-                            itemPlayback = playbackConfig,
+                            itemPlayback = itemPlayback,
                             plc = plc,
                             prefs = preferences,
                         )
@@ -543,7 +537,7 @@ class PlaybackViewModel
                             source = mediaSource,
                             audioStream = audioStream,
                             seriesId = base.seriesId,
-                            itemPlayback = playbackConfig,
+                            itemPlayback = itemPlayback,
                             plc = plc,
                             prefs = preferences,
                         )?.index
@@ -551,7 +545,7 @@ class PlaybackViewModel
                 Timber.d("Selected mediaSource=${mediaSource.id}, audioIndex=$audioIndex, subtitleIndex=$subtitleIndex")
 
                 val itemPlaybackToUse =
-                    playbackConfig ?: ItemPlayback(
+                    itemPlayback ?: ItemPlayback(
                         rowId = -1,
                         userId = -1,
                         itemId = base.id,
@@ -821,6 +815,7 @@ class PlaybackViewModel
                                                 subtitleIndex,
                                                 source,
                                             )
+                                        Timber.v("onTracksChanged: %s", result)
                                         if (result.bothSelected) {
                                             player.trackSelectionParameters =
                                                 result.trackSelectionParameters

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/TrackSelectionUtils.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/TrackSelectionUtils.kt
@@ -108,7 +108,7 @@ object TrackSelectionUtils {
                 true
             }
         val audioSelected =
-            if (audioIndex != null && supportsDirectPlay) {
+            if (audioIndex != null && audioIndex >= 0 && supportsDirectPlay) {
                 val indexToFind =
                     calculateIndexToFind(
                         audioIndex,
@@ -141,7 +141,7 @@ object TrackSelectionUtils {
                 }
                 chosenTrack != null
             } else {
-                audioIndex == null
+                true
             }
         return TrackSelectionResult(paramsBuilder.build(), audioSelected, subtitleSelected)
     }


### PR DESCRIPTION
## Description
Fixes an issue when changing subtitles during playback if you had previously explicitly chosen subtitles for that item but not chosen an audio track.

### Related issues
I don't think there is a specific issue for this

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None