### PR TITLE
Add option to never automatically hide controls

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -15,6 +15,7 @@ import com.github.damontecres.wholphin.ui.preferences.PreferenceGroup
 import com.github.damontecres.wholphin.ui.preferences.PreferenceScreenOption
 import com.github.damontecres.wholphin.ui.preferences.PreferenceValidation
 import com.github.damontecres.wholphin.util.DebugLogTree
+import java.util.Locale
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -119,18 +120,25 @@ sealed interface AppPreference<Pref, T> {
                 title = R.string.hide_controller_timeout,
                 defaultValue = 5000,
                 min = 500,
-                max = 15.seconds.inWholeMilliseconds,
+                max = 15_100, // Max 15 seconds but 15.1 is treated as never
                 interval = 100,
-                getter = { it.playbackPreferences.controllerTimeoutMs },
+                getter = { it.playbackPreferences.controllerTimeoutMs.coerceIn(500, 15_100) },
                 setter = { prefs, value ->
-                    prefs.updatePlaybackPreferences { controllerTimeoutMs = value }
+                    val toSave =
+                        if (value > 15_000) {
+                            Long.MAX_VALUE
+                        } else {
+                            value
+                        }
+                    prefs.updatePlaybackPreferences { controllerTimeoutMs = toSave }
                 },
                 summarizer = { value ->
                     value?.let {
-                        WholphinApplication.instance.getString(
-                            R.string.decimal_seconds,
-                            value / 1000.0,
-                        )
+                        if (value > 15_000) {
+                            WholphinApplication.instance.getString(R.string.next_up_never)
+                        } else {
+                            String.format(Locale.getDefault(), "%.2fs", value / 1000.0)
+                        }
                     }
                 },
             )
@@ -277,10 +285,14 @@ sealed interface AppPreference<Pref, T> {
                     }
                 },
                 summarizer = { value ->
-                    if (value == 0L) {
+                    if (value == null || value == 0L) {
                         WholphinApplication.instance.getString(R.string.disabled)
                     } else {
-                        "${value}s"
+                        WholphinApplication.instance.resources.getQuantityString(
+                            R.plurals.seconds,
+                            value.toInt(),
+                            value.toInt(),
+                        )
                     }
                 },
             )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/ComposablePreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/ComposablePreference.kt
@@ -238,6 +238,26 @@ fun <T> ComposablePreference(
                 onChange = { onValueChange(it as T) },
                 summaryBelow = false,
                 interactionSource = interactionSource,
+                labelWidth =
+                    remember(preference) {
+                        when (preference) {
+                            AppPreference.ControllerTimeout -> 40.dp
+
+                            AppPreference.ImageDiskCacheSize,
+                            AppPreference.MaxBitrate,
+                            AppPreference.PassOutProtection,
+                            -> 64.dp
+
+                            AppPreference.SkipForward,
+                            AppPreference.SkipBack,
+                            AppPreference.AutoPlayNextDelay,
+                            -> 72.dp
+
+                            AppPreference.SlideshowDuration -> 84.dp
+
+                            else -> 72.dp // Dp.Unspecified
+                        }
+                    },
                 modifier = modifier,
             )
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/SliderPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/SliderPreference.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -38,6 +39,7 @@ fun SliderPreference(
     summaryBelow: Boolean = false,
     heightAdjustment: Dp = 0.dp,
     additionalSummary: @Composable (ColumnScope.() -> Unit)? = null,
+    labelWidth: Dp = Dp.Unspecified,
 ) {
     val focused = interactionSource.collectIsFocusedAsState().value
     val background =
@@ -83,7 +85,11 @@ fun SliderPreference(
             )
 
             if (!summaryBelow) {
-                PreferenceSummary(summary, color = contentColor)
+                PreferenceSummary(
+                    summary,
+                    color = contentColor,
+                    modifier = Modifier.width(labelWidth),
+                )
             }
         }
         if (summaryBelow) {


### PR DESCRIPTION
## Description
Adds an option to disable automatically hiding playback controls. It can be enabled by by moving higher than 15 seconds.

Also, a slight UI tweaks to use a fixed width for the slider preference labels. This prevents the slider bar from changing size if the label becomes shorter or longer (eg "9 seconds"=>"10 seconds").

### Related issues
Closes #1629

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
<!-- If you used any AI or LLM assistance, please list where in the code and how you tested it -->
