### PR TITLE
Fix proguard for guava cache

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -8,3 +8,6 @@
   <methods>;
 }
 -dontwarn com.google.protobuf.**
+
+# TODO investigate using smaller scope
+-keep class com.google.common.cache.** { *; }


### PR DESCRIPTION
## Description
r8 optimizations seemingly cause guava's LocalCache to throw an AssertationError when evicting an entry. This PR adds a broad keep rule for the cache package.

The crash is reproducible on a release build with a TV Season that has 25+ episodes with people in them and scrolling through the episodes. It will crash when focusing on the ~25th episode.

### Related issues
Related to #1437 

### Testing
Emulator & nvidia shield

## Screenshots
N/A

## AI or LLM usage
None