### PR TITLE
Add Streamystats integration

### DIFF
--- a/app/schemas/com.github.damontecres.wholphin.data.AppDatabase/35.json
+++ b/app/schemas/com.github.damontecres.wholphin.data.AppDatabase/35.json
@@ -1,0 +1,795 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 35,
+    "identityHash": "00edfbdaab4d78440ff7b3b2b67194a5",
+    "entities": [
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT, `url` TEXT NOT NULL, `version` TEXT, `lastUsed` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUsed",
+            "columnName": "lastUsed",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT NOT NULL, `name` TEXT, `serverId` TEXT NOT NULL, `accessToken` TEXT, `pin` TEXT, `requireLogin` INTEGER NOT NULL DEFAULT false, `lastUsed` TEXT, `uiLanguage` TEXT, FOREIGN KEY(`serverId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessToken",
+            "columnName": "accessToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pin",
+            "columnName": "pin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "requireLogin",
+            "columnName": "requireLogin",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "lastUsed",
+            "columnName": "lastUsed",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uiLanguage",
+            "columnName": "uiLanguage",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_users_id_serverId",
+            "unique": true,
+            "columnNames": [
+              "id",
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_users_id_serverId` ON `${TABLE_NAME}` (`id`, `serverId`)"
+          },
+          {
+            "name": "index_users_id",
+            "unique": false,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_id` ON `${TABLE_NAME}` (`id`)"
+          },
+          {
+            "name": "index_users_serverId",
+            "unique": false,
+            "columnNames": [
+              "serverId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_users_serverId` ON `${TABLE_NAME}` (`serverId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ItemPlayback",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `userId` INTEGER NOT NULL, `itemId` TEXT NOT NULL, `sourceId` TEXT, `audioIndex` INTEGER NOT NULL, `subtitleIndex` INTEGER NOT NULL, FOREIGN KEY(`userId`) REFERENCES `users`(`rowId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioIndex",
+            "columnName": "audioIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleIndex",
+            "columnName": "subtitleIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ItemPlayback_userId_itemId",
+            "unique": true,
+            "columnNames": [
+              "userId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ItemPlayback_userId_itemId` ON `${TABLE_NAME}` (`userId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "rowId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "NavDrawerPinnedItem",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` INTEGER NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `order` INTEGER NOT NULL DEFAULT -1, PRIMARY KEY(`userId`, `itemId`), FOREIGN KEY(`userId`) REFERENCES `users`(`rowId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "itemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "rowId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "LibraryDisplayInfo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` INTEGER NOT NULL, `itemId` TEXT NOT NULL, `sort` TEXT NOT NULL, `direction` TEXT NOT NULL, `filter` TEXT NOT NULL DEFAULT '{}', `viewOptions` TEXT, PRIMARY KEY(`userId`, `itemId`), FOREIGN KEY(`userId`) REFERENCES `users`(`rowId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sort",
+            "columnName": "sort",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "direction",
+            "columnName": "direction",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filter",
+            "columnName": "filter",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'{}'"
+          },
+          {
+            "fieldPath": "viewOptions",
+            "columnName": "viewOptions",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_LibraryDisplayInfo_userId_itemId",
+            "unique": true,
+            "columnNames": [
+              "userId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_LibraryDisplayInfo_userId_itemId` ON `${TABLE_NAME}` (`userId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "rowId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_effects",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`jellyfinUserRowId` INTEGER NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `rotation` INTEGER NOT NULL, `brightness` INTEGER NOT NULL, `contrast` INTEGER NOT NULL, `saturation` INTEGER NOT NULL, `hue` INTEGER NOT NULL, `red` INTEGER NOT NULL, `green` INTEGER NOT NULL, `blue` INTEGER NOT NULL, `blur` INTEGER NOT NULL, PRIMARY KEY(`jellyfinUserRowId`, `itemId`, `type`))",
+        "fields": [
+          {
+            "fieldPath": "jellyfinUserRowId",
+            "columnName": "jellyfinUserRowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoFilter.rotation",
+            "columnName": "rotation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoFilter.brightness",
+            "columnName": "brightness",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoFilter.contrast",
+            "columnName": "contrast",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoFilter.saturation",
+            "columnName": "saturation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoFilter.hue",
+            "columnName": "hue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoFilter.red",
+            "columnName": "red",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoFilter.green",
+            "columnName": "green",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoFilter.blue",
+            "columnName": "blue",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoFilter.blur",
+            "columnName": "blur",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "jellyfinUserRowId",
+            "itemId",
+            "type"
+          ]
+        }
+      },
+      {
+        "tableName": "PlaybackLanguageChoice",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` INTEGER NOT NULL, `seriesId` TEXT NOT NULL, `itemId` TEXT, `audioLanguage` TEXT, `subtitleLanguage` TEXT, `subtitlesDisabled` INTEGER, PRIMARY KEY(`userId`, `seriesId`), FOREIGN KEY(`userId`) REFERENCES `users`(`rowId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioLanguage",
+            "columnName": "audioLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitleLanguage",
+            "columnName": "subtitleLanguage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitlesDisabled",
+            "columnName": "subtitlesDisabled",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "seriesId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "rowId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ItemTrackModification",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` INTEGER NOT NULL, `itemId` TEXT NOT NULL, `trackIndex` INTEGER NOT NULL, `delayMs` INTEGER NOT NULL, PRIMARY KEY(`userId`, `itemId`, `trackIndex`), FOREIGN KEY(`userId`) REFERENCES `users`(`rowId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackIndex",
+            "columnName": "trackIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "delayMs",
+            "columnName": "delayMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "itemId",
+            "trackIndex"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "rowId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "seerr_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT NOT NULL, `name` TEXT, `version` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_seerr_servers_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_seerr_servers_url` ON `${TABLE_NAME}` (`url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "seerr_users",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`jellyfinUserRowId` INTEGER NOT NULL, `serverId` INTEGER NOT NULL, `authMethod` TEXT NOT NULL, `username` TEXT, `password` TEXT, `credential` TEXT, PRIMARY KEY(`jellyfinUserRowId`, `serverId`), FOREIGN KEY(`serverId`) REFERENCES `seerr_servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`jellyfinUserRowId`) REFERENCES `users`(`rowId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "jellyfinUserRowId",
+            "columnName": "jellyfinUserRowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "serverId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authMethod",
+            "columnName": "authMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "credential",
+            "columnName": "credential",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "jellyfinUserRowId",
+            "serverId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "seerr_servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "serverId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "jellyfinUserRowId"
+            ],
+            "referencedColumns": [
+              "rowId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "RememberedTab",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` INTEGER NOT NULL, `itemId` TEXT NOT NULL, `index` INTEGER NOT NULL, PRIMARY KEY(`userId`, `itemId`), FOREIGN KEY(`userId`) REFERENCES `users`(`rowId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "userId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_RememberedTab_userId_itemId",
+            "unique": true,
+            "columnNames": [
+              "userId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_RememberedTab_userId_itemId` ON `${TABLE_NAME}` (`userId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "userId"
+            ],
+            "referencedColumns": [
+              "rowId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "streamystats_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`jellyfinUserRowId` INTEGER NOT NULL, `jellyfinServerId` TEXT NOT NULL, `serverUrl` TEXT NOT NULL, PRIMARY KEY(`jellyfinUserRowId`, `jellyfinServerId`), FOREIGN KEY(`jellyfinUserRowId`) REFERENCES `users`(`rowId`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`jellyfinServerId`) REFERENCES `servers`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "jellyfinUserRowId",
+            "columnName": "jellyfinUserRowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jellyfinServerId",
+            "columnName": "jellyfinServerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverUrl",
+            "columnName": "serverUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "jellyfinUserRowId",
+            "jellyfinServerId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_streamystats_settings_jellyfinUserRowId",
+            "unique": false,
+            "columnNames": [
+              "jellyfinUserRowId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_streamystats_settings_jellyfinUserRowId` ON `${TABLE_NAME}` (`jellyfinUserRowId`)"
+          },
+          {
+            "name": "index_streamystats_settings_jellyfinServerId",
+            "unique": false,
+            "columnNames": [
+              "jellyfinServerId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_streamystats_settings_jellyfinServerId` ON `${TABLE_NAME}` (`jellyfinServerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "users",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "jellyfinUserRowId"
+            ],
+            "referencedColumns": [
+              "rowId"
+            ]
+          },
+          {
+            "table": "servers",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "jellyfinServerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '00edfbdaab4d78440ff7b3b2b67194a5')"
+    ]
+  }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/data/AppDatabase.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/AppDatabase.kt
@@ -19,6 +19,7 @@ import com.github.damontecres.wholphin.data.model.PlaybackLanguageChoice
 import com.github.damontecres.wholphin.data.model.RememberedTab
 import com.github.damontecres.wholphin.data.model.SeerrServer
 import com.github.damontecres.wholphin.data.model.SeerrUser
+import com.github.damontecres.wholphin.data.model.StreamystatsSettings
 import com.github.damontecres.wholphin.ui.components.ViewOptions
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -48,8 +49,9 @@ import java.util.UUID
         SeerrServer::class,
         SeerrUser::class,
         RememberedTab::class,
+        StreamystatsSettings::class,
     ],
-    version = 34,
+    version = 35,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(3, 4),
@@ -67,6 +69,7 @@ import java.util.UUID
         AutoMigration(31, 32),
         AutoMigration(32, 33),
         AutoMigration(33, 34),
+        AutoMigration(34, 35),
     ],
 )
 @TypeConverters(Converters::class)
@@ -82,6 +85,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun playbackLanguageChoiceDao(): PlaybackLanguageChoiceDao
 
     abstract fun seerrServerDao(): SeerrServerDao
+
+    abstract fun streamystatsSettingsDao(): StreamystatsSettingsDao
 
     abstract fun playbackEffectDao(): PlaybackEffectDao
 

--- a/app/src/main/java/com/github/damontecres/wholphin/data/StreamystatsSettingsDao.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/StreamystatsSettingsDao.kt
@@ -1,0 +1,38 @@
+package com.github.damontecres.wholphin.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.github.damontecres.wholphin.data.model.StreamystatsSettings
+import java.util.UUID
+
+@Dao
+interface StreamystatsSettingsDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun set(settings: StreamystatsSettings)
+
+    @Query(
+        """
+        SELECT * FROM streamystats_settings
+        WHERE jellyfinUserRowId = :jellyfinUserRowId
+          AND jellyfinServerId = :jellyfinServerId
+        """,
+    )
+    suspend fun get(
+        jellyfinUserRowId: Int,
+        jellyfinServerId: UUID,
+    ): StreamystatsSettings?
+
+    @Query(
+        """
+        DELETE FROM streamystats_settings
+        WHERE jellyfinUserRowId = :jellyfinUserRowId
+          AND jellyfinServerId = :jellyfinServerId
+        """,
+    )
+    suspend fun delete(
+        jellyfinUserRowId: Int,
+        jellyfinServerId: UUID,
+    ): Int
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
@@ -16,6 +16,17 @@ import org.jellyfin.sdk.model.serializer.UUIDSerializer
 import java.util.UUID
 
 @Serializable
+enum class StreamystatsRecommendationType(
+    val queryValue: String,
+) {
+    @SerialName("Movie")
+    MOVIE("Movie"),
+
+    @SerialName("Series")
+    SERIES("Series"),
+}
+
+@Serializable
 sealed interface HomeRowConfig {
     val viewOptions: HomeRowViewOptions
 
@@ -192,6 +203,15 @@ sealed interface HomeRowConfig {
         override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
     ) : HomeRowConfig {
         override fun updateViewOptions(viewOptions: HomeRowViewOptions): GetItems = this.copy(viewOptions = viewOptions)
+    }
+
+    @Serializable
+    @SerialName("StreamystatsRecommendations")
+    data class StreamystatsRecommendations(
+        val recommendationType: StreamystatsRecommendationType,
+        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+    ) : HomeRowConfig {
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions): StreamystatsRecommendations = this.copy(viewOptions = viewOptions)
     }
 }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/StreamystatsSettings.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/StreamystatsSettings.kt
@@ -1,0 +1,43 @@
+@file:UseSerializers(UUIDSerializer::class)
+
+package com.github.damontecres.wholphin.data.model
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import org.jellyfin.sdk.model.serializer.UUIDSerializer
+import java.util.UUID
+
+/**
+ * Streamystats configuration for a single Jellyfin user on a single Jellyfin server.
+ */
+@Entity(
+    tableName = "streamystats_settings",
+    primaryKeys = ["jellyfinUserRowId", "jellyfinServerId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = JellyfinUser::class,
+            parentColumns = arrayOf("rowId"),
+            childColumns = arrayOf("jellyfinUserRowId"),
+            onDelete = ForeignKey.CASCADE,
+        ),
+        ForeignKey(
+            entity = JellyfinServer::class,
+            parentColumns = arrayOf("id"),
+            childColumns = arrayOf("jellyfinServerId"),
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index("jellyfinUserRowId"),
+        Index("jellyfinServerId"),
+    ],
+)
+@Serializable
+data class StreamystatsSettings(
+    val jellyfinUserRowId: Int,
+    val jellyfinServerId: UUID,
+    val serverUrl: String,
+)

--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -1009,6 +1009,13 @@ sealed interface AppPreference<Pref, T> {
                 setter = { prefs, _ -> prefs },
             )
 
+        val StreamystatsIntegration =
+            AppClickablePreference<AppPreferences>(
+                title = R.string.streamystats_integration,
+                getter = { },
+                setter = { prefs, _ -> prefs },
+            )
+
         val QuickConnect =
             AppClickablePreference<AppPreferences>(
                 title = R.string.quick_connect,
@@ -1125,6 +1132,7 @@ val basicPreferences =
                     if (BuildConfig.DISCOVER_ENABLED) {
                         add(AppPreference.SeerrIntegration)
                     }
+                    add(AppPreference.StreamystatsIntegration)
                     add(AppPreference.AdvancedSettings)
                 },
         ),

