### PR TITLE
Fix subtitle outline width not applying in release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -11,3 +11,14 @@
 
 # TODO investigate using smaller scope
 -keep class com.google.common.cache.** { *; }
+
+# Media3SubtitleOverride uses reflection to access/modify these fields
+-keep class androidx.media3.ui.SubtitleView {
+  private androidx.media3.ui.SubtitleView$Output output;
+}
+-keep class androidx.media3.ui.CanvasSubtitleOutput {
+  private final java.util.List painters;
+}
+-keep class androidx.media3.ui.SubtitlePainter {
+  private final float outlineWidth;
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/util/Media3SubtitleOverride.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/Media3SubtitleOverride.kt
@@ -1,5 +1,7 @@
 package com.github.damontecres.wholphin.util
 
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.SubtitleView
 import timber.log.Timber
 import java.lang.reflect.Field
@@ -7,6 +9,7 @@ import java.lang.reflect.Field
 /**
  * Utility class to override private fields in media3's [SubtitleView]
  */
+@OptIn(UnstableApi::class)
 class Media3SubtitleOverride(
     val outlineThicknessPx: Float,
 ) {


### PR DESCRIPTION
## Description
Fix applying the subtitle outline width in ExoPlayer for release builds

The outline width field isn't public, so reflection is used to bypass and modify it. Since proguard/r8 renames all of the classes and fields, this meant the field was no longer found. The fix is to have proguard preserve the necessary field names.

### Related issues
Fixes #1681

### Testing
Emulator w/ release build

## Screenshots
N/a

## AI or LLM usage
None