### PR TITLE
Add option for click to play continue watching/next up rows

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -226,6 +226,18 @@ sealed interface AppPreference<Pref, T> {
                 summaryOff = R.string.disabled,
             )
 
+        val HomeClickToPlay =
+            AppSwitchPreference<AppPreferences>(
+                title = R.string.continue_watching_click_behavior,
+                defaultValue = false,
+                getter = { it.homePagePreferences.clickToPlay },
+                setter = { prefs, value ->
+                    prefs.updateHomePagePreferences { clickToPlay = value }
+                },
+                summaryOn = R.string.continue_watching_click_summary_on,
+                summaryOff = R.string.continue_watching_click_summary_off,
+            )
+
         val PlayThemeMusic =
             AppChoicePreference<AppPreferences, ThemeSongVolume>(
                 title = R.string.play_theme_music,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
@@ -132,11 +132,18 @@ fun HomePage(
             var position by rememberPosition()
 
             val onFocusPosition = remember { { it: RowColumn -> position = it } }
+            val currentHomePrefs by rememberUpdatedState(preferences.appPreferences.homePagePreferences)
             val onClickItem =
                 remember {
                     { clickedPosition: RowColumn, item: BaseItem ->
                         position = clickedPosition
-                        viewModel.navigationManager.navigateTo(item.destination())
+                        if (currentHomePrefs.clickToPlay &&
+                            homeRows.getOrNull(clickedPosition.row)?.isContinueWatchingNextUp == true
+                        ) {
+                            viewModel.navigationManager.navigateTo(Destination.Playback(item))
+                        } else {
+                            viewModel.navigationManager.navigateTo(item.destination())
+                        }
                     }
                 }
             val onLongClickItem =
@@ -255,6 +262,14 @@ fun HomePage(
         }
     }
 }
+
+val HomeRowLoadingState?.isContinueWatchingNextUp: Boolean
+    get() =
+        (this as? HomeRowLoadingState.Success).let { row ->
+            row?.rowType is HomeRowConfig.ContinueWatching ||
+                row?.rowType is HomeRowConfig.NextUp ||
+                row?.rowType is HomeRowConfig.ContinueWatchingCombined
+        }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsGlobal.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsGlobal.kt
@@ -94,6 +94,18 @@ fun HomeSettingsGlobal(
                     modifier = Modifier,
                 )
             }
+            item {
+                ComposablePreference(
+                    preference = AppPreference.HomeClickToPlay,
+                    value = AppPreference.HomeClickToPlay.getter.invoke(preferences),
+                    onValueChange = {
+                        val newPrefs = AppPreference.HomeClickToPlay.setter.invoke(preferences, it)
+                        onPreferenceChange.invoke(newPrefs)
+                    },
+                    onNavigate = {},
+                    modifier = Modifier,
+                )
+            }
             item { HorizontalDivider() }
             item {
                 HomeSettingsListItem(

--- a/app/src/main/proto/WholphinDataStore.proto
+++ b/app/src/main/proto/WholphinDataStore.proto
@@ -94,6 +94,7 @@ message HomePagePreferences{
   bool enable_rewatching_next_up = 2;
   bool combine_continue_next = 3;
   int32 max_days_next_up = 4;
+  bool click_to_play = 5;
 }
 
 enum ThemeSongVolume {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -778,6 +778,9 @@
     <string name="skip_behavior_summary">For intros, credits, etc</string>
     <string name="play_with">Play with</string>
     <string name="transcoding">Transcoding</string>
+    <string name="continue_watching_click_behavior">Continue watching/Next up click behavior</string>
+    <string name="continue_watching_click_summary_on">Play on click</string>
+    <string name="continue_watching_click_summary_off">Show details on click</string>
     <array name="ass_subtitle_modes">
         <item>@string/ass_subtitle_mode_libass</item>
         <item>@string/ass_subtitle_mode_exoplayer</item>


### PR DESCRIPTION
## Description
Adds an option under Settings->Customize home page->Settings, "Continue watching/Next up click behavior":
- When disabled (the default), clicking goes to the item's details page
- When enabled, clicking starts playback for the item from its resume position

This only applies to the continue watching, next up, or combined rows. All other rows go to the details page no matter what.

### Related issues
Closes #1007

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None