--- a/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
@@ -8,6 +8,7 @@ import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.HomePageSettings
 import com.github.damontecres.wholphin.data.model.HomeRowConfig
 import com.github.damontecres.wholphin.data.model.SUPPORTED_HOME_PAGE_SETTINGS_VERSION
+import com.github.damontecres.wholphin.data.model.StreamystatsRecommendationType
 import com.github.damontecres.wholphin.data.model.createGenreDestination
 import com.github.damontecres.wholphin.data.model.createStudioDestination
 import com.github.damontecres.wholphin.preferences.DefaultUserConfiguration
@@ -93,6 +94,8 @@ class HomeSettingsService
         private val latestNextUpService: LatestNextUpService,
         private val imageUrlService: ImageUrlService,
         private val suggestionService: SuggestionService,
+        private val streamystatsSettingsRepository: StreamystatsSettingsRepository,
+        private val streamystatsService: StreamystatsService,
         private val displayPreferencesService: DisplayPreferencesService,
     ) {
         @OptIn(ExperimentalSerializationApi::class)
@@ -263,6 +266,45 @@ class HomeSettingsService
         }
 
         /**
+         * Removes Streamystats rows from locally and remotely saved custom home settings.
+         *
+         * Default home settings are generated from the active Streamystats connection, so there
+         * is nothing to persist for the default case once the integration is removed.
+         */
+        suspend fun removeStreamystatsRowsForCurrentUser() {
+            val userId = serverRepository.currentUser?.id ?: return
+            removeStreamystatsRowsFromLocal(userId)
+            removeStreamystatsRowsFromServer(userId)
+        }
+
+        private suspend fun removeStreamystatsRowsFromLocal(userId: UUID) {
+            try {
+                val settings = loadFromLocal(userId) ?: return
+                val updated = settings.withoutStreamystatsRows()
+                if (updated != settings) {
+                    saveToLocal(userId, updated)
+                }
+            } catch (ex: Exception) {
+                Timber.w(ex, "Error removing Streamystats rows from local home settings")
+            }
+        }
+
+        private suspend fun removeStreamystatsRowsFromServer(userId: UUID) {
+            try {
+                val settings = loadFromServer(userId) ?: return
+                val updated = settings.withoutStreamystatsRows()
+                if (updated != settings) {
+                    saveToServer(userId, updated)
+                }
+            } catch (ex: Exception) {
+                Timber.w(ex, "Error removing Streamystats rows from remote home settings")
+            }
+        }
+
+        private fun HomePageSettings.withoutStreamystatsRows(): HomePageSettings =
+            copy(rows = rows.filterNot { it is HomeRowConfig.StreamystatsRecommendations })
+
+        /**
          * Create a default [HomePageResolvedSettings] using the available libraries
          */
         suspend fun createDefault(userId: UUID): HomePageResolvedSettings {
@@ -303,7 +345,24 @@ class HomeSettingsService
                         config = HomeRowConfig.ContinueWatchingCombined(),
                     ),
                 )
