### PR TITLE
Fix ExoPlayer accessed on wrong thread when changing tracks

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -912,11 +912,12 @@ class PlaybackViewModel
                         } else {
                             _state.update { it.copy(currentItemPlayback = itemPlayback) }
                         }
+                        val currentTracks = onMain { player.currentTracks }
                         _state.update {
                             it.copy(
                                 currentPlayback =
                                     (it.currentPlayback ?: currentPlayback).copy(
-                                        tracks = checkForSupport(player.currentTracks),
+                                        tracks = checkForSupport(currentTracks),
                                     ),
                             )
                         }


### PR DESCRIPTION
## Description
`changeStreamsDirectPlay` was reading `player.currentTracks` on the IO dispatcher. ExoPlayer requires player access on the main thread, so switching audio/subtitle tracks during direct play could crash with `IllegalStateException: Player is accessed on the wrong thread`.

This reads the tracks via `onMain` first (same pattern already used elsewhere in that function), then uses that value for `checkForSupport`.

### Related issues
No existing issue. Reproduced while changing subtitle tracks during direct play; logcat showed:
`Player is accessed on the wrong thread` / `Expected thread: 'main'` / `Current thread: 'DefaultDispatcher-worker-…'` from `PlaybackViewModel.changeStreamsDirectPlay`.

### Testing
- Reproduced the crash on device before the fix when changing tracks during direct play
- After the fix, changing audio/subtitle tracks during direct play no longer crashes

## Screenshots
N/A

## AI or LLM usage
Cursor/Claude helped locate the crash from logcat and apply the one-line fix. I reviewed the change and can maintain it.