### PR TITLE
Fix cleaning up APKs on debug build updates

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/UpdateChecker.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/UpdateChecker.kt
@@ -340,7 +340,7 @@ class UpdateChecker
                         context.contentResolver.delete(
                             MediaStore.Downloads.EXTERNAL_CONTENT_URI,
                             "${MediaStore.MediaColumns.DISPLAY_NAME} LIKE ? AND ${MediaStore.MediaColumns.MIME_TYPE} = ?",
-                            arrayOf(context.getString(R.string.app_name) + "%", APK_MIME_TYPE),
+                            arrayOf("$ASSET_NAME%", APK_MIME_TYPE),
                         )
                     Timber.i("Deleted $deletedRows rows")
                 } else {


### PR DESCRIPTION
## Description
Directly use "Wholphin" when searching for older APKs to clean up.

On debug builds, the `app_name` string is "Wholphin (Debug)" but the APK file names is always "Wholphin.apk", so I think the debug build won't clean them up.

### Related issues
Fixes #1368

### Testing
Testing downloading a few times without this change, applied the change, and clean up worked

## Screenshots
N/A

## AI or LLM usage
None