-            val rowConfig = continueWatchingRow + includedIds
+            val streamystatsRows =
+                if (streamystatsSettingsRepository.connection.value is StreamystatsConnectionStatus.Success) {
+                    listOf(
+                        HomeRowConfigDisplay(
+                            id = includedIds.size + 2,
+                            title = getStreamystatsRecommendationsTitle(StreamystatsRecommendationType.MOVIE),
+                            config = HomeRowConfig.StreamystatsRecommendations(StreamystatsRecommendationType.MOVIE),
+                        ),
+                        HomeRowConfigDisplay(
+                            id = includedIds.size + 3,
+                            title = getStreamystatsRecommendationsTitle(StreamystatsRecommendationType.SERIES),
+                            config = HomeRowConfig.StreamystatsRecommendations(StreamystatsRecommendationType.SERIES),
+                        ),
+                    )
+                } else {
+                    emptyList()
+                }
+            val rowConfig = continueWatchingRow + streamystatsRows + includedIds
             return HomePageResolvedSettings(rowConfig)
         }
 
@@ -536,6 +595,14 @@ class HomeSettingsService
                     )
                 }
 
+                is HomeRowConfig.StreamystatsRecommendations -> {
+                    HomeRowConfigDisplay(
+                        id = id,
+                        title = getStreamystatsRecommendationsTitle(config.recommendationType),
+                        config = config,
+                    )
+                }
+
                 is HomeRowConfig.Suggestions -> {
                     val title = getItemName(R.string.suggestions_for, config.parentId)
                     HomeRowConfigDisplay(
@@ -544,6 +611,12 @@ class HomeSettingsService
                         config,
                     )
                 }
+            }
+
+        private fun getStreamystatsRecommendationsTitle(type: StreamystatsRecommendationType): StringProvider =
+            when (type) {
+                StreamystatsRecommendationType.MOVIE -> ResStringProvider(R.string.streamystats_recommended_movies)
+                StreamystatsRecommendationType.SERIES -> ResStringProvider(R.string.streamystats_recommended_series)
             }
 
         private suspend fun getItemName(
@@ -1112,6 +1185,48 @@ class HomeSettingsService
                             rowType = row,
                             showViewMore = it.size >= limit,
                         )
