### PR TITLE
Don't show home row w/ 404 Not Found

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
@@ -361,7 +361,7 @@ fun HomePageContent(
             ) {
                 LazyColumn(
                     state = listState,
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(0.dp),
                     contentPadding =
                         PaddingValues(
                             bottom = Cards.height2x3,
@@ -371,6 +371,10 @@ fun HomePageContent(
                             .focusRestorer(),
                 ) {
                     itemsIndexed(homeRows) { rowIndex, row ->
+                        val rowModifier =
+                            Modifier
+                                .animateItem()
+                                .padding(bottom = 8.dp)
                         CompositionLocalProvider(
                             LocalBringIntoViewSpec provides defaultBringIntoViewSpec,
                         ) {
@@ -381,7 +385,7 @@ fun HomePageContent(
                                     FocusableItemRow(
                                         title = r.title.getString(),
                                         subtitle = stringResource(R.string.loading),
-                                        modifier = Modifier.animateItem(),
+                                        modifier = rowModifier,
                                     )
                                 }
 
@@ -390,7 +394,7 @@ fun HomePageContent(
                                         title = r.title.getString(),
                                         subtitle = r.localizedMessage,
                                         isError = true,
-                                        modifier = Modifier.animateItem(),
+                                        modifier = rowModifier,
                                     )
                                 }
 
@@ -422,11 +426,10 @@ fun HomePageContent(
                                                     }
                                                 },
                                             modifier =
-                                                Modifier
+                                                rowModifier
                                                     .fillMaxWidth()
                                                     .focusGroup()
-                                                    .focusRequester(rowFocusRequesters[rowIndex])
-                                                    .animateItem(),
+                                                    .focusRequester(rowFocusRequesters[rowIndex]),
                                             horizontalPadding = viewOptions.spacing.dp,
                                             cardContent = { index, item, cardModifier, onClick, onLongClick ->
                                                 val onFocus =
@@ -502,7 +505,7 @@ fun HomePageContent(
                                         FocusableItemRow(
                                             title = r.title.getString(),
                                             subtitle = stringResource(R.string.no_results),
-                                            modifier = Modifier.animateItem(),
+                                            modifier = rowModifier,
                                         )
                                     }
                                 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomeViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomeViewModel.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+import org.jellyfin.sdk.api.client.exception.InvalidStatusException
 import org.jellyfin.sdk.model.api.BaseItemKind
 import timber.log.Timber
 import java.util.UUID
@@ -129,6 +130,25 @@ class HomeViewModel
                                                     limit = prefs.maxItemsPerRow,
                                                     isRefresh = refresh,
                                                 )
+                                            } catch (ex: InvalidStatusException) {
+                                                if (ex.status == 404) {
+                                                    Timber.w(ex, "404 on row %s", row)
+                                                    HomeRowLoadingState.Success(
+                                                        row.title,
+                                                        emptyList(),
+                                                    )
+                                                } else {
+                                                    Timber.e(
+                                                        ex,
+                                                        "Error %s on row %s",
+                                                        ex.status,
+                                                        row,
+                                                    )
+                                                    HomeRowLoadingState.Error(
+                                                        row.title,
+                                                        exception = ex,
+                                                    )
+                                                }
                                             } catch (ex: Exception) {
                                                 Timber.e(ex, "Error on row %s", row)
                                                 HomeRowLoadingState.Error(


### PR DESCRIPTION
## Description
If a home page row returns 404 Not Found, treat it as empty and don't show it.

It will still show as an error on home row settings, since this page doesn't hide empty rows.

Also fixes a bug where you can't scroll up if there are 3+ empty rows before the current row.

### Related issues
Closes #1469

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None