### PR TITLE
Only show view more card if row has more items

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
@@ -592,6 +592,7 @@ class HomeSettingsService
                         items = resume,
                         viewOptions = row.viewOptions,
                         rowType = row,
+                        showViewMore = resume.size >= limit,
                     )
                 }
 
@@ -611,6 +612,7 @@ class HomeSettingsService
                         items = nextUp,
                         viewOptions = row.viewOptions,
                         rowType = row,
+                        showViewMore = nextUp.size >= limit,
                     )
                 }
 
@@ -631,17 +633,14 @@ class HomeSettingsService
                             prefs.maxDaysNextUp,
                             row.viewOptions.useSeries,
                         )
+                    val combined = latestNextUpService.buildCombined(resume, nextUp)
 
                     Success(
                         title = ResStringProvider(R.string.continue_watching),
-                        items =
-                            latestNextUpService
-                                .buildCombined(
-                                    resume,
-                                    nextUp,
-                                ).take(limit),
+                        items = combined.take(limit),
                         viewOptions = row.viewOptions,
                         rowType = row,
+                        showViewMore = combined.size >= limit,
                     )
                 }
 
@@ -702,6 +701,7 @@ class HomeSettingsService
                         genres,
                         viewOptions = row.viewOptions,
                         rowType = row,
+                        showViewMore = genres.size >= limit,
                     )
                 }
 
@@ -753,6 +753,7 @@ class HomeSettingsService
                         title,
                         studios,
                         viewOptions = row.viewOptions,
+                        showViewMore = studios.size >= limit,
                     )
                 }
 
@@ -781,6 +782,7 @@ class HomeSettingsService
                                     it,
                                     row.viewOptions,
                                     rowType = row,
+                                    showViewMore = it.size >= limit,
                                 )
                             }
                     latest
@@ -835,6 +837,7 @@ class HomeSettingsService
                             it,
                             row.viewOptions,
                             rowType = row,
+                            showViewMore = it.size >= limit,
                         )
                     }
                 }
@@ -888,6 +891,7 @@ class HomeSettingsService
                             it,
                             row.viewOptions,
                             rowType = row,
+                            showViewMore = it.size >= limit,
                         )
                     }
                 }
@@ -925,6 +929,7 @@ class HomeSettingsService
                             it,
                             row.viewOptions,
                             rowType = row,
+                            showViewMore = it.size >= limit,
                         )
                     }
                 }
@@ -954,6 +959,7 @@ class HomeSettingsService
                                     title,
                                     it,
                                     row.viewOptions,
+                                    showViewMore = it.size >= limit,
                                 )
                             }
                     } else {
@@ -985,6 +991,7 @@ class HomeSettingsService
                                 it,
                                 row.viewOptions,
                                 rowType = row,
+                                showViewMore = it.size >= limit,
                             )
                         }
                     }
@@ -1020,6 +1027,7 @@ class HomeSettingsService
                             it,
                             row.viewOptions,
                             rowType = row,
+                            showViewMore = it.size >= limit,
                         )
                     }
                 }
@@ -1046,6 +1054,7 @@ class HomeSettingsService
                                 it,
                                 row.viewOptions,
                                 rowType = row,
+                                showViewMore = it.size >= limit,
                             )
                         }
                 }
@@ -1076,6 +1085,7 @@ class HomeSettingsService
                             it,
                             row.viewOptions,
                             rowType = row,
+                            showViewMore = it.size >= limit,
                         )
                     }
                 }
@@ -1108,6 +1118,7 @@ class HomeSettingsService
                                     suggestions.items,
                                     row.viewOptions,
                                     rowType = row,
+                                    showViewMore = suggestions.items.size >= limit,
                                 )
                             }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/ViewMoreCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/ViewMoreCard.kt
@@ -95,12 +95,15 @@ fun ViewMoreCard(
                     containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp),
                 ),
         ) {
-            Box {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.fillMaxSize(),
+            ) {
                 Icon(
                     imageVector = Icons.Default.ArrowForward,
                     tint = MaterialTheme.colorScheme.onSurface,
                     contentDescription = "View more",
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize(.66f),
                 )
             }
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
@@ -120,10 +120,12 @@ class RecommendedViewModel
                         viewModelScope.launchIO {
                             val result =
                                 try {
+                                    val items = execute(row, limit)
                                     HomeRowLoadingState.Success(
                                         title,
-                                        execute(row, limit),
+                                        items,
                                         viewOptions,
+                                        showViewMore = items.size >= limit,
                                     )
                                 } catch (ex: Exception) {
                                     Timber.e(ex, "Exception fetching %s", title)
@@ -172,6 +174,10 @@ class RecommendedViewModel
 
         private fun fetchSuggestions() {
             viewModelScope.launch(Dispatchers.IO) {
+                val limit =
+                    userPreferencesService
+                        .getCurrent()
+                        .appPreferences.homePagePreferences.maxItemsPerRow
                 val title = ResStringProvider(R.string.suggestions)
                 try {
                     suggestionService
@@ -188,6 +194,7 @@ class RecommendedViewModel
                                             title,
                                             resource.items,
                                             viewOptions,
+                                            showViewMore = resource.items.size >= limit,
                                         )
                                     }
 
@@ -196,6 +203,7 @@ class RecommendedViewModel
                                             title,
                                             emptyList(),
                                             viewOptions,
+                                            showViewMore = false,
                                         )
                                     }
                                 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionViewModel.kt
@@ -214,7 +214,11 @@ class CollectionViewModel
                                 val result =
                                     try {
                                         val pager = fetchItems(sort, filter, listOf(type))
-                                        HomeRowLoadingState.Success(title, pager)
+                                        HomeRowLoadingState.Success(
+                                            title,
+                                            pager,
+                                            showViewMore = false,
+                                        )
                                     } catch (ex: Exception) {
                                         Timber.e(
                                             ex,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
@@ -469,7 +469,7 @@ fun HomePageContent(
                                                             .onKeyEvent { onKey(it) },
                                                 )
                                             },
-                                            showViewMore = showViewMore,
+                                            showViewMore = showViewMore && row.showViewMore,
                                             viewMoreCardContent = { mod ->
                                                 HomePageViewMoreCard(
                                                     isEpisode = row.items.last()?.type == BaseItemKind.EPISODE,

--- a/app/src/main/java/com/github/damontecres/wholphin/util/LoadingState.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/LoadingState.kt
@@ -67,6 +67,7 @@ sealed interface HomeRowLoadingState {
         val items: List<BaseItem?>,
         val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
         val rowType: HomeRowConfig? = null,
+        val showViewMore: Boolean = true,
     ) : HomeRowLoadingState
 
     data class Error(


### PR DESCRIPTION
## Description
Only show the view more card at the end of row if there are actually more items (or at the limit).

Also reduces the size of the arrow a bit

### Related issues
Related to #1392 

### Testing
Emulator with different max items setting

## Screenshots
N/A

## AI or LLM usage
None