### PR TITLE
Add filtering & sorting for discover grid pages

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
@@ -6,6 +6,7 @@ import com.github.damontecres.wholphin.api.seerr.SearchApi
 import com.github.damontecres.wholphin.api.seerr.SearchApi.CertificationModeDiscoverTvGet
 import com.github.damontecres.wholphin.api.seerr.model.DiscoverMoviesGet200Response
 import com.github.damontecres.wholphin.api.seerr.model.DiscoverTvGet200Response
+import com.github.damontecres.wholphin.api.seerr.model.TvDetails
 import com.github.damontecres.wholphin.ui.data.flip
 import org.jellyfin.sdk.model.api.SortOrder
 import java.time.LocalDate
@@ -60,7 +61,7 @@ data class DiscoverFilter(
     val watchRegion: String? = null, // US
     // networkIds?
     // val watchProviders: String? = null,
-    val status: String? = null,
+    val status: List<TvDetails.Status>? = null,
     val certification: List<String>? = null,
     val certificationGte: String? = null,
     val certificationLte: String? = null,
@@ -109,9 +110,11 @@ data class DiscoverFilter(
             voteAverageLte = voteAverageLte,
             voteCountGte = voteCountGte,
             voteCountLte = voteCountLte,
-            watchRegion = watchRegion,
+            // TODO
+//            watchRegion = watchRegion,
+            watchRegion = networkIds?.let { "US" },
             watchProviders = networkIds?.joinToString(",") { it.toString() },
-            status = status,
+            status = status?.joinToString("|") { it.ordinal.toString() },
             certification = certification?.joinToString("|"),
             certificationGte = certificationGte,
             certificationLte = certificationLte,
@@ -142,7 +145,9 @@ data class DiscoverFilter(
             voteAverageLte = voteAverageLte,
             voteCountGte = voteCountGte,
             voteCountLte = voteCountLte,
-            watchRegion = watchRegion,
+            // TODO
+//            watchRegion = watchRegion,
+            watchRegion = networkIds?.let { "US" },
             watchProviders = networkIds?.joinToString(",") { it.toString() },
 //            status = status,
             certification = certification?.joinToString("|"),
@@ -163,11 +168,14 @@ data class DiscoverFilter(
 val discoverMovieFilters =
     listOf(
         DiscoverMovieGenreFilter,
+        DiscoverMovieStudiosFilter,
     )
 
 val discoverTvFilters =
     listOf(
         DiscoverTvGenreFilter,
+        DiscoverTvStudiosFilter,
+        DiscoverTvStatusFilter,
     )
 
 /**
@@ -201,4 +209,43 @@ data object DiscoverTvGenreFilter : DiscoverFilterBy<List<Int>> {
         value: List<Int>?,
         filter: DiscoverFilter,
     ): DiscoverFilter = filter.copy(genreIds = value)
+}
+
+data object DiscoverMovieStudiosFilter : DiscoverFilterBy<List<Int>> {
+    override val stringRes: Int = R.string.studios
+
+    override val supportMultiple: Boolean = true
+
+    override fun get(filter: DiscoverFilter): List<Int>? = filter.networkIds
+
+    override fun set(
+        value: List<Int>?,
+        filter: DiscoverFilter,
+    ): DiscoverFilter = filter.copy(networkIds = value)
+}
+
+data object DiscoverTvStudiosFilter : DiscoverFilterBy<List<Int>> {
+    override val stringRes: Int = R.string.studios
+
+    override val supportMultiple: Boolean = true
+
+    override fun get(filter: DiscoverFilter): List<Int>? = filter.networkIds
+
+    override fun set(
+        value: List<Int>?,
+        filter: DiscoverFilter,
+    ): DiscoverFilter = filter.copy(networkIds = value)
+}
+
+data object DiscoverTvStatusFilter : DiscoverFilterBy<List<TvDetails.Status>> {
+    override val stringRes: Int = R.string.studios
+
+    override val supportMultiple: Boolean = true
+
+    override fun get(filter: DiscoverFilter): List<TvDetails.Status>? = filter.status
+
+    override fun set(
+        value: List<TvDetails.Status>?,
+        filter: DiscoverFilter,
+    ): DiscoverFilter = filter.copy(status = value)
 }

--- a/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
@@ -159,17 +159,17 @@ val discoverMovieFilters =
     listOf(
         DiscoverMovieGenreFilter,
         DiscoverMovieStudiosFilter,
-        DiscoverMovieContentRatingFilter,
         DiscoverRatingFilter,
+        DiscoverMovieContentRatingFilter,
     )
 
 val discoverTvFilters =
     listOf(
         DiscoverTvGenreFilter,
         DiscoverTvStudiosFilter,
-        DiscoverTvStatusFilter,
-        DiscoverTvContentRatingFilter,
         DiscoverRatingFilter,
+        DiscoverTvContentRatingFilter,
+        DiscoverTvStatusFilter,
     )
 
 /**

--- a/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
@@ -1,9 +1,12 @@
 package com.github.damontecres.wholphin.data.filter
 
+import androidx.annotation.StringRes
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.api.seerr.SearchApi
 import com.github.damontecres.wholphin.api.seerr.SearchApi.CertificationModeDiscoverTvGet
+import com.github.damontecres.wholphin.api.seerr.model.DiscoverMoviesGet200Response
 import com.github.damontecres.wholphin.api.seerr.model.DiscoverTvGet200Response
+import com.github.damontecres.wholphin.ui.data.flip
 import org.jellyfin.sdk.model.api.SortOrder
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -26,11 +29,22 @@ private val SortOrder.key get() =
         SortOrder.DESCENDING -> "desc"
     }
 
-data class DiscoverSortBy(
-    val sort: DiscoverSort,
-    val direction: SortOrder,
+data class DiscoverSortAndDirection(
+    val sort: DiscoverSort = DiscoverSort.POPULARITY,
+    val direction: SortOrder = SortOrder.DESCENDING,
 ) {
     val key = "${sort.key}.${direction.key}"
+
+    fun flip() = copy(direction = direction.flip())
+
+    @StringRes
+    fun getStringRes(): Int =
+        when (sort) {
+            DiscoverSort.POPULARITY -> R.string.popularity
+            DiscoverSort.RELEASE_DATE -> R.string.sort_by_date_released
+            DiscoverSort.TMDB_VOTE -> R.string.community_rating
+            DiscoverSort.ALPHABETICAL -> R.string.sort_by_name
+        }
 }
 
 data class DiscoverFilter(
@@ -41,7 +55,7 @@ data class DiscoverFilter(
     // /api/v1/search/keyword
     val keywordIds: List<Int>? = null,
     val excludeKeywordIds: List<Int>? = null,
-    val sortBy: DiscoverSortBy? = null,
+    val sortBy: DiscoverSortAndDirection? = null,
     val firstAirDateGte: LocalDate? = null,
     val firstAirDateLte: LocalDate? = null,
     val withRuntimeGte: Duration? = null,
@@ -61,6 +75,28 @@ data class DiscoverFilter(
     val certificationCountry: String? = null, // US
     val certificationMatchExact: Boolean? = null,
 ) {
+    /**
+     * Returns how many of filters are actually being used in this
+     */
+    fun countFilters(filterOptions: List<DiscoverFilterBy<*>>): Int {
+        var count = 0
+        filterOptions.forEach {
+            if (it.get(this) != null) count++
+        }
+        return count
+    }
+
+    /**
+     * Clear all the values for the given filters
+     */
+    fun delete(filterOptions: List<DiscoverFilterBy<*>>): DiscoverFilter {
+        var newFilter = this
+        filterOptions.forEach {
+            newFilter = it.set(null, newFilter)
+        }
+        return newFilter
+    }
+
     suspend fun discoverTv(
         searchApi: SearchApi,
         page: Int,
@@ -93,7 +129,50 @@ data class DiscoverFilter(
                     if (certificationMatchExact) CertificationModeDiscoverTvGet.EXACT else CertificationModeDiscoverTvGet.RANGE
                 },
         )
+
+    suspend fun discoverMovies(
+        searchApi: SearchApi,
+        page: Int,
+    ): DiscoverMoviesGet200Response =
+        searchApi.discoverMoviesGet(
+            page = page,
+            language = language,
+            genre = genreIds?.joinToString(",") { it.toString() },
+//            network = null,
+            keywords = keywordIds?.joinToString(",") { it.toString() },
+            excludeKeywords = excludeKeywordIds?.joinToString(",") { it.toString() },
+            sortBy = sortBy?.key,
+//            firstAirDateGte = firstAirDateGte?.let { dateFormatter.format(it) },
+//            firstAirDateLte = firstAirDateLte?.let { dateFormatter.format(it) },
+            withRuntimeGte = withRuntimeGte?.inWholeMinutes?.toInt(),
+            withRuntimeLte = withRuntimeLte?.inWholeMinutes?.toInt(),
+            voteAverageGte = voteAverageGte,
+            voteAverageLte = voteAverageLte,
+            voteCountGte = voteCountGte,
+            voteCountLte = voteCountLte,
+            watchRegion = watchRegion,
+            watchProviders = networkIds?.joinToString(",") { it.toString() },
+//            status = status,
+            certification = certification?.joinToString("|"),
+            certificationGte = certificationGte,
+            certificationLte = certificationLte,
+            certificationCountry = certificationCountry,
+            certificationMode =
+                certificationMatchExact?.let {
+                    if (certificationMatchExact) {
+                        SearchApi.CertificationModeDiscoverMoviesGet.EXACT
+                    } else {
+                        SearchApi.CertificationModeDiscoverMoviesGet.RANGE
+                    }
+                },
+        )
 }
+
+val discoverMovieFilters =
+    listOf(
+        DiscoverMovieGenreFilter,
+        DiscoverTvGenreFilter,
+    )
 
 /**
  * A way to filter discover
@@ -102,7 +181,20 @@ data class DiscoverFilter(
  */
 sealed interface DiscoverFilterBy<T> : FilterBy<DiscoverFilter, T>
 
-data object DiscoverGenreFilter : DiscoverFilterBy<List<Int>> {
+data object DiscoverMovieGenreFilter : DiscoverFilterBy<List<Int>> {
+    override val stringRes: Int = R.string.genres
+
+    override val supportMultiple: Boolean = true
+
+    override fun get(filter: DiscoverFilter): List<Int>? = filter.genreIds
+
+    override fun set(
+        value: List<Int>?,
+        filter: DiscoverFilter,
+    ): DiscoverFilter = filter.copy(genreIds = value)
+}
+
+data object DiscoverTvGenreFilter : DiscoverFilterBy<List<Int>> {
     override val stringRes: Int = R.string.genres
 
     override val supportMultiple: Boolean = true

--- a/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
@@ -63,10 +63,10 @@ data class DiscoverFilter(
     // val watchProviders: String? = null,
     val status: List<TvDetails.Status>? = null,
     val certification: List<String>? = null,
-    val certificationGte: String? = null,
-    val certificationLte: String? = null,
-    val certificationCountry: String? = null, // US
-    val certificationMatchExact: Boolean? = null,
+//    val certificationGte: String? = null,
+//    val certificationLte: String? = null,
+//    val certificationCountry: String? = null, // US
+//    val certificationMatchExact: Boolean? = null,
 ) {
     /**
      * Returns how many of filters are actually being used in this
@@ -116,13 +116,10 @@ data class DiscoverFilter(
             watchProviders = networkIds?.joinToString(",") { it.toString() },
             status = status?.joinToString("|") { it.ordinal.toString() },
             certification = certification?.joinToString("|"),
-            certificationGte = certificationGte,
-            certificationLte = certificationLte,
-            certificationCountry = certificationCountry,
-            certificationMode =
-                certificationMatchExact?.let {
-                    if (certificationMatchExact) CertificationModeDiscoverTvGet.EXACT else CertificationModeDiscoverTvGet.RANGE
-                },
+//            certificationGte = certificationGte,
+//            certificationLte = certificationLte,
+            certificationCountry = certification?.let { "US" },
+            certificationMode = certification?.let { CertificationModeDiscoverTvGet.EXACT },
         )
 
     suspend fun discoverMovies(
@@ -151,17 +148,10 @@ data class DiscoverFilter(
             watchProviders = networkIds?.joinToString(",") { it.toString() },
 //            status = status,
             certification = certification?.joinToString("|"),
-            certificationGte = certificationGte,
-            certificationLte = certificationLte,
-            certificationCountry = certificationCountry,
-            certificationMode =
-                certificationMatchExact?.let {
-                    if (certificationMatchExact) {
-                        SearchApi.CertificationModeDiscoverMoviesGet.EXACT
-                    } else {
-                        SearchApi.CertificationModeDiscoverMoviesGet.RANGE
-                    }
-                },
+//            certificationGte = certificationGte,
+//            certificationLte = certificationLte,
+            certificationCountry = certification?.let { "US" },
+            certificationMode = certification?.let { SearchApi.CertificationModeDiscoverMoviesGet.EXACT },
         )
 }
 
@@ -169,6 +159,8 @@ val discoverMovieFilters =
     listOf(
         DiscoverMovieGenreFilter,
         DiscoverMovieStudiosFilter,
+        DiscoverMovieContentRatingFilter,
+        DiscoverRatingFilter,
     )
 
 val discoverTvFilters =
@@ -176,6 +168,8 @@ val discoverTvFilters =
         DiscoverTvGenreFilter,
         DiscoverTvStudiosFilter,
         DiscoverTvStatusFilter,
+        DiscoverTvContentRatingFilter,
+        DiscoverRatingFilter,
     )
 
 /**
@@ -238,7 +232,7 @@ data object DiscoverTvStudiosFilter : DiscoverFilterBy<List<Int>> {
 }
 
 data object DiscoverTvStatusFilter : DiscoverFilterBy<List<TvDetails.Status>> {
-    override val stringRes: Int = R.string.studios
+    override val stringRes: Int = R.string.production_status
 
     override val supportMultiple: Boolean = true
 
@@ -248,4 +242,43 @@ data object DiscoverTvStatusFilter : DiscoverFilterBy<List<TvDetails.Status>> {
         value: List<TvDetails.Status>?,
         filter: DiscoverFilter,
     ): DiscoverFilter = filter.copy(status = value)
+}
+
+data object DiscoverMovieContentRatingFilter : DiscoverFilterBy<List<String>> {
+    override val stringRes: Int = R.string.official_rating
+
+    override val supportMultiple: Boolean = true
+
+    override fun get(filter: DiscoverFilter): List<String>? = filter.certification
+
+    override fun set(
+        value: List<String>?,
+        filter: DiscoverFilter,
+    ): DiscoverFilter = filter.copy(certification = value)
+}
+
+data object DiscoverTvContentRatingFilter : DiscoverFilterBy<List<String>> {
+    override val stringRes: Int = R.string.official_rating
+
+    override val supportMultiple: Boolean = true
+
+    override fun get(filter: DiscoverFilter): List<String>? = filter.certification
+
+    override fun set(
+        value: List<String>?,
+        filter: DiscoverFilter,
+    ): DiscoverFilter = filter.copy(certification = value)
+}
+
+data object DiscoverRatingFilter : DiscoverFilterBy<Int> {
+    override val stringRes: Int = R.string.community_rating
+
+    override val supportMultiple: Boolean = true
+
+    override fun get(filter: DiscoverFilter): Int? = filter.voteAverageGte
+
+    override fun set(
+        value: Int?,
+        filter: DiscoverFilter,
+    ): DiscoverFilter = filter.copy(voteAverageGte = value)
 }

--- a/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
@@ -16,11 +16,12 @@ private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-M-d")
 
 enum class DiscoverSort(
     val key: String,
+    @StringRes val stringRes: Int,
 ) {
-    POPULARITY("popularity"),
-    RELEASE_DATE("release_date"),
-    TMDB_VOTE("vote_average"),
-    ALPHABETICAL("original_title"),
+    POPULARITY("popularity", R.string.popularity),
+    RELEASE_DATE("release_date", R.string.sort_by_date_released),
+    TMDB_VOTE("vote_average", R.string.community_rating),
+    ALPHABETICAL("original_title", R.string.sort_by_name),
 }
 
 private val SortOrder.key get() =
@@ -36,15 +37,6 @@ data class DiscoverSortAndDirection(
     val key = "${sort.key}.${direction.key}"
 
     fun flip() = copy(direction = direction.flip())
-
-    @StringRes
-    fun getStringRes(): Int =
-        when (sort) {
-            DiscoverSort.POPULARITY -> R.string.popularity
-            DiscoverSort.RELEASE_DATE -> R.string.sort_by_date_released
-            DiscoverSort.TMDB_VOTE -> R.string.community_rating
-            DiscoverSort.ALPHABETICAL -> R.string.sort_by_name
-        }
 }
 
 data class DiscoverFilter(
@@ -171,6 +163,10 @@ data class DiscoverFilter(
 val discoverMovieFilters =
     listOf(
         DiscoverMovieGenreFilter,
+    )
+
+val discoverTvFilters =
+    listOf(
         DiscoverTvGenreFilter,
     )
 

--- a/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilterBy.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilterBy.kt
@@ -1,0 +1,116 @@
+package com.github.damontecres.wholphin.data.filter
+
+import com.github.damontecres.wholphin.R
+import com.github.damontecres.wholphin.api.seerr.SearchApi
+import com.github.damontecres.wholphin.api.seerr.SearchApi.CertificationModeDiscoverTvGet
+import com.github.damontecres.wholphin.api.seerr.model.DiscoverTvGet200Response
+import org.jellyfin.sdk.model.api.SortOrder
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import kotlin.time.Duration
+
+private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-M-d")
+
+enum class DiscoverSort(
+    val key: String,
+) {
+    POPULARITY("popularity"),
+    RELEASE_DATE("release_date"),
+    TMDB_VOTE("vote_average"),
+    ALPHABETICAL("original_title"),
+}
+
+private val SortOrder.key get() =
+    when (this) {
+        SortOrder.ASCENDING -> "asc"
+        SortOrder.DESCENDING -> "desc"
+    }
+
+data class DiscoverSortBy(
+    val sort: DiscoverSort,
+    val direction: SortOrder,
+) {
+    val key = "${sort.key}.${direction.key}"
+}
+
+data class DiscoverFilter(
+    // /api/v1/languages
+    val language: String? = null,
+    val genreIds: List<Int>? = null,
+    val networkIds: List<Int>? = null,
+    // /api/v1/search/keyword
+    val keywordIds: List<Int>? = null,
+    val excludeKeywordIds: List<Int>? = null,
+    val sortBy: DiscoverSortBy? = null,
+    val firstAirDateGte: LocalDate? = null,
+    val firstAirDateLte: LocalDate? = null,
+    val withRuntimeGte: Duration? = null,
+    val withRuntimeLte: Duration? = null,
+    val voteAverageGte: Int? = null,
+    val voteAverageLte: Int? = null,
+    val voteCountGte: Int? = null,
+    val voteCountLte: Int? = null,
+    // /api/v1/watchproviders/regions
+    val watchRegion: String? = null, // US
+    // networkIds?
+    // val watchProviders: String? = null,
+    val status: String? = null,
+    val certification: List<String>? = null,
+    val certificationGte: String? = null,
+    val certificationLte: String? = null,
+    val certificationCountry: String? = null, // US
+    val certificationMatchExact: Boolean? = null,
+) {
+    suspend fun discoverTv(
+        searchApi: SearchApi,
+        page: Int,
+    ): DiscoverTvGet200Response =
+        searchApi.discoverTvGet(
+            page = page,
+            language = language,
+            genre = genreIds?.joinToString(",") { it.toString() },
+            network = null,
+            keywords = keywordIds?.joinToString(",") { it.toString() },
+            excludeKeywords = excludeKeywordIds?.joinToString(",") { it.toString() },
+            sortBy = sortBy?.key,
+            firstAirDateGte = firstAirDateGte?.let { dateFormatter.format(it) },
+            firstAirDateLte = firstAirDateLte?.let { dateFormatter.format(it) },
+            withRuntimeGte = withRuntimeGte?.inWholeMinutes?.toInt(),
+            withRuntimeLte = withRuntimeLte?.inWholeMinutes?.toInt(),
+            voteAverageGte = voteAverageGte,
+            voteAverageLte = voteAverageLte,
+            voteCountGte = voteCountGte,
+            voteCountLte = voteCountLte,
+            watchRegion = watchRegion,
+            watchProviders = networkIds?.joinToString(",") { it.toString() },
+            status = status,
+            certification = certification?.joinToString("|"),
+            certificationGte = certificationGte,
+            certificationLte = certificationLte,
+            certificationCountry = certificationCountry,
+            certificationMode =
+                certificationMatchExact?.let {
+                    if (certificationMatchExact) CertificationModeDiscoverTvGet.EXACT else CertificationModeDiscoverTvGet.RANGE
+                },
+        )
+}
+
+/**
+ * A way to filter discover
+ *
+ * Gets and sets values within a [DiscoverFilter]
+ */
+sealed interface DiscoverFilterBy<T> : FilterBy<DiscoverFilter, T>
+
+data object DiscoverGenreFilter : DiscoverFilterBy<List<Int>> {
+    override val stringRes: Int = R.string.genres
+
+    override val supportMultiple: Boolean = true
+
+    override fun get(filter: DiscoverFilter): List<Int>? = filter.genreIds
+
+    override fun set(
+        value: List<Int>?,
+        filter: DiscoverFilter,
+    ): DiscoverFilter = filter.copy(genreIds = value)
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/data/filter/ItemFilterBy.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/filter/ItemFilterBy.kt
@@ -77,23 +77,28 @@ val DefaultPlaylistItemsOptions =
     )
 
 /**
- * A way to filter libraries
- *
- * Gets and sets values within a [GetItemsFilter]
+ * Abstract way to filter data
  */
-sealed interface ItemFilterBy<T> {
+sealed interface FilterBy<FilterType, DataType> {
     @get:StringRes
     val stringRes: Int
 
     val supportMultiple: Boolean
 
-    fun get(filter: GetItemsFilter): T?
+    fun get(filter: FilterType): DataType?
 
     fun set(
-        value: T?,
-        filter: GetItemsFilter,
-    ): GetItemsFilter
+        value: DataType?,
+        filter: FilterType,
+    ): FilterType
 }
+
+/**
+ * A way to filter jellyfin libraries
+ *
+ * Gets and sets values within a [GetItemsFilter]
+ */
+sealed interface ItemFilterBy<T> : FilterBy<GetItemsFilter, T>
 
 data object GenreFilter : ItemFilterBy<List<UUID>> {
     override val stringRes: Int = R.string.genres

--- a/app/src/main/java/com/github/damontecres/wholphin/data/filter/SearchFilter.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/filter/SearchFilter.kt
@@ -1,0 +1,27 @@
+package com.github.damontecres.wholphin.data.filter
+
+import com.github.damontecres.wholphin.data.model.GetItemsFilter
+
+interface SearchFilter<T : SearchFilter<T>> {
+    /**
+     * Returns how many of filters are actually being used in this [GetItemsFilter]
+     */
+    fun countFilters(filterOptions: List<FilterBy<T, *>>): Int {
+        var count = 0
+        filterOptions.forEach {
+            if (it.get(this as T) != null) count++
+        }
+        return count
+    }
+
+    /**
+     * Clear all the values for the given filters
+     */
+    fun delete(filterOptions: List<FilterBy<T, *>>): T {
+        var newFilter = this
+        filterOptions.forEach {
+            newFilter = it.set(null, newFilter as T)
+        }
+        return newFilter as T
+    }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/services/FilterOptionCache.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/FilterOptionCache.kt
@@ -6,8 +6,11 @@ import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.filter.CommunityRatingFilter
 import com.github.damontecres.wholphin.data.filter.DecadeFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverFilterBy
+import com.github.damontecres.wholphin.data.filter.DiscoverMovieContentRatingFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverMovieGenreFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverMovieStudiosFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverRatingFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverTvContentRatingFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverTvGenreFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverTvStatusFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverTvStudiosFilter
@@ -238,6 +241,22 @@ class FilterOptionCache
                 DiscoverTvStatusFilter -> {
                     TvDetails.Status.entries.map {
                         FilterValueOption(it.value, it)
+                    }
+                }
+
+                DiscoverMovieContentRatingFilter -> {
+                    listOf("NR", "G", "PG", "PG-13", "R", "NC-17")
+                        .map { FilterValueOption(it, it) }
+                }
+
+                DiscoverTvContentRatingFilter -> {
+                    listOf("NR", "TV-Y", "TV-Y7", "TV-G", "TV-PG", "TV-14", "TV-MA")
+                        .map { FilterValueOption(it, it) }
+                }
+
+                DiscoverRatingFilter -> {
+                    (1..10).map {
+                        FilterValueOption("$it", it)
                     }
                 }
             }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/FilterOptionCache.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/FilterOptionCache.kt
@@ -4,11 +4,14 @@ import android.content.Context
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.filter.CommunityRatingFilter
 import com.github.damontecres.wholphin.data.filter.DecadeFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverFilterBy
+import com.github.damontecres.wholphin.data.filter.DiscoverMovieGenreFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverTvGenreFilter
 import com.github.damontecres.wholphin.data.filter.FavoriteFilter
+import com.github.damontecres.wholphin.data.filter.FilterBy
 import com.github.damontecres.wholphin.data.filter.FilterValueOption
 import com.github.damontecres.wholphin.data.filter.FilterVideoType
 import com.github.damontecres.wholphin.data.filter.GenreFilter
-import com.github.damontecres.wholphin.data.filter.ItemFilterBy
 import com.github.damontecres.wholphin.data.filter.OfficialRatingFilter
 import com.github.damontecres.wholphin.data.filter.PlayedFilter
 import com.github.damontecres.wholphin.data.filter.StudioFilter
@@ -20,6 +23,7 @@ import com.mayakapps.kache.InMemoryKache
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.firstOrNull
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.filterApi
 import org.jellyfin.sdk.api.client.extensions.genresApi
@@ -47,6 +51,7 @@ class FilterOptionCache
         @param:IoCoroutineScope private val ioCoroutineScope: CoroutineScope,
         private val api: ApiClient,
         private val serverRepository: ServerRepository,
+        private val seerrService: SeerrService,
     ) {
         private val cache =
             InMemoryKache<FilterOptionCacheKey, List<FilterValueOption>>(16) {
@@ -61,7 +66,7 @@ class FilterOptionCache
          */
         suspend fun getFilterOptionValues(
             parentId: UUID?,
-            filterOption: ItemFilterBy<*>,
+            filterOption: FilterBy<*, *>,
         ): List<FilterValueOption> {
             val cacheKey = FilterOptionCacheKey(serverRepository.currentUser?.id, parentId, filterOption)
             return try {
@@ -81,7 +86,7 @@ class FilterOptionCache
         private suspend fun getFilterOptionValues(
             userId: UUID?,
             parentId: UUID?,
-            filterOption: ItemFilterBy<*>,
+            filterOption: FilterBy<*, *>,
         ) = when (filterOption) {
             GenreFilter -> {
                 api.genresApi
@@ -173,11 +178,40 @@ class FilterOptionCache
                     FilterValueOption("$it", it)
                 }
             }
+
+            is DiscoverFilterBy -> {
+                getDiscoverFilterOptionValues(filterOption)
+            }
+        }
+
+        private suspend fun getDiscoverFilterOptionValues(filterOption: DiscoverFilterBy<*>): List<FilterValueOption> {
+            if (seerrService.active.firstOrNull() != true) {
+                return emptyList()
+            }
+            return when (filterOption) {
+                DiscoverMovieGenreFilter -> {
+                    seerrService.api.searchApi
+                        .discoverGenresliderMovieGet()
+                        .filter { it.name != null && it.id != null }
+                        .map {
+                            FilterValueOption(it.name!!, it.id!!)
+                        }
+                }
+
+                DiscoverTvGenreFilter -> {
+                    seerrService.api.searchApi
+                        .discoverGenresliderTvGet()
+                        .filter { it.name != null && it.id != null }
+                        .map {
+                            FilterValueOption(it.name!!, it.id!!)
+                        }
+                }
+            }
         }
 
         private data class FilterOptionCacheKey(
             val userId: UUID?,
             val parentId: UUID?,
-            val filterOption: ItemFilterBy<*>,
+            val filterOption: FilterBy<*, *>,
         )
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/FilterOptionCache.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/FilterOptionCache.kt
@@ -1,12 +1,16 @@
 package com.github.damontecres.wholphin.services
 
 import android.content.Context
+import com.github.damontecres.wholphin.api.seerr.model.TvDetails
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.filter.CommunityRatingFilter
 import com.github.damontecres.wholphin.data.filter.DecadeFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverFilterBy
 import com.github.damontecres.wholphin.data.filter.DiscoverMovieGenreFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverMovieStudiosFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverTvGenreFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverTvStatusFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverTvStudiosFilter
 import com.github.damontecres.wholphin.data.filter.FavoriteFilter
 import com.github.damontecres.wholphin.data.filter.FilterBy
 import com.github.damontecres.wholphin.data.filter.FilterValueOption
@@ -205,6 +209,36 @@ class FilterOptionCache
                         .map {
                             FilterValueOption(it.name!!, it.id!!)
                         }
+                }
+
+                DiscoverMovieStudiosFilter -> {
+                    // TODO region
+                    seerrService.api.otherApi
+                        .watchprovidersMoviesGet("US")
+                        .filter { it.name != null && it.id != null }
+                        // TODO not what this is for
+//                        .sortedBy { it.displayPriority }
+                        .map {
+                            // TODO logo?
+                            FilterValueOption(it.name!!, it.id!!)
+                        }
+                }
+
+                DiscoverTvStudiosFilter -> {
+                    // TODO region
+                    seerrService.api.otherApi
+                        .watchprovidersTvGet("US")
+                        .filter { it.name != null && it.id != null }
+//                        .sortedBy { it.displayPriority }
+                        .map {
+                            FilterValueOption(it.name!!, it.id!!)
+                        }
+                }
+
+                DiscoverTvStatusFilter -> {
+                    TvDetails.Status.entries.map {
+                        FilterValueOption(it.value, it)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/FilterByButton.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/FilterByButton.kt
@@ -42,8 +42,11 @@ import com.github.damontecres.wholphin.data.filter.CommunityRatingFilter
 import com.github.damontecres.wholphin.data.filter.DecadeFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverFilterBy
+import com.github.damontecres.wholphin.data.filter.DiscoverMovieContentRatingFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverMovieGenreFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverMovieStudiosFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverRatingFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverTvContentRatingFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverTvGenreFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverTvStatusFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverTvStudiosFilter
@@ -599,6 +602,18 @@ fun DiscoverFilterByButton(
                                             .orEmpty()
                                             .contains(value.value)
                                     }
+
+                                    DiscoverMovieContentRatingFilter,
+                                    DiscoverTvContentRatingFilter,
+                                    -> {
+                                        (currentValue as? List<String>)
+                                            .orEmpty()
+                                            .contains(value.value)
+                                    }
+
+                                    DiscoverRatingFilter -> {
+                                        (currentValue as? Int) == value.value
+                                    }
                                 }
                             }
                         val interactionSource = remember { MutableInteractionSource() }
@@ -615,7 +630,7 @@ fun DiscoverFilterByButton(
                                 }
                             },
                             text = {
-                                if (filterOption == CommunityRatingFilter) {
+                                if (filterOption == DiscoverRatingFilter) {
                                     SimpleStarRating(
                                         "${value.name}+",
                                         starColor = if (focused) EmptyStarColor else FilledStarColor,
@@ -662,6 +677,30 @@ fun DiscoverFilterByButton(
                                                         }
                                                     }.takeIf { it.isNotEmpty() }
                                             filterOption.set(newValue, current)
+                                        }
+
+                                        DiscoverMovieContentRatingFilter,
+                                        DiscoverTvContentRatingFilter,
+                                        -> {
+                                            val list = (currentValue as? List<String>).orEmpty()
+                                            val newValue =
+                                                list
+                                                    .toMutableList()
+                                                    .apply {
+                                                        if (isSelected) {
+                                                            remove(value.value!!)
+                                                        } else {
+                                                            add(value.value!! as String)
+                                                        }
+                                                    }.takeIf { it.isNotEmpty() }
+                                            filterOption.set(newValue, current)
+                                        }
+
+                                        DiscoverRatingFilter -> {
+                                            filterOption.set(
+                                                value.value as? Int,
+                                                current,
+                                            )
                                         }
                                     }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/FilterByButton.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/FilterByButton.kt
@@ -37,12 +37,16 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import androidx.tv.material3.surfaceColorAtElevation
 import com.github.damontecres.wholphin.R
+import com.github.damontecres.wholphin.api.seerr.model.TvDetails
 import com.github.damontecres.wholphin.data.filter.CommunityRatingFilter
 import com.github.damontecres.wholphin.data.filter.DecadeFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverFilterBy
 import com.github.damontecres.wholphin.data.filter.DiscoverMovieGenreFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverMovieStudiosFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverTvGenreFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverTvStatusFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverTvStudiosFilter
 import com.github.damontecres.wholphin.data.filter.FavoriteFilter
 import com.github.damontecres.wholphin.data.filter.FilterValueOption
 import com.github.damontecres.wholphin.data.filter.FilterVideoType
@@ -582,8 +586,16 @@ fun DiscoverFilterByButton(
                                 when (filterOption) {
                                     DiscoverMovieGenreFilter,
                                     DiscoverTvGenreFilter,
+                                    DiscoverMovieStudiosFilter,
+                                    DiscoverTvStudiosFilter,
                                     -> {
                                         (currentValue as? List<Int>)
+                                            .orEmpty()
+                                            .contains(value.value)
+                                    }
+
+                                    DiscoverTvStatusFilter -> {
+                                        (currentValue as? List<TvDetails.Status>)
                                             .orEmpty()
                                             .contains(value.value)
                                     }
@@ -619,6 +631,8 @@ fun DiscoverFilterByButton(
                                     when (filterOption) {
                                         DiscoverMovieGenreFilter,
                                         DiscoverTvGenreFilter,
+                                        DiscoverMovieStudiosFilter,
+                                        DiscoverTvStudiosFilter,
                                         -> {
                                             val list = (currentValue as? List<Int>).orEmpty()
                                             val newValue =
@@ -629,6 +643,22 @@ fun DiscoverFilterByButton(
                                                             remove(value.value!!)
                                                         } else {
                                                             add(value.value!! as Int)
+                                                        }
+                                                    }.takeIf { it.isNotEmpty() }
+                                            filterOption.set(newValue, current)
+                                        }
+
+                                        DiscoverTvStatusFilter -> {
+                                            val list =
+                                                (currentValue as? List<TvDetails.Status>).orEmpty()
+                                            val newValue =
+                                                list
+                                                    .toMutableList()
+                                                    .apply {
+                                                        if (isSelected) {
+                                                            remove(value.value!!)
+                                                        } else {
+                                                            add(value.value!! as TvDetails.Status)
                                                         }
                                                     }.takeIf { it.isNotEmpty() }
                                             filterOption.set(newValue, current)

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/FilterByButton.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/FilterByButton.kt
@@ -39,6 +39,10 @@ import androidx.tv.material3.surfaceColorAtElevation
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.filter.CommunityRatingFilter
 import com.github.damontecres.wholphin.data.filter.DecadeFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverFilterBy
+import com.github.damontecres.wholphin.data.filter.DiscoverMovieGenreFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverTvGenreFilter
 import com.github.damontecres.wholphin.data.filter.FavoriteFilter
 import com.github.damontecres.wholphin.data.filter.FilterValueOption
 import com.github.damontecres.wholphin.data.filter.FilterVideoType
@@ -423,6 +427,224 @@ fun ExpandableFilterButton(
                 style = MaterialTheme.typography.titleSmall,
                 modifier = Modifier.padding(start = 4.dp, end = 4.dp),
             )
+        }
+    }
+}
+
+// TODO this all duplicated code from FilterByButton
+@Composable
+fun DiscoverFilterByButton(
+    filterOptions: List<DiscoverFilterBy<*>>,
+    current: DiscoverFilter,
+    onFilterChange: (DiscoverFilter) -> Unit,
+    getPossibleValues: suspend (DiscoverFilterBy<*>) -> List<FilterValueOption>,
+    modifier: Modifier = Modifier,
+    onShow: ((Boolean) -> Unit)? = null,
+) {
+    var dropDown by remember { mutableStateOf(false) }
+    var nestedDropDown by remember { mutableStateOf<DiscoverFilterBy<*>?>(null) }
+    val filterCount = remember(current, filterOptions) { current.countFilters(filterOptions) }
+
+    Box(modifier = modifier) {
+        ExpandableFilterButton(
+            filterCount = filterCount,
+            onClick = {
+                onShow?.invoke(true)
+                dropDown = true
+            },
+            modifier = Modifier,
+        )
+
+        DropdownMenu(
+            expanded = dropDown,
+            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp),
+            onDismissRequest = {
+                onShow?.invoke(false)
+                dropDown = false
+                nestedDropDown = null
+            },
+        ) {
+            if (filterCount > 0) {
+                val interactionSource = remember { MutableInteractionSource() }
+                val focused by interactionSource.collectIsFocusedAsState()
+                TvDropdownMenuItem(
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = null,
+                            tint = Color.Red.copy(alpha = .8f),
+                        )
+                    },
+                    text = {
+                        Text(
+                            text = stringResource(R.string.remove),
+                            color = if (focused) MaterialTheme.colorScheme.onError else MaterialTheme.colorScheme.error,
+                        )
+                    },
+                    onClick = {
+                        onFilterChange.invoke(current.delete(filterOptions))
+                        dropDown = false
+                    },
+                    interactionSource = interactionSource,
+                    modifier = Modifier,
+                )
+                HorizontalDivider()
+            }
+            filterOptions
+                .forEachIndexed { index, filterOption ->
+                    val focusRequester = remember { FocusRequester() }
+                    if (index == 0) {
+                        LaunchedEffect(Unit) { focusRequester.tryRequestFocus() }
+                    }
+                    val currentValue = remember(current) { filterOption.get(current) }
+                    TvDropdownMenuItem(
+                        leadingIcon = {
+                            if (currentValue != null) {
+                                Icon(
+                                    imageVector = Icons.Default.Check,
+                                    contentDescription = "Filter active",
+                                )
+                            }
+                        },
+                        text = {
+                            Text(
+                                text = stringResource(filterOption.stringRes),
+                            )
+                        },
+                        onClick = {
+                            nestedDropDown = filterOption
+                        },
+                        modifier = Modifier.focusRequester(focusRequester),
+                    )
+                }
+        }
+
+        DropdownMenu(
+            expanded = nestedDropDown != null,
+            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
+            offset = DpOffset(80.dp, 16.dp),
+            onDismissRequest = {
+                nestedDropDown = null
+            },
+        ) {
+            nestedDropDown?.let { filterOption ->
+                filterOption as DiscoverFilterBy<Any>
+                val currentValue = remember(current) { filterOption.get(current) }
+
+                var possibleValues by remember { mutableStateOf<List<FilterValueOption>?>(null) }
+                LaunchedEffect(Unit) {
+                    possibleValues = getPossibleValues.invoke(filterOption)
+                }
+
+                if (currentValue != null) {
+                    val interactionSource = remember { MutableInteractionSource() }
+                    val focused by interactionSource.collectIsFocusedAsState()
+                    TvDropdownMenuItem(
+                        elevation = 5.dp,
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = null,
+                                tint = Color.Red.copy(alpha = .8f),
+                            )
+                        },
+                        text = {
+                            Text(
+                                text = stringResource(R.string.remove),
+                                color = if (focused) MaterialTheme.colorScheme.onError else MaterialTheme.colorScheme.error,
+                            )
+                        },
+                        onClick = {
+                            onFilterChange.invoke(filterOption.set(null, current))
+                            nestedDropDown = null
+                        },
+                        interactionSource = interactionSource,
+                        modifier = Modifier,
+                    )
+                    HorizontalDivider()
+                }
+
+                if (possibleValues == null) {
+                    CircularProgress(Modifier.size(48.dp))
+                } else if (possibleValues?.isEmpty() == true) {
+                    Text(
+                        text = stringResource(R.string.no_results),
+                    )
+                } else {
+                    possibleValues.orEmpty().forEachIndexed { index, value ->
+                        val focusRequester = remember { FocusRequester() }
+                        if (index == 0) {
+                            LaunchedEffect(Unit) { focusRequester.tryRequestFocus() }
+                        }
+
+                        val isSelected =
+                            remember(currentValue) {
+                                when (filterOption) {
+                                    DiscoverMovieGenreFilter,
+                                    DiscoverTvGenreFilter,
+                                    -> {
+                                        (currentValue as? List<Int>)
+                                            .orEmpty()
+                                            .contains(value.value)
+                                    }
+                                }
+                            }
+                        val interactionSource = remember { MutableInteractionSource() }
+                        val focused by interactionSource.collectIsFocusedAsState()
+                        TvDropdownMenuItem(
+                            elevation = 8.dp,
+                            interactionSource = interactionSource,
+                            leadingIcon = {
+                                if (isSelected) {
+                                    Icon(
+                                        imageVector = Icons.Default.Check,
+                                        contentDescription = "Filter active",
+                                    )
+                                }
+                            },
+                            text = {
+                                if (filterOption == CommunityRatingFilter) {
+                                    SimpleStarRating(
+                                        "${value.name}+",
+                                        starColor = if (focused) EmptyStarColor else FilledStarColor,
+                                    )
+                                } else {
+                                    Text(
+                                        text = value.name,
+                                    )
+                                }
+                            },
+                            onClick = {
+                                val newFilter =
+                                    when (filterOption) {
+                                        DiscoverMovieGenreFilter,
+                                        DiscoverTvGenreFilter,
+                                        -> {
+                                            val list = (currentValue as? List<Int>).orEmpty()
+                                            val newValue =
+                                                list
+                                                    .toMutableList()
+                                                    .apply {
+                                                        if (isSelected) {
+                                                            remove(value.value!!)
+                                                        } else {
+                                                            add(value.value!! as Int)
+                                                        }
+                                                    }.takeIf { it.isNotEmpty() }
+                                            filterOption.set(newValue, current)
+                                        }
+                                    }
+
+                                onFilterChange.invoke(newFilter)
+                                if (!filterOption.supportMultiple) {
+                                    nestedDropDown = null
+                                }
+                            },
+                            modifier = Modifier.focusRequester(focusRequester),
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/SortByButton.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/SortByButton.kt
@@ -167,7 +167,7 @@ fun DiscoverSortByButton(
                         },
                         text = {
                             Text(
-                                text = stringResource(current.getStringRes()),
+                                text = stringResource(sortOption.stringRes),
                             )
                         },
                         onClick = {
@@ -206,5 +206,5 @@ fun DiscoverSortAndDirection.toAnnotatedString() =
             )
         }
         append(" ")
-        append(stringResource(getStringRes()))
+        append(stringResource(sort.stringRes))
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/SortByButton.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/SortByButton.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.tv.material3.Text
 import com.github.damontecres.wholphin.R
+import com.github.damontecres.wholphin.data.filter.DiscoverSort
+import com.github.damontecres.wholphin.data.filter.DiscoverSortAndDirection
 import com.github.damontecres.wholphin.ui.FontAwesome
 import com.github.damontecres.wholphin.ui.data.SortAndDirection
 import com.github.damontecres.wholphin.ui.data.flip
@@ -114,4 +116,95 @@ fun SortAndDirection.toAnnotatedString() =
         }
         append(" ")
         append(stringResource(getStringRes(sort)))
+    }
+
+// TODO code duplicated from SortByButton
+@Composable
+fun DiscoverSortByButton(
+    sortOptions: List<DiscoverSort>,
+    current: DiscoverSortAndDirection,
+    onSortChange: (DiscoverSortAndDirection) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val currentSort = current.sort
+    val currentDirection = current.direction
+    var sortByDropDown by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        TextButton(
+            onClick = { sortByDropDown = true },
+            onLongClick = {
+                onSortChange.invoke(current.flip())
+            },
+        ) {
+            Text(
+                text = current.toAnnotatedString(),
+            )
+        }
+
+        DropdownMenu(
+            expanded = sortByDropDown,
+            onDismissRequest = { sortByDropDown = false },
+        ) {
+            sortOptions
+//                .sortedBy { it.name }
+                .forEach { sortOption ->
+                    TvDropdownMenuItem(
+                        leadingIcon = {
+                            if (sortOption == currentSort) {
+                                if (currentDirection == SortOrder.ASCENDING) {
+                                    Text(
+                                        text = stringResource(R.string.fa_caret_up),
+                                        fontFamily = FontAwesome,
+                                    )
+                                } else {
+                                    Text(
+                                        text = stringResource(R.string.fa_caret_down),
+                                        fontFamily = FontAwesome,
+                                    )
+                                }
+                            }
+                        },
+                        text = {
+                            Text(
+                                text = stringResource(current.getStringRes()),
+                            )
+                        },
+                        onClick = {
+                            sortByDropDown = false
+                            val newDirection =
+                                if (currentSort == sortOption) {
+                                    currentDirection.flip()
+                                } else {
+                                    currentDirection
+                                }
+                            onSortChange.invoke(
+                                DiscoverSortAndDirection(
+                                    sortOption,
+                                    newDirection,
+                                ),
+                            )
+                        },
+                    )
+                }
+        }
+    }
+}
+
+@Composable
+fun DiscoverSortAndDirection.toAnnotatedString() =
+    buildAnnotatedString {
+        withStyle(SpanStyle(fontFamily = FontAwesome)) {
+            append(
+                stringResource(
+                    if (direction == SortOrder.ASCENDING) {
+                        R.string.fa_caret_up
+                    } else {
+                        R.string.fa_caret_down
+                    },
+                ),
+            )
+        }
+        append(" ")
+        append(stringResource(getStringRes()))
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverGridHeader.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverGridHeader.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.unit.dp
-import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.filter.DiscoverFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverFilterBy
 import com.github.damontecres.wholphin.data.filter.DiscoverSort
@@ -24,7 +23,6 @@ import com.github.damontecres.wholphin.data.filter.DiscoverSortAndDirection
 import com.github.damontecres.wholphin.data.filter.FilterValueOption
 import com.github.damontecres.wholphin.ui.components.DiscoverFilterByButton
 import com.github.damontecres.wholphin.ui.components.DiscoverSortByButton
-import com.github.damontecres.wholphin.ui.components.ExpandableFaButton
 import com.github.damontecres.wholphin.ui.components.GridTitle
 
 @Composable
@@ -92,12 +90,12 @@ fun DiscoverGridHeader(
                                 onShow = onShowFilterDropdown,
                             )
                         }
-                        ExpandableFaButton(
-                            title = R.string.view_options,
-                            iconStringRes = R.string.fa_sliders,
-                            onClick = onClickShowViewOptions,
-                            modifier = Modifier,
-                        )
+//                        ExpandableFaButton(
+//                            title = R.string.view_options,
+//                            iconStringRes = R.string.fa_sliders,
+//                            onClick = onClickShowViewOptions,
+//                            modifier = Modifier,
+//                        )
                     }
                 }
             }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverGridHeader.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverGridHeader.kt
@@ -1,0 +1,106 @@
+package com.github.damontecres.wholphin.ui.discover
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.unit.dp
+import com.github.damontecres.wholphin.R
+import com.github.damontecres.wholphin.data.filter.DiscoverFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverFilterBy
+import com.github.damontecres.wholphin.data.filter.DiscoverSort
+import com.github.damontecres.wholphin.data.filter.DiscoverSortAndDirection
+import com.github.damontecres.wholphin.data.filter.FilterValueOption
+import com.github.damontecres.wholphin.ui.components.DiscoverFilterByButton
+import com.github.damontecres.wholphin.ui.components.DiscoverSortByButton
+import com.github.damontecres.wholphin.ui.components.ExpandableFaButton
+import com.github.damontecres.wholphin.ui.components.GridTitle
+
+@Composable
+fun DiscoverGridHeader(
+    showHeader: Boolean,
+    showTitle: Boolean,
+    title: String,
+    sortAndDirection: DiscoverSortAndDirection,
+    onSortChange: (DiscoverSortAndDirection) -> Unit,
+    sortOptions: List<DiscoverSort>,
+    getPossibleFilterValues: suspend (DiscoverFilterBy<*>) -> List<FilterValueOption>,
+    onClickShowViewOptions: () -> Unit,
+    modifier: Modifier = Modifier,
+    currentFilter: DiscoverFilter = DiscoverFilter(),
+    filterOptions: List<DiscoverFilterBy<*>> = listOf(),
+    onFilterChange: (DiscoverFilter) -> Unit = {},
+    onShowFilterDropdown: ((Boolean) -> Unit)? = null,
+    filterButtonFocusRequester: FocusRequester = remember { FocusRequester() },
+) {
+    AnimatedVisibility(
+        showHeader,
+        enter = expandVertically(),
+        exit = shrinkVertically(),
+        modifier = modifier,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            if (showTitle) {
+                GridTitle(title)
+            }
+            val endPadding =
+                16.dp // + if (sortAndDirection.sort == DiscoverSort.ALPHABETICAL) 24.dp else 0.dp
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier =
+                    Modifier
+                        .padding(start = 16.dp, end = endPadding)
+                        .focusRestorer()
+                        .fillMaxWidth(),
+            ) {
+                if (sortOptions.isNotEmpty() || filterOptions.isNotEmpty()) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.focusRestorer(),
+                    ) {
+                        if (sortOptions.isNotEmpty()) {
+                            DiscoverSortByButton(
+                                sortOptions = sortOptions,
+                                current = sortAndDirection,
+                                onSortChange = onSortChange,
+                                modifier = Modifier,
+                            )
+                        }
+                        if (filterOptions.isNotEmpty()) {
+                            DiscoverFilterByButton(
+                                filterOptions = filterOptions,
+                                current = currentFilter,
+                                onFilterChange = onFilterChange,
+                                getPossibleValues = getPossibleFilterValues,
+                                modifier = Modifier.focusRequester(filterButtonFocusRequester),
+                                onShow = onShowFilterDropdown,
+                            )
+                        }
+                        ExpandableFaButton(
+                            title = R.string.view_options,
+                            iconStringRes = R.string.fa_sliders,
+                            onClick = onClickShowViewOptions,
+                            modifier = Modifier,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverPage.kt
@@ -79,6 +79,7 @@ fun DiscoverPage(
             3 -> {
                 DiscoverRequestGrid(
                     viewModelKey = "movies",
+                    showTitle = false,
                     destination =
                         Destination.DiscoverMoreResult(
                             DiscoverRequestType.DISCOVER_MOVIES,
@@ -95,6 +96,7 @@ fun DiscoverPage(
             4 -> {
                 DiscoverRequestGrid(
                     viewModelKey = "tv",
+                    showTitle = false,
                     destination =
                         Destination.DiscoverMoreResult(
                             DiscoverRequestType.DISCOVER_TV,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverPage.kt
@@ -78,6 +78,7 @@ fun DiscoverPage(
             // Movies
             3 -> {
                 DiscoverRequestGrid(
+                    viewModelKey = "movies",
                     destination =
                         Destination.DiscoverMoreResult(
                             DiscoverRequestType.DISCOVER_MOVIES,
@@ -93,6 +94,7 @@ fun DiscoverPage(
             // TV
             4 -> {
                 DiscoverRequestGrid(
+                    viewModelKey = "tv",
                     destination =
                         Destination.DiscoverMoreResult(
                             DiscoverRequestType.DISCOVER_TV,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverPage.kt
@@ -88,6 +88,7 @@ fun DiscoverPage(
                             DiscoverRequestType.DISCOVER_MOVIES,
                             0,
                         ),
+                    positionCallback = { columns, index -> showHeader = index < columns },
                     modifier =
                         Modifier
                             .fillMaxSize()
@@ -105,6 +106,7 @@ fun DiscoverPage(
                             DiscoverRequestType.DISCOVER_TV,
                             0,
                         ),
+                    positionCallback = { columns, index -> showHeader = index < columns },
                     modifier =
                         Modifier
                             .fillMaxSize()

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverPage.kt
@@ -14,7 +14,9 @@ import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.ErrorMessage
 import com.github.damontecres.wholphin.ui.components.TabDetails
 import com.github.damontecres.wholphin.ui.components.TabbedPage
+import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.nav.NavDrawerItem
+import com.github.damontecres.wholphin.util.DiscoverRequestType
 
 @Composable
 fun DiscoverPage(
@@ -27,6 +29,8 @@ fun DiscoverPage(
                 TabDetails(R.string.discover),
                 TabDetails(R.string.request),
                 TabDetails(R.string.search),
+                TabDetails(R.string.movies_title),
+                TabDetails(R.string.tv_shows_title),
             )
         }
     var showHeader by rememberSaveable { mutableStateOf(true) }
@@ -64,6 +68,36 @@ fun DiscoverPage(
             2 -> {
                 DiscoverSearchPage(
                     preferences = preferences,
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .focusRequester(tabDetails.contentFocusRequester),
+                )
+            }
+
+            // Movies
+            3 -> {
+                DiscoverRequestGrid(
+                    destination =
+                        Destination.DiscoverMoreResult(
+                            DiscoverRequestType.DISCOVER_MOVIES,
+                            0,
+                        ),
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .focusRequester(tabDetails.contentFocusRequester),
+                )
+            }
+
+            // TV
+            4 -> {
+                DiscoverRequestGrid(
+                    destination =
+                        Destination.DiscoverMoreResult(
+                            DiscoverRequestType.DISCOVER_TV,
+                            0,
+                        ),
                     modifier =
                         Modifier
                             .fillMaxSize()

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
@@ -1,7 +1,9 @@
 package com.github.damontecres.wholphin.ui.discover
 
 import android.content.Context
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -12,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -21,6 +24,7 @@ import com.github.damontecres.wholphin.data.filter.DiscoverSort
 import com.github.damontecres.wholphin.data.filter.DiscoverSortAndDirection
 import com.github.damontecres.wholphin.data.filter.FilterValueOption
 import com.github.damontecres.wholphin.data.filter.discoverMovieFilters
+import com.github.damontecres.wholphin.data.filter.discoverTvFilters
 import com.github.damontecres.wholphin.data.model.DiscoverItem
 import com.github.damontecres.wholphin.services.FilterOptionCache
 import com.github.damontecres.wholphin.services.NavigationManager
@@ -76,11 +80,10 @@ class DiscoverRequestViewModel
 
         init {
             viewModelScope.launchDefault {
-
                 // TODO
                 val (sortOptions, filterOptions) =
                     when (type) {
-                        DiscoverRequestType.DISCOVER_TV -> emptyList<DiscoverSort>() to emptyList()
+                        DiscoverRequestType.DISCOVER_TV -> emptyList<DiscoverSort>() to discoverTvFilters
                         DiscoverRequestType.DISCOVER_MOVIES -> DiscoverSort.entries.toList() to discoverMovieFilters
                         DiscoverRequestType.TRENDING -> emptyList<DiscoverSort>() to emptyList()
                         DiscoverRequestType.UPCOMING_TV -> emptyList<DiscoverSort>() to emptyList()
@@ -98,6 +101,7 @@ class DiscoverRequestViewModel
                     }
                 _state.update {
                     it.copy(
+                        startIndex = startIndex,
                         sortOptions = sortOptions,
                         filterOptions = filterOptions,
                         sortAndDirection = sortAndDirection,
@@ -113,6 +117,13 @@ class DiscoverRequestViewModel
             startIndex: Int = 0,
         ) {
             try {
+                _state.update {
+                    it.copy(
+                        filter = filter,
+                        sortAndDirection = sortAndDirection,
+                        loading = DataLoadingState.Loading,
+                    )
+                }
                 val filter = filter.copy(sortBy = sortAndDirection)
                 val pager =
                     when (type) {
@@ -182,12 +193,14 @@ class DiscoverRequestViewModel
 
         fun onSortChange(newSort: DiscoverSortAndDirection) {
             viewModelScope.launchDefault {
+                _state.update { it.copy(startIndex = 0) }
                 fetchData(newSort, state.value.filter)
             }
         }
 
         fun onFilterChange(newFilter: DiscoverFilter) {
             viewModelScope.launchDefault {
+                _state.update { it.copy(startIndex = 0) }
                 fetchData(state.value.sortAndDirection, newFilter)
             }
         }
@@ -198,6 +211,7 @@ class DiscoverRequestViewModel
 
 data class DiscoverRequestState(
     val loading: DataLoadingState<List<DiscoverItem?>> = DataLoadingState.Pending,
+    val startIndex: Int = 0,
     val sortOptions: List<DiscoverSort> = emptyList(),
     val filterOptions: List<DiscoverFilterBy<*>> = emptyList(),
     val filter: DiscoverFilter = DiscoverFilter(),
@@ -214,40 +228,41 @@ fun DiscoverRequestGrid(
         ),
 ) {
     val state by viewModel.state.collectAsState()
-    when (val s = state.loading) {
-        DataLoadingState.Pending,
-        DataLoadingState.Loading,
-        -> {
-            LoadingPage(modifier)
-        }
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier,
+    ) {
+        DiscoverGridHeader(
+            showHeader = true,
+            showTitle = true,
+            title = stringResource(destination.type.stringRes),
+            sortAndDirection = state.sortAndDirection,
+            onSortChange = viewModel::onSortChange,
+            sortOptions = state.sortOptions,
+            getPossibleFilterValues = viewModel::getPossibleFilterValues,
+            onClickShowViewOptions = {},
+            currentFilter = state.filter,
+            filterOptions = state.filterOptions,
+            onFilterChange = viewModel::onFilterChange,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        when (val s = state.loading) {
+            DataLoadingState.Pending,
+            DataLoadingState.Loading,
+            -> {
+                LoadingPage(Modifier)
+            }
 
-        is DataLoadingState.Error -> {
-            ErrorMessage(s, modifier)
-        }
+            is DataLoadingState.Error -> {
+                ErrorMessage(s, Modifier)
+            }
 
-        is DataLoadingState.Success<List<DiscoverItem?>> -> {
-            val gridFocusRequester = remember { FocusRequester() }
-            LaunchedEffect(Unit) { gridFocusRequester.tryRequestFocus() }
-            Column(
-                modifier = modifier,
-            ) {
-                DiscoverGridHeader(
-                    showHeader = true,
-                    showTitle = true,
-                    title = stringResource(destination.type.stringRes),
-                    sortAndDirection = state.sortAndDirection,
-                    onSortChange = viewModel::onSortChange,
-                    sortOptions = state.sortOptions,
-                    getPossibleFilterValues = viewModel::getPossibleFilterValues,
-                    onClickShowViewOptions = {},
-                    currentFilter = state.filter,
-                    filterOptions = state.filterOptions,
-                    onFilterChange = viewModel::onFilterChange,
-                    modifier = Modifier.fillMaxWidth(),
-                )
+            is DataLoadingState.Success<List<DiscoverItem?>> -> {
+                val gridFocusRequester = remember { FocusRequester() }
+                LaunchedEffect(Unit) { gridFocusRequester.tryRequestFocus() }
 
                 CardGrid(
-                    initialPosition = destination.startIndex,
+                    initialPosition = state.startIndex,
                     pager = s.data,
                     onClickItem = { index, item ->
                         viewModel.navigationManager.navigateTo(Destination.DiscoveredItem(item))
@@ -267,6 +282,7 @@ fun DiscoverRequestGrid(
                             width = Dp.Unspecified,
                         )
                     },
+                    modifier = Modifier.fillMaxSize(),
                 )
             }
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
@@ -83,7 +83,7 @@ class DiscoverRequestViewModel
                 // TODO
                 val (sortOptions, filterOptions) =
                     when (type) {
-                        DiscoverRequestType.DISCOVER_TV -> emptyList<DiscoverSort>() to discoverTvFilters
+                        DiscoverRequestType.DISCOVER_TV -> DiscoverSort.entries.toList() to discoverTvFilters
                         DiscoverRequestType.DISCOVER_MOVIES -> DiscoverSort.entries.toList() to discoverMovieFilters
                         DiscoverRequestType.TRENDING -> emptyList<DiscoverSort>() to emptyList()
                         DiscoverRequestType.UPCOMING_TV -> emptyList<DiscoverSort>() to emptyList()
@@ -130,7 +130,7 @@ class DiscoverRequestViewModel
                         DiscoverRequestType.DISCOVER_TV -> {
                             DiscoverRequestPager(
                                 api,
-                                DiscoverTvRequestHandler,
+                                DiscoverTvRequestHandler(filter),
                                 seerrService::createDiscoverItem,
                                 viewModelScope,
                             )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
@@ -50,6 +50,8 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -111,11 +113,14 @@ class DiscoverRequestViewModel
             }
         }
 
+        private var fetchJob: Job? = null
+
         private suspend fun fetchData(
             sortAndDirection: DiscoverSortAndDirection,
             filter: DiscoverFilter,
             startIndex: Int = 0,
         ) {
+            fetchJob?.cancel()
             try {
                 _state.update {
                     it.copy(
@@ -125,62 +130,67 @@ class DiscoverRequestViewModel
                     )
                 }
                 val filter = filter.copy(sortBy = sortAndDirection)
-                val pager =
-                    when (type) {
-                        DiscoverRequestType.DISCOVER_TV -> {
-                            DiscoverRequestPager(
-                                api,
-                                DiscoverTvRequestHandler(filter),
-                                seerrService::createDiscoverItem,
-                                viewModelScope,
+                fetchJob =
+                    viewModelScope.launchDefault {
+                        val pager =
+                            when (type) {
+                                DiscoverRequestType.DISCOVER_TV -> {
+                                    DiscoverRequestPager(
+                                        api,
+                                        DiscoverTvRequestHandler(filter),
+                                        seerrService::createDiscoverItem,
+                                        viewModelScope,
+                                    )
+                                }
+
+                                DiscoverRequestType.DISCOVER_MOVIES -> {
+                                    DiscoverRequestPager(
+                                        api,
+                                        DiscoverMovieRequestHandler(filter),
+                                        seerrService::createDiscoverItem,
+                                        viewModelScope,
+                                    )
+                                }
+
+                                DiscoverRequestType.TRENDING -> {
+                                    DiscoverRequestPager(
+                                        api,
+                                        TrendingRequestHandler,
+                                        seerrService::createDiscoverItem,
+                                        viewModelScope,
+                                    )
+                                }
+
+                                DiscoverRequestType.UPCOMING_TV -> {
+                                    DiscoverRequestPager(
+                                        api,
+                                        UpcomingTvRequestHandler,
+                                        seerrService::createDiscoverItem,
+                                        viewModelScope,
+                                    )
+                                }
+
+                                DiscoverRequestType.UPCOMING_MOVIES -> {
+                                    DiscoverRequestPager(
+                                        api,
+                                        UpcomingMovieRequestHandler,
+                                        seerrService::createDiscoverItem,
+                                        viewModelScope,
+                                    )
+                                }
+
+                                DiscoverRequestType.UNKNOWN -> {
+                                    throw IllegalArgumentException("Cannot display grid for DiscoverRequestType.UNKNOWN")
+                                }
+                            }.init(startIndex)
+                        _state.update {
+                            it.copy(
+                                loading = DataLoadingState.Success(pager),
                             )
                         }
-
-                        DiscoverRequestType.DISCOVER_MOVIES -> {
-                            DiscoverRequestPager(
-                                api,
-                                DiscoverMovieRequestHandler(filter),
-                                seerrService::createDiscoverItem,
-                                viewModelScope,
-                            )
-                        }
-
-                        DiscoverRequestType.TRENDING -> {
-                            DiscoverRequestPager(
-                                api,
-                                TrendingRequestHandler,
-                                seerrService::createDiscoverItem,
-                                viewModelScope,
-                            )
-                        }
-
-                        DiscoverRequestType.UPCOMING_TV -> {
-                            DiscoverRequestPager(
-                                api,
-                                UpcomingTvRequestHandler,
-                                seerrService::createDiscoverItem,
-                                viewModelScope,
-                            )
-                        }
-
-                        DiscoverRequestType.UPCOMING_MOVIES -> {
-                            DiscoverRequestPager(
-                                api,
-                                UpcomingMovieRequestHandler,
-                                seerrService::createDiscoverItem,
-                                viewModelScope,
-                            )
-                        }
-
-                        DiscoverRequestType.UNKNOWN -> {
-                            throw IllegalArgumentException("Cannot display grid for DiscoverRequestType.UNKNOWN")
-                        }
-                    }.init(startIndex)
-                _state.update {
-                    it.copy(
-                        loading = DataLoadingState.Success(pager),
-                    )
-                }
+                    }
+            } catch (ex: CancellationException) {
+                throw ex
             } catch (ex: Exception) {
                 Timber.e(ex, "Error initializing %s", type)
                 _state.update {
@@ -222,8 +232,10 @@ data class DiscoverRequestState(
 fun DiscoverRequestGrid(
     destination: Destination.DiscoverMoreResult,
     modifier: Modifier = Modifier,
+    viewModelKey: String? = null,
     viewModel: DiscoverRequestViewModel =
         hiltViewModel<DiscoverRequestViewModel, DiscoverRequestViewModel.Factory>(
+            key = viewModelKey,
             creationCallback = { it.create(destination.type, destination.startIndex) },
         ),
 ) {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
@@ -2,6 +2,7 @@ package com.github.damontecres.wholphin.ui.discover
 
 import android.content.Context
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -14,13 +15,19 @@ import androidx.compose.ui.unit.Dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.damontecres.wholphin.data.filter.DiscoverFilter
+import com.github.damontecres.wholphin.data.filter.DiscoverFilterBy
+import com.github.damontecres.wholphin.data.filter.DiscoverSort
+import com.github.damontecres.wholphin.data.filter.DiscoverSortAndDirection
+import com.github.damontecres.wholphin.data.filter.FilterValueOption
+import com.github.damontecres.wholphin.data.filter.discoverMovieFilters
 import com.github.damontecres.wholphin.data.model.DiscoverItem
+import com.github.damontecres.wholphin.services.FilterOptionCache
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.SeerrApi
 import com.github.damontecres.wholphin.services.SeerrService
 import com.github.damontecres.wholphin.ui.cards.DiscoverItemCard
 import com.github.damontecres.wholphin.ui.components.ErrorMessage
-import com.github.damontecres.wholphin.ui.components.GridTitle
 import com.github.damontecres.wholphin.ui.components.LoadingPage
 import com.github.damontecres.wholphin.ui.detail.CardGrid
 import com.github.damontecres.wholphin.ui.launchDefault
@@ -52,6 +59,7 @@ class DiscoverRequestViewModel
         private val seerrService: SeerrService,
         val navigationManager: NavigationManager,
         private val api: SeerrApi,
+        private val filterOptionCache: FilterOptionCache,
         @Assisted val type: DiscoverRequestType,
         @Assisted startIndex: Int,
     ) : ViewModel() {
@@ -68,77 +76,132 @@ class DiscoverRequestViewModel
 
         init {
             viewModelScope.launchDefault {
-                try {
-                    val pager =
-                        when (type) {
-                            DiscoverRequestType.DISCOVER_TV -> {
-                                DiscoverRequestPager(
-                                    api,
-                                    DiscoverTvRequestHandler,
-                                    seerrService::createDiscoverItem,
-                                    viewModelScope,
-                                )
-                            }
 
-                            DiscoverRequestType.DISCOVER_MOVIES -> {
-                                DiscoverRequestPager(
-                                    api,
-                                    DiscoverMovieRequestHandler,
-                                    seerrService::createDiscoverItem,
-                                    viewModelScope,
-                                )
-                            }
-
-                            DiscoverRequestType.TRENDING -> {
-                                DiscoverRequestPager(
-                                    api,
-                                    TrendingRequestHandler,
-                                    seerrService::createDiscoverItem,
-                                    viewModelScope,
-                                )
-                            }
-
-                            DiscoverRequestType.UPCOMING_TV -> {
-                                DiscoverRequestPager(
-                                    api,
-                                    UpcomingTvRequestHandler,
-                                    seerrService::createDiscoverItem,
-                                    viewModelScope,
-                                )
-                            }
-
-                            DiscoverRequestType.UPCOMING_MOVIES -> {
-                                DiscoverRequestPager(
-                                    api,
-                                    UpcomingMovieRequestHandler,
-                                    seerrService::createDiscoverItem,
-                                    viewModelScope,
-                                )
-                            }
-
-                            DiscoverRequestType.UNKNOWN -> {
-                                throw IllegalArgumentException("Cannot display grid for DiscoverRequestType.UNKNOWN")
-                            }
-                        }.init(startIndex)
-                    _state.update {
-                        it.copy(
-                            loading = DataLoadingState.Success(pager),
-                        )
+                // TODO
+                val (sortOptions, filterOptions) =
+                    when (type) {
+                        DiscoverRequestType.DISCOVER_TV -> emptyList<DiscoverSort>() to emptyList()
+                        DiscoverRequestType.DISCOVER_MOVIES -> DiscoverSort.entries.toList() to discoverMovieFilters
+                        DiscoverRequestType.TRENDING -> emptyList<DiscoverSort>() to emptyList()
+                        DiscoverRequestType.UPCOMING_TV -> emptyList<DiscoverSort>() to emptyList()
+                        DiscoverRequestType.UPCOMING_MOVIES -> emptyList<DiscoverSort>() to emptyList()
+                        DiscoverRequestType.UNKNOWN -> emptyList<DiscoverSort>() to emptyList()
                     }
-                } catch (ex: Exception) {
-                    Timber.e(ex, "Error initializing %s", type)
-                    _state.update {
-                        it.copy(
-                            loading = DataLoadingState.Error(ex),
-                        )
+                val sortAndDirection =
+                    when (type) {
+                        DiscoverRequestType.DISCOVER_TV -> DiscoverSortAndDirection()
+                        DiscoverRequestType.DISCOVER_MOVIES -> DiscoverSortAndDirection()
+                        DiscoverRequestType.TRENDING -> DiscoverSortAndDirection()
+                        DiscoverRequestType.UPCOMING_TV -> DiscoverSortAndDirection()
+                        DiscoverRequestType.UPCOMING_MOVIES -> DiscoverSortAndDirection()
+                        DiscoverRequestType.UNKNOWN -> DiscoverSortAndDirection()
                     }
+                _state.update {
+                    it.copy(
+                        sortOptions = sortOptions,
+                        filterOptions = filterOptions,
+                        sortAndDirection = sortAndDirection,
+                    )
+                }
+                fetchData(sortAndDirection, DiscoverFilter(), startIndex)
+            }
+        }
+
+        private suspend fun fetchData(
+            sortAndDirection: DiscoverSortAndDirection,
+            filter: DiscoverFilter,
+            startIndex: Int = 0,
+        ) {
+            try {
+                val filter = filter.copy(sortBy = sortAndDirection)
+                val pager =
+                    when (type) {
+                        DiscoverRequestType.DISCOVER_TV -> {
+                            DiscoverRequestPager(
+                                api,
+                                DiscoverTvRequestHandler,
+                                seerrService::createDiscoverItem,
+                                viewModelScope,
+                            )
+                        }
+
+                        DiscoverRequestType.DISCOVER_MOVIES -> {
+                            DiscoverRequestPager(
+                                api,
+                                DiscoverMovieRequestHandler(filter),
+                                seerrService::createDiscoverItem,
+                                viewModelScope,
+                            )
+                        }
+
+                        DiscoverRequestType.TRENDING -> {
+                            DiscoverRequestPager(
+                                api,
+                                TrendingRequestHandler,
+                                seerrService::createDiscoverItem,
+                                viewModelScope,
+                            )
+                        }
+
+                        DiscoverRequestType.UPCOMING_TV -> {
+                            DiscoverRequestPager(
+                                api,
+                                UpcomingTvRequestHandler,
+                                seerrService::createDiscoverItem,
+                                viewModelScope,
+                            )
+                        }
+
+                        DiscoverRequestType.UPCOMING_MOVIES -> {
+                            DiscoverRequestPager(
+                                api,
+                                UpcomingMovieRequestHandler,
+                                seerrService::createDiscoverItem,
+                                viewModelScope,
+                            )
+                        }
+
+                        DiscoverRequestType.UNKNOWN -> {
+                            throw IllegalArgumentException("Cannot display grid for DiscoverRequestType.UNKNOWN")
+                        }
+                    }.init(startIndex)
+                _state.update {
+                    it.copy(
+                        loading = DataLoadingState.Success(pager),
+                    )
+                }
+            } catch (ex: Exception) {
+                Timber.e(ex, "Error initializing %s", type)
+                _state.update {
+                    it.copy(
+                        loading = DataLoadingState.Error(ex),
+                    )
                 }
             }
         }
+
+        fun onSortChange(newSort: DiscoverSortAndDirection) {
+            viewModelScope.launchDefault {
+                fetchData(newSort, state.value.filter)
+            }
+        }
+
+        fun onFilterChange(newFilter: DiscoverFilter) {
+            viewModelScope.launchDefault {
+                fetchData(state.value.sortAndDirection, newFilter)
+            }
+        }
+
+        suspend fun getPossibleFilterValues(filter: DiscoverFilterBy<*>): List<FilterValueOption> =
+            filterOptionCache.getFilterOptionValues(null, filter)
     }
 
 data class DiscoverRequestState(
     val loading: DataLoadingState<List<DiscoverItem?>> = DataLoadingState.Pending,
+    val sortOptions: List<DiscoverSort> = emptyList(),
+    val filterOptions: List<DiscoverFilterBy<*>> = emptyList(),
+    val filter: DiscoverFilter = DiscoverFilter(),
+    val sortAndDirection: DiscoverSortAndDirection = DiscoverSortAndDirection(),
 )
 
 @Composable
@@ -168,7 +231,20 @@ fun DiscoverRequestGrid(
             Column(
                 modifier = modifier,
             ) {
-                GridTitle(stringResource(destination.type.stringRes))
+                DiscoverGridHeader(
+                    showHeader = true,
+                    showTitle = true,
+                    title = stringResource(destination.type.stringRes),
+                    sortAndDirection = state.sortAndDirection,
+                    onSortChange = viewModel::onSortChange,
+                    sortOptions = state.sortOptions,
+                    getPossibleFilterValues = viewModel::getPossibleFilterValues,
+                    onClickShowViewOptions = {},
+                    currentFilter = state.filter,
+                    filterOptions = state.filterOptions,
+                    onFilterChange = viewModel::onFilterChange,
+                    modifier = Modifier.fillMaxWidth(),
+                )
 
                 CardGrid(
                     initialPosition = destination.startIndex,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
@@ -242,6 +242,7 @@ data class DiscoverRequestState(
 fun DiscoverRequestGrid(
     destination: Destination.DiscoverMoreResult,
     showTitle: Boolean,
+    positionCallback: (columns: Int, position: Int) -> Unit,
     modifier: Modifier = Modifier,
     viewModelKey: String? = null,
     viewModel: DiscoverRequestViewModel =
@@ -266,7 +267,9 @@ fun DiscoverRequestGrid(
         DiscoverGridHeader(
             showHeader = showHeader,
             showTitle = showTitle,
-            title = stringResource(destination.type.stringRes),
+            title =
+                destination.titleOverride?.getString()
+                    ?: stringResource(destination.type.stringRes),
             sortAndDirection = state.sortAndDirection,
             onSortChange = viewModel::onSortChange,
             sortOptions = state.sortOptions,
@@ -313,7 +316,10 @@ fun DiscoverRequestGrid(
                         )
                     },
                     columns = 6,
-                    positionCallback = { columns, index -> showHeader = index < columns },
+                    positionCallback = { columns, index ->
+                        showHeader = index < columns
+                        positionCallback.invoke(columns, index)
+                    },
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverRequestGrid.kt
@@ -9,7 +9,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.res.stringResource
@@ -231,6 +233,7 @@ data class DiscoverRequestState(
 @Composable
 fun DiscoverRequestGrid(
     destination: Destination.DiscoverMoreResult,
+    showTitle: Boolean,
     modifier: Modifier = Modifier,
     viewModelKey: String? = null,
     viewModel: DiscoverRequestViewModel =
@@ -240,13 +243,15 @@ fun DiscoverRequestGrid(
         ),
 ) {
     val state by viewModel.state.collectAsState()
+
+    var showHeader by remember { mutableStateOf(state.startIndex < 6) }
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier,
     ) {
         DiscoverGridHeader(
-            showHeader = true,
-            showTitle = true,
+            showHeader = showHeader,
+            showTitle = showTitle,
             title = stringResource(destination.type.stringRes),
             sortAndDirection = state.sortAndDirection,
             onSortChange = viewModel::onSortChange,
@@ -294,6 +299,8 @@ fun DiscoverRequestGrid(
                             width = Dp.Unspecified,
                         )
                     },
+                    columns = 6,
+                    positionCallback = { columns, index -> showHeader = index < columns },
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
@@ -406,6 +406,7 @@ fun DestinationContent(
             DiscoverRequestGrid(
                 destination = destination,
                 showTitle = true,
+                positionCallback = { _, _ -> },
                 modifier = modifier,
             )
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
@@ -405,6 +405,7 @@ fun DestinationContent(
             LaunchedEffect(Unit) { onClearBackdrop.invoke() }
             DiscoverRequestGrid(
                 destination = destination,
+                showTitle = true,
                 modifier = modifier,
             )
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/util/DiscoverRequestPager.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/DiscoverRequestPager.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.api.seerr.model.MovieResult
 import com.github.damontecres.wholphin.api.seerr.model.TvResult
+import com.github.damontecres.wholphin.data.filter.DiscoverFilter
 import com.github.damontecres.wholphin.data.model.DiscoverItem
 import com.github.damontecres.wholphin.services.SeerrApi
 import com.github.damontecres.wholphin.services.SeerrSearchResult
@@ -66,16 +67,17 @@ val DiscoverTvRequestHandler =
             }
     }
 
-val DiscoverMovieRequestHandler =
-    object : DiscoverRequestHandler<MovieResult> {
-        override suspend fun execute(
-            api: SeerrApi,
-            pageNumber: Int,
-        ): QueryResult<MovieResult> =
-            api.api.searchApi.discoverMoviesGet(page = pageNumber).let {
-                QueryResult(it.results.orEmpty(), it.totalResults ?: 0)
-            }
-    }
+class DiscoverMovieRequestHandler(
+    val filter: DiscoverFilter = DiscoverFilter(),
+) : DiscoverRequestHandler<MovieResult> {
+    override suspend fun execute(
+        api: SeerrApi,
+        pageNumber: Int,
+    ): QueryResult<MovieResult> =
+        filter.discoverMovies(api.api.searchApi, pageNumber).let {
+            QueryResult(it.results.orEmpty(), it.totalResults ?: 0)
+        }
+}
 
 val TrendingRequestHandler =
     object : DiscoverRequestHandler<SeerrSearchResult> {

--- a/app/src/main/java/com/github/damontecres/wholphin/util/DiscoverRequestPager.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/DiscoverRequestPager.kt
@@ -56,16 +56,17 @@ interface DiscoverRequestHandler<T> {
     ): QueryResult<T>
 }
 
-val DiscoverTvRequestHandler =
-    object : DiscoverRequestHandler<TvResult> {
-        override suspend fun execute(
-            api: SeerrApi,
-            pageNumber: Int,
-        ): QueryResult<TvResult> =
-            api.api.searchApi.discoverTvGet(page = pageNumber).let {
-                QueryResult(it.results.orEmpty(), it.totalResults ?: 0)
-            }
-    }
+class DiscoverTvRequestHandler(
+    val filter: DiscoverFilter = DiscoverFilter(),
+) : DiscoverRequestHandler<TvResult> {
+    override suspend fun execute(
+        api: SeerrApi,
+        pageNumber: Int,
+    ): QueryResult<TvResult> =
+        filter.discoverTv(api.api.searchApi, pageNumber).let {
+            QueryResult(it.results.orEmpty(), it.totalResults ?: 0)
+        }
+}
 
 class DiscoverMovieRequestHandler(
     val filter: DiscoverFilter = DiscoverFilter(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -822,4 +822,5 @@
     <string name="sort">Sort</string>
     <string name="split_into_separate_rows">Split into separate rows</string>
     <string name="popularity">Popularity</string>
+    <string name="production_status">Production status</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -821,4 +821,5 @@
     <string name="tomatoes">Tomatoes</string>
     <string name="sort">Sort</string>
     <string name="split_into_separate_rows">Split into separate rows</string>
+    <string name="popularity">Popularity</string>
 </resources>

--- a/app/src/main/seerr/seerr-api.yml
+++ b/app/src/main/seerr/seerr-api.yml
@@ -1200,6 +1200,7 @@ components:
             $ref: '#/components/schemas/Season'
         status:
           type: string
+          enum: ["Returning Series", "Planned", "In Production", "Ended", "Cancelled", "Pilot"]
         tagline:
           type: string
         type:


### PR DESCRIPTION
## Description
This PR adds sort & filter options for the discover grid pages.

Sort options:
- Popularity
- Release date
- "Community rating" (TMDB user vote)
- Name

Filter options:
- Genre
- Studio/Network
- "Community rating" (TMDB user vote)
- Parental rating
- Production status (TV only)

Also, two more tabs are added to the discover page for browsing movies and TV. These are essentially the same as clicking "View more" on the respective rows on the Discover tab.

### Limitations

This PR hardcodes the region used for studio listing and filtering to "United States". I'll work on a follow up PR to enable users to specify this.

The sort & filters are not persisted. I think they should be on the two new tabs, but not elsewhere, but this will be a follow up PR.

### Related issues
Related to #702 
Implements some of #1511
Rewrites the filter logic in #1610 

### Testing
Emulator, but needs further testing

## Screenshots
<img width="1280" height="720" alt="discover_filters Large" src="https://github.com/user-attachments/assets/cdefb95c-c4b7-4e06-9bac-b535d372ba03" />


## AI or LLM usage
None
