### PR TITLE
Show runtime on different versions dialog

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/Dialogs.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/Dialogs.kt
@@ -70,6 +70,7 @@ import com.github.damontecres.wholphin.ui.isNotNullOrBlank
 import com.github.damontecres.wholphin.ui.playback.SimpleMediaStream
 import com.github.damontecres.wholphin.ui.playback.isDown
 import com.github.damontecres.wholphin.ui.playback.isUp
+import com.github.damontecres.wholphin.ui.roundMinutes
 import com.github.damontecres.wholphin.ui.tryRequestFocus
 import com.github.damontecres.wholphin.util.ExceptionHandler
 import kotlinx.coroutines.delay
@@ -77,6 +78,7 @@ import kotlinx.coroutines.launch
 import org.jellyfin.sdk.model.api.MediaSourceInfo
 import org.jellyfin.sdk.model.api.MediaStream
 import org.jellyfin.sdk.model.api.MediaStreamType
+import org.jellyfin.sdk.model.extensions.ticks
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
 import java.util.UUID
 
@@ -639,6 +641,16 @@ fun chooseVersionParams(
                                 }.joinToString(", ")
                             }
                         Text(text)
+                    },
+                    trailingContent = {
+                        val runtime =
+                            remember {
+                                source.runTimeTicks
+                                    ?.ticks
+                                    ?.roundMinutes
+                                    .toString()
+                            }
+                        Text(runtime)
                     },
                     onClick = { onClick.invoke(index) },
                 )


### PR DESCRIPTION
## Description
Small PR to add the runtime for different versions of media to the choose version dialog.

This can be helpful to further distinguish versions such as theatrical vs extended editions.

### Related issues
Suggested https://github.com/damontecres/Wholphin/pull/1522#issuecomment-4766811832

### Testing
Emulator

## Screenshots
<img width="560" height="337" alt="image" src="https://github.com/user-attachments/assets/47b0c1be-d1d7-4845-b097-a67358f584f9" />


## AI or LLM usage
None