+                    }
+                }
+
+                is HomeRowConfig.StreamystatsRecommendations -> {
+                    val title = getStreamystatsRecommendationsTitle(row.recommendationType)
+                    try {
+                        val ids =
+                            streamystatsService.getRecommendationIds(row.recommendationType, limit)
+                        if (ids.isEmpty()) {
+                            Success(
+                                title = title,
+                                items = emptyList(),
+                                viewOptions = row.viewOptions,
+                                rowType = row,
+                            )
+                        } else {
+                            val order = ids.mapIndexed { index, id -> id to index }.toMap()
+                            val request =
+                                GetItemsRequest(
+                                    userId = userDto.id,
+                                    ids = ids,
+                                    fields = DefaultItemFields,
+                                    enableImages = true,
+                                )
+                            GetItemsRequestHandler
+                                .execute(api, request)
+                                .content.items
+                                .sortedBy { order[it.id] ?: Int.MAX_VALUE }
+                                .map { BaseItem(it, row.viewOptions.useSeries) }
+                                .let {
+                                    Success(
+                                        title,
+                                        it,
+                                        row.viewOptions,
+                                        rowType = row,
+                                        showViewMore = ids.size >= limit,
+                                    )
+                                }
+                        }
+                    } catch (ex: Exception) {
+                        Timber.w(ex, "Error loading Streamystats row")
+                        HomeRowLoadingState.Error(title = title, exception = ex)
                     }
                 }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/services/StreamystatsService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/StreamystatsService.kt
@@ -1,0 +1,129 @@
+package com.github.damontecres.wholphin.services
+
+import com.github.damontecres.wholphin.data.ServerRepository
+import com.github.damontecres.wholphin.data.model.StreamystatsRecommendationType
+import com.github.damontecres.wholphin.services.hilt.AuthOkHttpClient
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.jellyfin.sdk.model.serializer.toUUIDOrNull
+import timber.log.Timber
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val MAX_STREAMYSTATS_ERROR_BODY_LOG_LENGTH = 500
+
+@Singleton
+class StreamystatsService
+    @Inject
+    constructor(
+        private val serverRepository: ServerRepository,
+        private val settingsRepository: StreamystatsSettingsRepository,
+        @param:AuthOkHttpClient private val okHttpClient: OkHttpClient,
+    ) {
+        private val json = Json { ignoreUnknownKeys = true }
+
+        /**
+         * Loads recommended Jellyfin item IDs from Streamystats.
+         *
+         * Endpoint shape mirrors Streamyfin's local client (`utils/streamystats/api.ts`)
+         * for Streamystats: https://github.com/fredrikburmester/streamystats
+         */
+        suspend fun getRecommendationIds(
+            type: StreamystatsRecommendationType,
+            limit: Int,
+        ): List<UUID> {
+            val settings =
+                (settingsRepository.connection.first() as? StreamystatsConnectionStatus.Success)
+                    ?.settings
+                    ?: return emptyList()
+            val jellyfinServerId = serverRepository.currentServer?.id ?: return emptyList()
+            return getRecommendationIds(settings.serverUrl, jellyfinServerId, type, limit)
+        }
+
+        suspend fun testConnection(serverUrl: String) {
+            val jellyfinServerId =
+                serverRepository.currentServer?.id
+                    ?: throw IllegalStateException("No Jellyfin server selected")
+            getRecommendationIds(serverUrl, jellyfinServerId, StreamystatsRecommendationType.MOVIE, 1)
+        }
+
+        private fun getRecommendationIds(
+            serverUrl: String,
+            jellyfinServerId: UUID,
+            type: StreamystatsRecommendationType,
+            limit: Int,
+        ): List<UUID> {
+            val url =
+                serverUrl
+                    .toHttpUrl()
+                    .newBuilder()
+                    .addPathSegment("api")
+                    .addPathSegment("recommendations")
+                    .addQueryParameter("jellyfinServerId", jellyfinServerId.toJellyfinServerId())
+                    .addQueryParameter("format", "ids")
+                    .addQueryParameter("type", type.queryValue)
+                    .addQueryParameter("limit", limit.toString())
+                    .addQueryParameter("includeBasedOn", "false")
+                    .addQueryParameter("includeReasons", "false")
+                    .build()
+            Timber.d(
+                "Calling Streamystats recommendations endpoint: GET %s; configuredUrl=%s",
+                url,
+                serverUrl,
+            )
+            val request =
+                Request
+                    .Builder()
+                    .url(url)
+                    .get()
+                    .build()
+            return okHttpClient.newCall(request).execute().use { response ->
+                val body = response.body.string()
+                if (!response.isSuccessful) {
+                    Timber.w(
+                        "Streamystats recommendations request failed: status=%s url=%s body=%s",
+                        response.code,
+                        url,
+                        body.take(MAX_STREAMYSTATS_ERROR_BODY_LOG_LENGTH),
+                    )
+                    throw StreamystatsApiException(response.code)
+                }
+                val ids =
+                    json
+                        .decodeFromString<StreamystatsRecommendationIdsResponse>(body)
+                        .data
+                        .idsFor(type)
+                ids.mapNotNull { it.toUUIDOrNull() }
+            }
+        }
+    }
+
+@Serializable
+private data class StreamystatsRecommendationIdsResponse(
+    val data: StreamystatsRecommendationIds = StreamystatsRecommendationIds(),
+)
+
+@Serializable
+private data class StreamystatsRecommendationIds(
+    val movies: List<String> = emptyList(),
+    val series: List<String> = emptyList(),
+) {
+    fun idsFor(type: StreamystatsRecommendationType): List<String> =
+        when (type) {
+            StreamystatsRecommendationType.MOVIE -> movies
+            StreamystatsRecommendationType.SERIES -> series
+        }
+}
+
+// Jellyfin exposes PublicSystemInfo.Id as a 32-character hex string. Wholphin stores
+// the same value as UUID, so convert it back before calling Streamystats.
+private fun UUID.toJellyfinServerId(): String = toString().replace("-", "")
+
+class StreamystatsApiException(
+    val statusCode: Int,
+) : RuntimeException("HTTP $statusCode from Streamystats")

