### PR TITLE
Update media3 to 1.10.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ tvFoundation = "1.0.0"
 tvMaterial = "1.1.0-alpha01"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
-androidx-media3 = "1.10.0"
+androidx-media3 = "1.10.1"
 coil = "3.4.0"
 jellyfin-sdk = "1.7.1"
 nav3Core = "1.1.1"
@@ -45,7 +45,7 @@ kotlinxCoroutinesTest = "1.11.0"
 coreTesting = "2.2.0"
 openapi-generator = "7.22.0"
 runner = "1.7.0"
-wholphin-extensions = "0.1.2"
+wholphin-extensions = "0.1.3"
 
 [libraries]
 wholphin-extensions-mpv = { module = "com.github.damontecres.wholphin.mpv:wholphin-mpv", version.ref = "wholphin-extensions" }


### PR DESCRIPTION
Updates media3 to v1.10.1 & wholphin-extensions to v0.1.3

Fixes #1189
Fixes #1399
Replaces #1380