### PR TITLE
Prefer non-forced when subtitle preference is always on

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/StreamChoiceService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/StreamChoiceService.kt
@@ -277,8 +277,10 @@ class StreamChoiceService
                     SubtitlePlaybackMode.ALWAYS -> {
                         if (subtitleLanguage.isNotNullOrBlank()) {
                             candidates.firstOrNull {
-                                it.language.equals(subtitleLanguage, true) ||
-                                    it.language.isUnknown
+                                // Prefer non-forced first
+                                !it.isForced && it.language.equalsLangOrUnknown(subtitleLanguage)
+                            } ?: candidates.firstOrNull {
+                                it.language.equalsLangOrUnknown(subtitleLanguage)
                             }
                         } else {
                             candidates.firstOrNull()
@@ -371,3 +373,5 @@ private val String?.isUnknown: Boolean
             this.equals("undetermined", true) ||
             this.equals("mul", true) ||
             this.equals("zxx", true)
+
+private fun String?.equalsLangOrUnknown(lang: String): Boolean = equals(lang, ignoreCase = true) || this.isUnknown

--- a/app/src/main/java/com/github/damontecres/wholphin/services/StreamChoiceService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/StreamChoiceService.kt
@@ -283,7 +283,7 @@ class StreamChoiceService
                                 it.language.equalsLangOrUnknown(subtitleLanguage)
                             }
                         } else {
-                            candidates.firstOrNull()
+                            candidates.firstOrNull { !it.isForced } ?: candidates.firstOrNull()
                         }
                     }
 

--- a/app/src/test/java/com/github/damontecres/wholphin/services/StreamChoiceServiceTest.kt
+++ b/app/src/test/java/com/github/damontecres/wholphin/services/StreamChoiceServiceTest.kt
@@ -113,6 +113,16 @@ class StreamChoiceServiceTest(
                         ),
                 ),
                 TestInput(
+                    1,
+                    SubtitlePlaybackMode.ALWAYS,
+                    userSubtitleLang = null,
+                    subtitles =
+                        listOf(
+                            subtitle(0, "eng", default = true, forced = true),
+                            subtitle(1, "eng", default = false, forced = false),
+                        ),
+                ),
+                TestInput(
                     0,
                     SubtitlePlaybackMode.SMART,
                     userSubtitleLang = "eng",
@@ -317,7 +327,7 @@ class TestStreamChoiceServiceSmart(
                 TestInput(
                     0,
                     SubtitlePlaybackMode.SMART,
-                    userSubtitleLang = "end",
+                    userSubtitleLang = "eng",
                     subtitles =
                         listOf(
                             subtitle(0, "eng", false),

--- a/app/src/test/java/com/github/damontecres/wholphin/services/StreamChoiceServiceTest.kt
+++ b/app/src/test/java/com/github/damontecres/wholphin/services/StreamChoiceServiceTest.kt
@@ -102,6 +102,46 @@ class StreamChoiceServiceTest(
                         ),
                     itemPlayback = itemPlayback(subtitleIndex = TrackIndex.UNSPECIFIED),
                 ),
+                TestInput(
+                    1,
+                    SubtitlePlaybackMode.ALWAYS,
+                    userSubtitleLang = "eng",
+                    subtitles =
+                        listOf(
+                            subtitle(0, "eng", default = true, forced = true),
+                            subtitle(1, "eng", default = false, forced = false),
+                        ),
+                ),
+                TestInput(
+                    0,
+                    SubtitlePlaybackMode.SMART,
+                    userSubtitleLang = "eng",
+                    subtitles =
+                        listOf(
+                            subtitle(0, "eng", default = true, forced = true),
+                            subtitle(1, "eng", default = false, forced = false),
+                        ),
+                ),
+                TestInput(
+                    0,
+                    SubtitlePlaybackMode.ONLY_FORCED,
+                    userSubtitleLang = "eng",
+                    subtitles =
+                        listOf(
+                            subtitle(0, "eng", default = true, forced = true),
+                            subtitle(1, "eng", default = false, forced = false),
+                        ),
+                ),
+                TestInput(
+                    null,
+                    SubtitlePlaybackMode.NONE,
+                    userSubtitleLang = "eng",
+                    subtitles =
+                        listOf(
+                            subtitle(0, "eng", default = true, forced = true),
+                            subtitle(1, "eng", default = false, forced = false),
+                        ),
+                ),
             )
     }
 }
@@ -277,6 +317,7 @@ class TestStreamChoiceServiceSmart(
                 TestInput(
                     0,
                     SubtitlePlaybackMode.SMART,
+                    userSubtitleLang = "end",
                     subtitles =
                         listOf(
                             subtitle(0, "eng", false),
@@ -488,7 +529,7 @@ class TestStreamChoiceServiceMultipleChoices(
         fun data(): Collection<TestInput> =
             listOf(
                 TestInput(
-                    0,
+                    1,
                     SubtitlePlaybackMode.ALWAYS,
                     subtitles =
                         listOf(


### PR DESCRIPTION
## Description
If subtitles preferences are "Always", this PR will prefer non-forced tracks even if any forced ones are default tracks.

This is in-line with the web UI from my testing and another review of the code.

### Related issues
Fixes https://github.com/damontecres/Wholphin/issues/790#issuecomment-4708705576

### Testing
Unit tests

## Screenshots
N/A

## AI or LLM usage
None