### PR TITLE
Guard back-stack serialization to avoid crash in onSaveInstanceState

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
@@ -151,10 +151,22 @@ class MainActivity : AppCompatActivity() {
         lifecycle.addObserver(playbackLifecycleObserver)
 
         val backStackStr = savedInstanceState?.getString(KEY_BACK_STACK)
-        if (backStackStr != null) {
+        val restoredBackStack =
+            if (backStackStr != null) {
+                try {
+                    json.decodeFromString<List<Destination>>(backStackStr)
+                } catch (ex: Exception) {
+                    // Best-effort: a previously persisted back stack we can no longer decode
+                    // must not crash startup; fall back to a fresh start destination.
+                    Timber.w(ex, "Could not restore back stack; starting fresh")
+                    null
+                }
+            } else {
+                null
+            }
+        if (restoredBackStack != null) {
             Timber.d("Restoring back stack")
-            var backStack = json.decodeFromString<List<Destination>>(backStackStr)
-
+            var backStack = restoredBackStack
             if (!playExternalViewModel.launched.value) {
                 val lastDest = backStack.lastOrNull()
                 if (lastDest.isPlayback) {
@@ -320,8 +332,14 @@ class MainActivity : AppCompatActivity() {
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         Timber.d("onSaveInstanceState")
-        val str = json.encodeToString(navigationManager.backStack.toList())
-        outState.putString(KEY_BACK_STACK, str)
+        try {
+            val str = json.encodeToString(navigationManager.backStack.toList())
+            outState.putString(KEY_BACK_STACK, str)
+        } catch (ex: Exception) {
+            // Best-effort: some destinations carry types we can't serialize; skip persisting
+            // the back stack rather than crashing in onSaveInstanceState.
+            Timber.w(ex, "Could not persist back stack; skipping")
+        }
         val playerBackend =
             runBlocking { userPreferencesDataStore.data.firstOrNull() }?.playbackPreferences?.playerBackend
         outState.putBoolean(KEY_EXTERNAL_PLAYER, playerBackend == PlayerBackend.EXTERNAL_PLAYER)


### PR DESCRIPTION
<!-- By submitting this pull request, you acknowledge that you have read the [contributing guide](https://github.com/damontecres/Wholphin/blob/main/CONTRIBUTING.md, including the AI/LLM policy, and [developer's guide](https://github.com/damontecres/Wholphin/blob/main/DEVELOPMENT.md) -->

## Description
ItemGrid destinations carry @Contextual request types with no registered serializer, which threw a SerializationException when Android saved the back stack. Wrap save and restore in try/catch so persistence is best-effort: on failure the back stack is simply not persisted/restored instead of crashing.

### Related issues
Workaround for #1598. This stops the crash but does not fix the root cause — the proper fix is to register the request types and RequestHandler polymorphism in the nav Json's serializersModule (see the issue).

### Testing
Built and ran on the Android TV emulator and a Fire TV Stick (AFTMM). assembleDefaultDebug and the unit tests pass; ktlint via pre-commit is clean. Verified the app no longer crashes when backgrounding from an ItemGrid.

## Screenshots
N/A — no UI changes.

## AI or LLM usage
Disclosure: this change was written with AI assistance (Claude Code). I directed the design, reviewed the diff, and tested it on an emulator and a Fire TV Stick. I understand the code and can maintain it.