--- a/app/src/main/java/com/github/damontecres/wholphin/services/StreamystatsSettingsRepository.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/StreamystatsSettingsRepository.kt
@@ -1,0 +1,115 @@
+package com.github.damontecres.wholphin.services
+
+import com.github.damontecres.wholphin.data.ServerRepository
+import com.github.damontecres.wholphin.data.StreamystatsSettingsDao
+import com.github.damontecres.wholphin.data.model.StreamystatsSettings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Reads Streamystats settings for the currently signed-in Jellyfin user.
+ *
+ * The source boundary is intentionally small so a future Jellyfin-plugin source can be checked
+ * before the local Room source without changing Streamystats API calls or home row rendering.
+ */
+interface StreamystatsSettingsSource {
+    suspend fun getCurrentSettings(): StreamystatsSettings?
+}
+
+@Singleton
+class LocalStreamystatsSettingsSource
+    @Inject
+    constructor(
+        private val streamystatsSettingsDao: StreamystatsSettingsDao,
+        private val serverRepository: ServerRepository,
+    ) : StreamystatsSettingsSource {
+        override suspend fun getCurrentSettings(): StreamystatsSettings? {
+            val current = serverRepository.current.value ?: return null
+            return streamystatsSettingsDao.get(
+                jellyfinUserRowId = current.user.rowId,
+                jellyfinServerId = current.server.id,
+            )
+        }
+    }
+
+@Singleton
+class StreamystatsSettingsRepository
+    @Inject
+    constructor(
+        private val streamystatsSettingsDao: StreamystatsSettingsDao,
+        private val serverRepository: ServerRepository,
+        private val localSource: LocalStreamystatsSettingsSource,
+    ) {
+        private val _connection =
+            MutableStateFlow<StreamystatsConnectionStatus>(StreamystatsConnectionStatus.NotConfigured)
+        val connection: StateFlow<StreamystatsConnectionStatus> = _connection
+
+        val active = connection.map { it is StreamystatsConnectionStatus.Success }
+
+        suspend fun loadForCurrentUser() {
+            val settings = localSource.getCurrentSettings()
+            _connection.update {
+                settings?.let { StreamystatsConnectionStatus.Success(it) }
+                    ?: StreamystatsConnectionStatus.NotConfigured
+            }
+        }
+
+        fun clear() {
+            _connection.update { StreamystatsConnectionStatus.NotConfigured }
+        }
+
+        suspend fun setServerUrl(url: String) {
+            val current = serverRepository.current.value ?: return
+            val settings =
+                StreamystatsSettings(
+                    jellyfinUserRowId = current.user.rowId,
+                    jellyfinServerId = current.server.id,
+                    serverUrl = normalizeStreamystatsUrl(url),
+                )
+            streamystatsSettingsDao.set(settings)
+            _connection.update { StreamystatsConnectionStatus.Success(settings) }
+        }
+
+        suspend fun removeForCurrentUser(): Boolean {
+            val current = serverRepository.current.value ?: return false
+            val rows =
+                streamystatsSettingsDao.delete(
+                    jellyfinUserRowId = current.user.rowId,
+                    jellyfinServerId = current.server.id,
+                )
+            clear()
+            return rows > 0
+        }
+    }
+
+sealed interface StreamystatsConnectionStatus {
+    data object NotConfigured : StreamystatsConnectionStatus
+
+    data class Success(
+        val settings: StreamystatsSettings,
+    ) : StreamystatsConnectionStatus
+}
+
+fun normalizeStreamystatsUrl(url: String): String {
+    val trimmed = url.trim()
+    if (trimmed.isBlank()) {
+        throw IllegalArgumentException("URL is blank")
+    }
+    val withScheme =
+        if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+            trimmed
+        } else {
+            "http://$trimmed"
+        }
+    return withScheme
+        .toHttpUrl()
+        .newBuilder()
+        .build()
+        .toString()
+        .removeSuffix("/")
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/services/UserSwitchListener.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/UserSwitchListener.kt
@@ -33,6 +33,7 @@ class UserSwitchListener
         private val seerrServerRepository: SeerrServerRepository,
         private val seerrServerDao: SeerrServerDao,
         private val seerrApi: SeerrApi,
