### PR TITLE
Fix possible crash if remembered tab no longer exists

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/TabbedPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/TabbedPage.kt
@@ -37,10 +37,14 @@ class TabViewModel
         private val rememberedTabService: RememberedTabService,
         private val backdropService: BackdropService,
         @param:Assisted private val itemId: String,
+        @param:Assisted private val tabCount: Int,
     ) : ViewModel() {
         @AssistedFactory
         interface Factory {
-            fun create(itemId: String): TabViewModel
+            fun create(
+                itemId: String,
+                tabCount: Int,
+            ): TabViewModel
         }
 
         private val _state = MutableStateFlow<Int>(UNSET)
@@ -52,7 +56,9 @@ class TabViewModel
                     if (shouldRememberTabs()) {
                         Timber.v("Getting remembered tab for %s", itemId)
                         try {
-                            rememberedTabService.getRememberedTab(itemId)
+                            rememberedTabService
+                                .getRememberedTab(itemId)
+                                ?.coerceIn(0..<tabCount)
                         } catch (ex: Exception) {
                             Timber.e(ex, "Error getting tab for %s", itemId)
                             null
@@ -106,12 +112,13 @@ fun TabbedPage(
     showTabs: Boolean = true,
     viewModel: TabViewModel =
         hiltViewModel<TabViewModel, TabViewModel.Factory>(
-            key = itemId,
-            creationCallback = { it.create(itemId) },
+            key = "$itemId-${tabs.size}",
+            creationCallback = { it.create(itemId, tabs.size) },
         ),
     tabContent: @Composable (Int, TabDetails) -> Unit,
 ) {
     val selectedTabIndex by viewModel.state.collectAsState()
+
     Column(
         modifier = modifier,
     ) {


### PR DESCRIPTION
## Description
If remember tabs is enabled and the current remembered index is somehow removed, the app would crash.

I think the only way a regular user can encounter this is if the server removes a live TV recording folder that the user has selected/remembered. All other tabbed pages use a fixed list.

### Related issues
None

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None