### PR TITLE
Fix MPV minify crash

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,6 +1,6 @@
 -keepattributes SourceFile,LineNumberTable
 
--keep class com.github.damontecres.wholphin.util.mpv.* { *; }
+-keep class com.github.damontecres.wholphin.mpv.MPVLib { *; }
 
 -keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
 -keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite {


### PR DESCRIPTION
## Description
Fixes a crash when trying to play content via MPV on release builds.

After #1365, the package name for `MPVLib` changed, so the existing proguard rule no longer applied. This meant the native code could no longer find the right class.

### Related issues
Fixes #1633
https://github.com/damontecres/wholphin-extensions/pull/9 fixes this upstream

### Testing
Tested release builds on emulator

## Screenshots
N/A

## AI or LLM usage
None