### PR TITLE
Fix bottom padding in playback controls

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/overlay/PlaybackController.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/overlay/PlaybackController.kt
@@ -10,9 +10,7 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -117,7 +115,7 @@ fun PlaybackController(
             }
 
             else -> {
-                Spacer(Modifier.height(32.dp))
+                Unit
             }
         }
     }


### PR DESCRIPTION
Fixes #1396.

The else branch of `when (nextState)` in PlaybackController added a 32dp Spacer that left empty space below the controls when there were no chapters or queue.

Possible follow-up: Pentaphon's idea of a "similar items" row in that empty slot. Happy to put up a separate PR if useful.

## Testing

Verified on an Android TV (1080p) AVD running API 34 by playing a movie with no chapters and no next-up item. With the fix, the bottom of the control overlay sits the expected 8dp from the screen edge (the existing parent padding). Also rebuilt without the fix and compared back-to-back to confirm the Spacer was the cause.

The CHAPTERS and QUEUE branches were not modified.

## Screenshot
<img width="1920" height="1080" alt="case1-controls" src="https://github.com/user-attachments/assets/18f50a87-a373-4f48-a9d4-f3c2a5cb2c00" />

## AI or LLM usage

I used Claude to help identify the file containing the bug and to suggest the fix. I reviewed the diff before committing.