+        private val streamystatsSettingsRepository: StreamystatsSettingsRepository,
         private val homeSettingsService: HomeSettingsService,
     ) {
         init {
@@ -41,6 +42,7 @@ class UserSwitchListener
                 serverRepository.currentUserFlow.collect { user ->
                     Timber.d("New user")
                     seerrServerRepository.clear()
+                    streamystatsSettingsRepository.clear()
                     homeSettingsService.currentSettings.update { HomePageResolvedSettings.EMPTY }
                     if (user != null) {
                         switchUser(user)
@@ -62,6 +64,7 @@ class UserSwitchListener
 
                 // Check for home settings
                 launchIO {
+                    streamystatsSettingsRepository.loadForCurrentUser()
                     homeSettingsService.loadCurrentSettings(user.id)
                 }
                 if (BuildConfig.DISCOVER_ENABLED) {

--- a/app/src/main/java/com/github/damontecres/wholphin/services/hilt/DatabaseModule.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/hilt/DatabaseModule.kt
@@ -19,6 +19,7 @@ import com.github.damontecres.wholphin.data.PlaybackLanguageChoiceDao
 import com.github.damontecres.wholphin.data.RememberedTabDao
 import com.github.damontecres.wholphin.data.SeerrServerDao
 import com.github.damontecres.wholphin.data.ServerPreferencesDao
+import com.github.damontecres.wholphin.data.StreamystatsSettingsDao
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.AppPreferencesSerializer
 import dagger.Module
@@ -70,6 +71,10 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun seerrServerDao(db: AppDatabase): SeerrServerDao = db.seerrServerDao()
+
+    @Provides
+    @Singleton
+    fun streamystatsSettingsDao(db: AppDatabase): StreamystatsSettingsDao = db.streamystatsSettingsDao()
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsAddRow.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsAddRow.kt
@@ -23,6 +23,7 @@ import com.github.damontecres.wholphin.ui.ifElse
 fun HomeSettingsAddRow(
     libraries: List<Library>,
     showDiscover: Boolean,
+    showStreamystats: Boolean,
     onClick: (Library) -> Unit,
     onClickMeta: (MetaRowType) -> Unit,
     modifier: Modifier,
@@ -93,6 +94,21 @@ fun HomeSettingsAddRow(
                     )
                 }
             }
+            if (showStreamystats) {
+                itemsIndexed(
+                    listOf(
+                        MetaRowType.STREAMYSTATS_MOVIES,
+                        MetaRowType.STREAMYSTATS_SERIES,
+                    ),
+                ) { _, type ->
+                    HomeSettingsListItem(
+                        selected = false,
+                        headlineText = stringResource(type.stringId),
+                        onClick = { onClickMeta.invoke(type) },
+                        modifier = Modifier,
+                    )
+                }
+            }
         }
     }
 }
@@ -107,4 +123,6 @@ enum class MetaRowType(
     DISCOVER(R.string.discover),
     COLLECTION(R.string.collection),
     PLAYLIST(R.string.playlist),
+    STREAMYSTATS_MOVIES(R.string.streamystats_recommended_movies),
+    STREAMYSTATS_SERIES(R.string.streamystats_recommended_series),
 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsPage.kt
@@ -68,6 +68,7 @@ fun HomeSettingsPage(
     var position by rememberPosition(0, 0)
     // TODO discover rows
     val discoverEnabled = false // by viewModel.discoverEnabled.collectAsState(false)
+    val streamystatsEnabled by viewModel.streamystatsEnabled.collectAsState(false)
 
     // Adds a row, waits until its done loading, then scrolls to the new row
     fun addRow(
@@ -144,6 +145,7 @@ fun HomeSettingsPage(
                                 HomeSettingsAddRow(
                                     libraries = state.libraries,
                                     showDiscover = discoverEnabled,
+                                    showStreamystats = streamystatsEnabled,
                                     onClick = { backStack.add(ChooseRowType(it)) },
                                     onClickMeta = {
                                         when (it) {
@@ -160,6 +162,12 @@ fun HomeSettingsPage(
 
                                             MetaRowType.DISCOVER -> {
                                                 backStack.add(HomeSettingsDestination.ChooseDiscover)
+                                            }
+
+                                            MetaRowType.STREAMYSTATS_MOVIES,
+                                            MetaRowType.STREAMYSTATS_SERIES,
+                                            -> {
+                                                addRow { viewModel.addRow(it) }
                                             }
 
                                             MetaRowType.COLLECTION -> {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
@@ -22,6 +22,7 @@ import com.github.damontecres.wholphin.data.model.HomeRowConfig.TvChannels
 import com.github.damontecres.wholphin.data.model.HomeRowConfig.TvPrograms
 import com.github.damontecres.wholphin.data.model.HomeRowViewOptions
 import com.github.damontecres.wholphin.data.model.SUPPORTED_HOME_PAGE_SETTINGS_VERSION
+import com.github.damontecres.wholphin.data.model.StreamystatsRecommendationType
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.HomePageResolvedSettings
@@ -29,6 +30,7 @@ import com.github.damontecres.wholphin.services.HomeRowConfigDisplay
 import com.github.damontecres.wholphin.services.HomeSettingsService
 import com.github.damontecres.wholphin.services.NavDrawerService
 import com.github.damontecres.wholphin.services.SeerrServerRepository
+import com.github.damontecres.wholphin.services.StreamystatsSettingsRepository
 import com.github.damontecres.wholphin.services.UnsupportedHomeSettingsVersionException
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.services.hilt.IoCoroutineScope
@@ -79,6 +81,7 @@ class HomeSettingsViewModel
         private val navDrawerService: NavDrawerService,
         private val backdropService: BackdropService,
         private val seerrServerRepository: SeerrServerRepository,
+        private val streamystatsSettingsRepository: StreamystatsSettingsRepository,
         val preferencesDataStore: DataStore<AppPreferences>,
         @param:IoCoroutineScope private val ioScope: CoroutineScope,
     ) : ViewModel() {
@@ -88,6 +91,7 @@ class HomeSettingsViewModel
         private var idCounter by Delegates.notNull<Int>()
 
         val discoverEnabled = seerrServerRepository.active
+        val streamystatsEnabled = streamystatsSettingsRepository.active
 
         private var originalLocalSettings: HomePageSettings? = null
         private var originalRemoteSettings: HomePageSettings? = null
@@ -257,6 +261,22 @@ class HomeSettingsViewModel
 
                         MetaRowType.DISCOVER -> {
                             TODO()
+                        }
+
+                        MetaRowType.STREAMYSTATS_MOVIES -> {
+                            HomeRowConfigDisplay(
+                                id = id,
+                                title = ResStringProvider(R.string.streamystats_recommended_movies),
+                                config = HomeRowConfig.StreamystatsRecommendations(StreamystatsRecommendationType.MOVIE),
+                            )
+                        }
+
+                        MetaRowType.STREAMYSTATS_SERIES -> {
+                            HomeRowConfigDisplay(
+                                id = id,
+                                title = ResStringProvider(R.string.streamystats_recommended_series),
+                                config = HomeRowConfig.StreamystatsRecommendations(StreamystatsRecommendationType.SERIES),
+                            )
                         }
                     }
                 updateState {
@@ -732,6 +752,15 @@ class HomeSettingsViewModel
 
                                 is HomeRowConfig.GetItems -> {
                                     it.config
+                                }
+
+                                is HomeRowConfig.StreamystatsRecommendations -> {
+                                    val viewOptions =
+                                        when (it.config.recommendationType) {
+                                            StreamystatsRecommendationType.MOVIE -> preset.movieLibrary
+                                            StreamystatsRecommendationType.SERIES -> preset.tvLibrary
+                                        }
+                                    it.config.updateViewOptions(viewOptions)
                                 }
 
                                 is RecentlyAdded -> {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesContent.kt
@@ -59,6 +59,7 @@ import com.github.damontecres.wholphin.preferences.screensaverPreferences
 import com.github.damontecres.wholphin.preferences.updatePlaybackPreferences
 import com.github.damontecres.wholphin.services.Release
 import com.github.damontecres.wholphin.services.SeerrConnectionStatus
+import com.github.damontecres.wholphin.services.StreamystatsConnectionStatus
 import com.github.damontecres.wholphin.services.UpdateChecker
 import com.github.damontecres.wholphin.ui.components.ConfirmDialog
 import com.github.damontecres.wholphin.ui.components.ErrorMessage
@@ -74,6 +75,8 @@ import com.github.damontecres.wholphin.ui.setup.ReleaseNotes
 import com.github.damontecres.wholphin.ui.setup.UpdateViewModel
 import com.github.damontecres.wholphin.ui.setup.seerr.AddSeerServerDialog
 import com.github.damontecres.wholphin.ui.setup.seerr.SwitchSeerrViewModel
+import com.github.damontecres.wholphin.ui.setup.streamystats.StreamystatsSettingsDialog
+import com.github.damontecres.wholphin.ui.setup.streamystats.SwitchStreamystatsViewModel
 import com.github.damontecres.wholphin.ui.showToast
 import com.github.damontecres.wholphin.ui.tryRequestFocus
 import com.github.damontecres.wholphin.util.DataLoadingState
@@ -91,6 +94,7 @@ fun PreferencesContent(
     viewModel: PreferencesViewModel = hiltViewModel(),
     updateVM: UpdateViewModel = hiltViewModel(),
     seerrVm: SwitchSeerrViewModel = hiltViewModel(),
+    streamystatsVm: SwitchStreamystatsViewModel = hiltViewModel(),
     onFocus: (Int, Int) -> Unit = { _, _ -> },
 ) {
     val context = LocalContext.current
@@ -107,6 +111,10 @@ fun PreferencesContent(
 
     var cacheUsage by remember { mutableStateOf(CacheUsage(0, 0, 0)) }
     val seerrConnection by viewModel.seerrConnection.collectAsState()
+    val streamystatsConnection by streamystatsVm.connection.collectAsState()
+    var streamystatsDialogMode by remember {
+        mutableStateOf<StreamystatsDialogMode>(StreamystatsDialogMode.None)
+    }
     var seerrDialogMode by remember { mutableStateOf<SeerrDialogMode>(SeerrDialogMode.None) }
     var showQuickConnectDialog by remember { mutableStateOf(false) }
     var showLocaleChoiceDialog by remember { mutableStateOf(false) }
@@ -481,6 +489,33 @@ fun PreferencesContent(
                                     )
                                 }
 
+                                AppPreference.StreamystatsIntegration -> {
+                                    ClickPreference(
+                                        title = stringResource(pref.title),
+                                        onClick = {
+                                            streamystatsVm.resetStatus()
+                                            streamystatsDialogMode =
+                                                when (val conn = streamystatsConnection) {
+                                                    StreamystatsConnectionStatus.NotConfigured -> {
+                                                        StreamystatsDialogMode.Add
+                                                    }
+
+                                                    is StreamystatsConnectionStatus.Success -> {
+                                                        StreamystatsDialogMode.Remove(conn.settings.serverUrl)
+                                                    }
+                                                }
+                                        },
+                                        modifier = focusModifier,
+                                        summary =
+                                            when (val conn = streamystatsConnection) {
+                                                StreamystatsConnectionStatus.NotConfigured -> stringResource(R.string.add_server)
+                                                is StreamystatsConnectionStatus.Success -> conn.settings.serverUrl
+                                            },
+                                        onLongClick = {},
+                                        interactionSource = interactionSource,
+                                    )
+                                }
+
                                 AppPreference.QuickConnect -> {
                                     ClickPreference(
                                         title = stringResource(pref.title),
@@ -680,6 +715,31 @@ fun PreferencesContent(
 
             SeerrDialogMode.None -> {}
         }
+        when (val mode = streamystatsDialogMode) {
+            StreamystatsDialogMode.Add -> {
+                val status by streamystatsVm.status.collectAsState(LoadingState.Pending)
+                StreamystatsSettingsDialog(
+                    currentUrl = null,
+                    status = status,
+                    onSubmit = streamystatsVm::submitServer,
+                    onDismissRequest = { streamystatsDialogMode = StreamystatsDialogMode.None },
+                )
+            }
+
+            is StreamystatsDialogMode.Remove -> {
+                ConfirmDialog(
+                    title = stringResource(R.string.remove_streamystats_server),
+                    body = mode.serverUrl,
+                    onCancel = { streamystatsDialogMode = StreamystatsDialogMode.None },
+                    onConfirm = {
+                        streamystatsVm.removeServer()
+                        streamystatsDialogMode = StreamystatsDialogMode.None
+                    },
+                )
+            }
+
+            StreamystatsDialogMode.None -> {}
+        }
     }
 
     if (showQuickConnectDialog) {
@@ -781,6 +841,16 @@ data class CacheUsage(
     val imageMemoryMax: Long,
     val imageDiskUsed: Long,
 )
+
+private sealed interface StreamystatsDialogMode {
+    data object None : StreamystatsDialogMode
+
+    data object Add : StreamystatsDialogMode
+
+    data class Remove(
+        val serverUrl: String,
+    ) : StreamystatsDialogMode
+}
 
 private sealed interface SeerrDialogMode {
     data object None : SeerrDialogMode

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/setup/streamystats/StreamystatsSettingsDialog.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/setup/streamystats/StreamystatsSettingsDialog.kt
@@ -1,0 +1,136 @@
+package com.github.damontecres.wholphin.ui.setup.streamystats
+
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import com.github.damontecres.wholphin.R
+import com.github.damontecres.wholphin.ui.components.BasicDialog
+import com.github.damontecres.wholphin.ui.components.EditTextBox
+import com.github.damontecres.wholphin.ui.components.TextButton
+import com.github.damontecres.wholphin.ui.isNotNullOrBlank
+import com.github.damontecres.wholphin.ui.tryRequestFocus
+import com.github.damontecres.wholphin.util.LoadingState
+
+@Composable
+fun StreamystatsSettingsDialog(
+    currentUrl: String?,
+    status: LoadingState,
+    onSubmit: (url: String) -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    LaunchedEffect(status) {
+        if (status is LoadingState.Success) {
+            onDismissRequest.invoke()
+        }
+    }
+    BasicDialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        StreamystatsSettingsDialogContent(
+            currentUrl = currentUrl.orEmpty(),
+            status = status,
+            onSubmit = onSubmit,
+            modifier = Modifier.widthIn(min = 360.dp),
+        )
+    }
+}
+
+@Composable
+private fun StreamystatsSettingsDialogContent(
+    currentUrl: String,
+    status: LoadingState,
+    onSubmit: (url: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var error by remember(status) { mutableStateOf((status as? LoadingState.Error)?.localizedMessage) }
+    var url by remember(currentUrl) { mutableStateOf(currentUrl) }
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.tryRequestFocus() }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier =
+            modifier
+                .focusGroup()
+                .padding(16.dp)
+                .wrapContentSize(),
+    ) {
+        Text(
+            text = stringResource(R.string.streamystats_integration),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Text(
+                text = stringResource(R.string.url),
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier =
+                    Modifier
+                        .width(90.dp)
+                        .padding(end = 8.dp),
+            )
+            EditTextBox(
+                value = url,
+                onValueChange = {
+                    error = null
+                    url = it
+                },
+                keyboardOptions =
+                    KeyboardOptions(
+                        capitalization = KeyboardCapitalization.None,
+                        autoCorrectEnabled = false,
+                        keyboardType = KeyboardType.Uri,
+                        imeAction = ImeAction.Go,
+                    ),
+                keyboardActions = KeyboardActions(onGo = { onSubmit.invoke(url) }),
+                isInputValid = { true },
+                modifier = Modifier.focusRequester(focusRequester),
+            )
+        }
+        error?.let {
+            Text(
+                text = it,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.titleLarge,
+            )
+        }
+        TextButton(
+            stringRes = R.string.submit,
+            onClick = { onSubmit.invoke(url) },
+            enabled = status !is LoadingState.Loading && url.isNotNullOrBlank(),
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
+    }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/setup/streamystats/SwitchStreamystatsViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/setup/streamystats/SwitchStreamystatsViewModel.kt
@@ -1,0 +1,62 @@
+package com.github.damontecres.wholphin.ui.setup.streamystats
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.damontecres.wholphin.data.ServerRepository
+import com.github.damontecres.wholphin.services.HomeSettingsService
+import com.github.damontecres.wholphin.services.StreamystatsService
+import com.github.damontecres.wholphin.services.StreamystatsSettingsRepository
+import com.github.damontecres.wholphin.services.normalizeStreamystatsUrl
+import com.github.damontecres.wholphin.ui.launchIO
+import com.github.damontecres.wholphin.util.LoadingState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class SwitchStreamystatsViewModel
+    @Inject
+    constructor(
+        val streamystatsSettingsRepository: StreamystatsSettingsRepository,
+        private val streamystatsService: StreamystatsService,
+        private val serverRepository: ServerRepository,
+        private val homeSettingsService: HomeSettingsService,
+    ) : ViewModel() {
+        val connection = streamystatsSettingsRepository.connection
+        val status = MutableStateFlow<LoadingState>(LoadingState.Pending)
+
+        fun submitServer(url: String) {
+            viewModelScope.launchIO {
+                status.update { LoadingState.Loading }
+                try {
+                    val normalizedUrl = normalizeStreamystatsUrl(url)
+                    streamystatsService.testConnection(normalizedUrl)
+                    streamystatsSettingsRepository.setServerUrl(normalizedUrl)
+                    reloadHomeSettings()
+                    status.update { LoadingState.Success }
+                } catch (ex: IllegalArgumentException) {
+                    status.update { LoadingState.Error("Invalid URL", ex) }
+                } catch (ex: Exception) {
+                    status.update { LoadingState.Error(ex) }
+                }
+            }
+        }
+
+        fun removeServer() {
+            viewModelScope.launchIO {
+                streamystatsSettingsRepository.removeForCurrentUser()
+                homeSettingsService.removeStreamystatsRowsForCurrentUser()
+                reloadHomeSettings()
+                status.update { LoadingState.Pending }
+            }
+        }
+
+        private suspend fun reloadHomeSettings() {
+            serverRepository.currentUser?.let { homeSettingsService.loadCurrentSettings(it.id) }
+        }
+
+        fun resetStatus() {
+            status.update { LoadingState.Pending }
+        }
+    }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -472,7 +472,11 @@
     <string name="request">Request</string>
     <string name="pending">Pending</string>
     <string name="seerr_integration">Seerr integration</string>
+    <string name="streamystats_integration">Streamystats integration</string>
+    <string name="streamystats_recommended_movies">Recommended Movies (Streamystats)</string>
+    <string name="streamystats_recommended_series">Recommended Shows (Streamystats)</string>
     <string name="remove_seerr_server">Remove Seerr Server</string>
+    <string name="remove_streamystats_server">Remove Streamystats Server</string>
     <string name="seerr_server_added">Seerr server added</string>
     <string name="quick_connect">Quick Connect</string>
     <string name="quick_connect_summary">Authorize another device to log in to your account</string>


### PR DESCRIPTION
## Description

Streamystats (https://github.com/fredrikburmester/streamystats) is a Jellyfin companion service that tracks user watch history and provides AI-based recommendations for each user.

This PR adds a Streamystats integration to the settings dialog. The server URL is stored per Jellyfin user/server and is tested before saving. This setting is already behind a small repository/source layer, so this should make it straightforward to load the config from the Wholphin Jellyfin plugin later on. The existing Seerr integration was used as a reference for the implementation of the settings dialog.

When Streamystats is configured, Wholphin can show two new home rows:

- Recommended Movies (Streamystats)
- Recommended Shows (Streamystats)

The Streamystats rows are available in the home layout editor. If no custom home layout is configured, they are automatically added to the default home layout while the Streamystats integration is active.

Removing the integration also removes saved Streamystats rows from custom home settings.

Streamystats also exposes promoted/seasonal watchlists (Christmas, Halloween,...). I left those out of this PR because they need a separate change to how Wholphin expands home layout rows.

### Related issues

None

### Testing

Tested locally with my Jellyfin server and Streamystats instance inside an AndroidTV emulator.

Checked:

- adding a valid Streamystats URL
- rejecting invalid/unreachable URLs
- loading movie recommendations
- loading show recommendations
- adding Streamystats rows in the home layout editor
- removing the integration again
- empty recommendation results

## Screenshots

<img width="974" height="573" alt="Screenshot from 2026-06-10 17-59-44" src="https://github.com/user-attachments/assets/189230b4-934e-45e5-9391-6f77f1ddcb0b" />

<img width="372" height="554" alt="Screenshot from 2026-06-10 18-02-33" src="https://github.com/user-attachments/assets/3c23f49d-fbdd-49fe-b7bf-d2a23e5e76f1" />

<img width="372" height="554" alt="Screenshot from 2026-06-10 18-02-17" src="https://github.com/user-attachments/assets/a7be0ffe-eaa7-4d8f-9266-16d5a24d6a3d" />

## AI or LLM usage

AI assistance was used during implementation. I reviewed the changes myself and tested them locally as described above.