### PR TITLE
Fix remove series from next up

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
@@ -182,6 +182,7 @@ fun HomePage(
                                             overviewDialog = ItemDetailsDialogInfo(it)
                                         },
                                         onClearChosenStreams = {},
+                                        onClickRemoveFromNextUp = viewModel::removeFromNextUp,
                                     ),
                             )
                     }


### PR DESCRIPTION
## Description
Fixes the "Remove series from next up" context menu item not working at all.

Looks like after the refactoring in #1302, I missed [adding back the function call](https://github.com/damontecres/Wholphin/pull/1302/changes#diff-440f67bfe7be2011418c2f90e3a8ae2af05795a5161edd1a8bda14bc3b962cdcL175).

### Related issues
Fixes #1363

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None