### PR TITLE
Fix combined search results losing keyboard focus when typing

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/SearchPage.kt
@@ -1017,7 +1017,6 @@ private fun <T : CardGridItem> SearchGrid(
     positionCallback: (columns: Int, position: Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    RequestOrRestoreFocus(focusRequester)
     Column(
         verticalArrangement = Arrangement.spacedBy(0.dp),
         modifier = modifier,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/SearchPage.kt
@@ -77,7 +77,6 @@ import com.github.damontecres.wholphin.services.SeerrService
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.ui.AspectRatios
 import com.github.damontecres.wholphin.ui.Cards
-import com.github.damontecres.wholphin.ui.RequestOrRestoreFocus
 import com.github.damontecres.wholphin.ui.SlimItemFields
 import com.github.damontecres.wholphin.ui.cards.DiscoverItemCard
 import com.github.damontecres.wholphin.ui.cards.EpisodeCard
@@ -405,7 +404,7 @@ fun SearchPage(
     var showViewOptions by rememberSaveable { mutableStateOf(false) }
 
     var position by rememberPosition(0, 0)
-    var searchClicked by rememberSaveable { mutableStateOf(false) }
+    var searchClicked by rememberSaveable(query) { mutableStateOf(false) }
     var immediateSearchQuery by rememberSaveable { mutableStateOf<String?>(null) }
 
     LifecycleResumeEffect(Unit) {


### PR DESCRIPTION
## Description
Minor tweak to prevent the keyboard from losing focus when typing search queries when "combine search results" is enabled

### Related issues
Fixes #1523

### Testing
Emulator only

## Screenshots
N/A

## AI or LLM usage
None
