### PR TITLE
Added Release Date sort option to Music Video library

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/data/SortAndDirection.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/data/SortAndDirection.kt
@@ -61,6 +61,19 @@ val EpisodeSortOptions =
         ItemSortBy.RANDOM,
     )
 
+val MusicVideoSortOptions =
+    listOf(
+        ItemSortBy.SORT_NAME,
+        ItemSortBy.PREMIERE_DATE,
+        ItemSortBy.COMMUNITY_RATING,
+        ItemSortBy.CRITIC_RATING,
+        ItemSortBy.DATE_CREATED,
+        ItemSortBy.DATE_PLAYED,
+        ItemSortBy.PLAY_COUNT,
+        ItemSortBy.RUNTIME,
+        ItemSortBy.RANDOM,
+    )
+
 val VideoSortOptions =
     listOf(
         ItemSortBy.SORT_NAME,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
@@ -470,6 +470,29 @@ fun CollectionFolder(
             )
         }
 
+        CollectionType.MUSICVIDEOS -> {
+            CollectionFolderGeneric(
+                preferences,
+                destination.itemId,
+                usePosters = usePostersOverride ?: false,
+                recursive = recursiveOverride ?: false,
+                playEnabled = true,
+                modifier = modifier,
+                sortOptions = MusicVideoSortOptions,
+            )
+        }
+        
+        CollectionType.BOOKS -> {
+            CollectionFolderGeneric(
+                preferences,
+                destination.itemId,
+                usePosters = usePostersOverride ?: false,
+                recursive = recursiveOverride ?: false,
+                playEnabled = true,
+                modifier = modifier,
+            )
+        }
+
         CollectionType.HOMEVIDEOS,
         CollectionType.PHOTOS,
         -> {
@@ -477,19 +500,6 @@ fun CollectionFolder(
                 preferences = preferences,
                 itemId = destination.itemId,
                 recursive = recursiveOverride ?: false,
-                modifier = modifier,
-            )
-        }
-
-        CollectionType.MUSICVIDEOS,
-        CollectionType.BOOKS,
-        -> {
-            CollectionFolderGeneric(
-                preferences,
-                destination.itemId,
-                usePosters = usePostersOverride ?: false,
-                recursive = recursiveOverride ?: false,
-                playEnabled = true,
                 modifier = modifier,
             )
         }


### PR DESCRIPTION
## Description
- I noticed the `CollectionFolderGeneric` defaults to `VideoSortOptions` for Music Video Library.
- My best guess is that `VideoSortOptions` was missing `ItemSortBy.PREMIERE_DATE` which is why Release Date wasn't showing up as a sort option.
- So I created a dedicated `MusicVideoSortOptions` instead of modifying the shared `VideoSortOptions` to avoid affecting other collection types.

## AI/LLM usage
Used Claude to help find and diagnose the bug. Wrote the fix myself.