### PR TITLE
Various minor bug fixes

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/StreamChoiceService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/StreamChoiceService.kt
@@ -138,17 +138,7 @@ class StreamChoiceService
                     playbackLanguageChoice?.audioLanguage?.takeIf { it.isNotNullOrBlank() }
                 // If the user has chosen a different language for the series, prefer that
                 val audioLanguage =
-                    if (seriesLang != null) {
-                        seriesLang
-                    } else {
-                        val pref = prefs.userPreferences?.preferredAudioLanguage
-                        when (pref) {
-                            UserProfileSettings.USE_USER_PROFILE -> userConfig?.audioLanguagePreference
-                            UserProfileSettings.PREFER_ANY_LANGUAGE -> null
-                            else -> pref
-                        }
-                    }
-
+                    seriesLang ?: getPreferredLanguage(MediaStreamType.AUDIO, prefs, userConfig)
                 if (audioLanguage.isNotNullOrBlank()) {
                     val sorted =
                         candidates.sortedWith(compareBy<MediaStream> { it.language }.thenByDescending { it.channels })
@@ -242,16 +232,7 @@ class StreamChoiceService
             val seriesLang =
                 playbackLanguageChoice?.subtitleLanguage?.takeIf { it.isNotNullOrBlank() }
             val subtitleLanguage =
-                if (seriesLang != null) {
-                    seriesLang
-                } else {
-                    val pref = prefs.userPreferences?.preferredSubtitleLanguage
-                    when (pref) {
-                        UserProfileSettings.USE_USER_PROFILE -> userConfig?.subtitleLanguagePreference
-                        UserProfileSettings.PREFER_ANY_LANGUAGE -> null
-                        else -> pref
-                    }?.takeIf { it.isNotNullOrBlank() }
-                }
+                seriesLang ?: getPreferredLanguage(MediaStreamType.SUBTITLE, prefs, userConfig)
             if (itemPlayback?.subtitleIndex == TrackIndex.ONLY_FORCED) {
                 // Client-side manual override: User selected "Only Forced" in player menu
                 return findForcedTrack(candidates, subtitleLanguage, audioStreamLang)
@@ -398,3 +379,36 @@ private val String?.isUnknown: Boolean
             this.equals("zxx", true)
 
 private fun String?.equalsLangOrUnknown(lang: String): Boolean = equals(lang, ignoreCase = true) || this.isUnknown
+
+/**
+ * Based on the user's preferences, get their preferred language for audio or subtitles
+ *
+ * @param prefs the [UserPreferences]
+ */
+fun getPreferredLanguage(
+    type: MediaStreamType,
+    prefs: UserPreferences,
+    userConfig: UserConfiguration?,
+): String? {
+    val (pref, profileLang) =
+        when (type) {
+            MediaStreamType.AUDIO -> {
+                prefs.userPreferences?.preferredAudioLanguage to
+                    userConfig?.audioLanguagePreference
+            }
+
+            MediaStreamType.SUBTITLE -> {
+                prefs.userPreferences?.preferredSubtitleLanguage to
+                    userConfig?.subtitleLanguagePreference
+            }
+
+            else -> {
+                throw IllegalArgumentException("Only audio or subtitle supported, not $type")
+            }
+        }
+    return when (pref) {
+        UserProfileSettings.USE_USER_PROFILE -> profileLang
+        UserProfileSettings.PREFER_ANY_LANGUAGE -> null
+        else -> pref
+    }?.takeIf { it.isNotNullOrBlank() }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/HiddenFocusBox.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/HiddenFocusBox.kt
@@ -25,7 +25,7 @@ fun HiddenFocusBox(
     modifier =
         Modifier
             .fillMaxWidth()
-            .height(1.dp)
+            .height(0.dp)
             .focusRequester(focusRequester)
             .onFocusChanged {
                 if (it.isFocused) onFocus.invoke()

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/PersonPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/PersonPage.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -503,8 +504,9 @@ fun PersonHeader(
                 val text =
                     if (age != null) {
                         stringResource(R.string.born) + ": ${formatDate(it)} (${
-                            stringResource(
-                                R.string.years_old,
+                            pluralStringResource(
+                                R.plurals.years_old,
+                                age,
                                 age,
                             )
                         })"
@@ -533,8 +535,9 @@ fun PersonHeader(
                 val text =
                     if (age != null) {
                         stringResource(R.string.died) + ": ${formatDate(it)} (${
-                            stringResource(
-                                R.string.years_old,
+                            pluralStringResource(
+                                R.plurals.years_old,
+                                age,
                                 age,
                             )
                         })"

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionDetails.kt
@@ -343,6 +343,7 @@ fun CollectionDetailsContent(
                                 modifier =
                                     Modifier
                                         .padding(
+                                            start = HeaderUtils.startPadding,
                                             top = HeaderUtils.topPadding,
                                             bottom = 8.dp,
                                         ).height(HeaderUtils.height),

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/NavDrawer.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/NavDrawer.kt
@@ -432,6 +432,7 @@ fun NavDrawer(
                                     viewModel.setIndex(HOME_INDEX)
                                     if (destination is Destination.Home) {
                                         viewModel.navigationManager.reloadHome()
+                                        onClearBackdrop.invoke()
                                     } else {
                                         viewModel.navigationManager.goToHome()
                                     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -181,7 +181,7 @@ class PlaybackViewModel
         private val _state = MutableStateFlow(PlaybackState())
         val state: StateFlow<PlaybackState> = _state
 
-        private lateinit var preferences: UserPreferences
+        internal lateinit var preferences: UserPreferences
         internal lateinit var itemId: UUID
         internal lateinit var currentItem: PlaylistItem
         internal var forceTranscoding: Boolean = false

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/SubtitleSearchUtils.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/SubtitleSearchUtils.kt
@@ -7,6 +7,7 @@ import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.PlaylistItem
 import com.github.damontecres.wholphin.data.model.TrackIndex
+import com.github.damontecres.wholphin.services.getPreferredLanguage
 import com.github.damontecres.wholphin.ui.isNotNullOrBlank
 import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.ui.onMain
@@ -42,15 +43,17 @@ sealed interface SubtitleSearchStatus {
 /**
  * Trigger a search for subtitles in the given language for the currently playing media
  */
-fun PlaybackViewModel.searchForSubtitles(
-    language: String =
-        serverRepository
-            .currentUserDto
-            ?.configuration
-            ?.subtitleLanguagePreference
-            ?.takeIf { it.isNotNullOrBlank() }
-            ?: Locale.current.language,
-) {
+fun PlaybackViewModel.searchForSubtitles(language: String? = null) {
+    val language =
+        language ?: getPreferredLanguage(
+            MediaStreamType.SUBTITLE,
+            preferences,
+            serverRepository
+                .currentUserDto
+                ?.configuration,
+        )?.takeIf { it.isNotNullOrBlank() }
+            ?: Locale.current.language
+
     subtitleSearchState.update {
         it.copy(
             status = SubtitleSearchStatus.Searching,

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -161,7 +161,9 @@
     <string name="video">Video</string>
     <string name="videos">Videa</string>
     <string name="watch_live">Sledujte živě</string>
-    <string name="years_old">%1$d let starý</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d let starý</item>
+    </plurals>
     <string name="play_with_transcoding">Přehraj s překódováním</string>
     <string name="media_information">Informace o médiu</string>
     <string name="show_clock">Zobrazit hodiny</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -164,7 +164,9 @@
     <string name="video">Video</string>
     <string name="videos">Videoer</string>
     <string name="watch_live">Se direkte</string>
-    <string name="years_old">%1$d år gammel</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d år gammel</item>
+    </plurals>
     <string name="play_with_transcoding">Afspil med transkodning</string>
     <string name="media_information">Medieinformation</string>
     <string name="show_clock">Vis ur</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -58,7 +58,9 @@
     <string name="updates">Aktualisierungen</string>
     <string name="version">Version</string>
     <string name="watch_live">Live ansehen</string>
-    <string name="years_old">%1$d Jahre alt</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d Jahre alt</item>
+    </plurals>
     <string name="extras_title">Extras</string>
     <plurals name="scenes">
         <item quantity="one">Szene</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -73,7 +73,9 @@
     <string name="version">Versión</string>
     <string name="video">Vídeo</string>
     <string name="videos">Vídeos</string>
-    <string name="years_old">%1$d años</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d años</item>
+    </plurals>
     <string name="play_with_transcoding">Reproducir con transcodificación</string>
     <string name="show_clock">Mostrar reloj</string>
     <string name="create_playlist">Crear nueva lista de reproducción</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -231,7 +231,9 @@
     <string name="video">Video</string>
     <string name="videos">Videod</string>
     <string name="watch_live">Vaata otse-eetris</string>
-    <string name="years_old">%1$d aasta(t) vana</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d aasta(t) vana</item>
+    </plurals>
     <string name="play_with_transcoding">Esita koos teisendamisega</string>
     <string name="show_clock">Näita kella</string>
     <string name="aired_episode_order">Eetris olnud osade järjestus</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -178,7 +178,9 @@
     <string name="tv_guide">Guide</string>
     <string name="ui_interface">Interface</string>
     <string name="video_scale">Échelle de la vidéo</string>
-    <string name="years_old">%1$d ans</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d ans</item>
+    </plurals>
     <string name="italic_font">Mettre la police en italique</string>
     <string name="official_rating">Classification parentale</string>
     <string name="extras_title">Bonus</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -136,7 +136,9 @@
     <string name="video">Videó</string>
     <string name="videos">Videók</string>
     <string name="watch_live">Nézze élőben</string>
-    <string name="years_old">%1$d éves</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d éves</item>
+    </plurals>
     <string name="play_with_transcoding">Lejátszás átalakítással</string>
     <string name="show_clock">Aktuális idő mutatása</string>
     <string name="aired_episode_order">Sorrend epizód vetítése alapján</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -137,7 +137,9 @@
     <string name="video">Video</string>
     <string name="videos">Video</string>
     <string name="watch_live">Tonton langsung</string>
-    <string name="years_old">%1$d tahun</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d tahun</item>
+    </plurals>
     <string name="play_with_transcoding">Putar dengan transcoding</string>
     <string name="show_clock">Tampilkan Jam</string>
     <string name="aired_episode_order">Urutan Episode Tayang</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -183,7 +183,9 @@
     <string name="video_scale">Scala Video</string>
     <string name="video">Video</string>
     <string name="videos">I video</string>
-    <string name="years_old">%1$d anni</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d anni</item>
+    </plurals>
     <string name="play_with_transcoding">Riproduci con transcodifica</string>
     <string name="immediate">Immediato</string>
     <string name="show_next_up_when">Mostra prossimo episodio</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -215,7 +215,9 @@
     <string name="video_scale">קנה מידה של הוידאו</string>
     <string name="video">וידאו</string>
     <string name="watch_live">צפה בשידור חי</string>
-    <string name="years_old">בגיל %1$d</string>
+    <plurals name="years_old">
+        <item quantity="other">בגיל %1$d</item>
+    </plurals>
     <string name="play_with_transcoding">נגן עם המרת קידוד</string>
     <string name="media_information">פרטי המדיה</string>
     <string name="show_clock">הצג שעון</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -164,7 +164,9 @@
     <string name="video">Video</string>
     <string name="videos">Video</string>
     <string name="watch_live">Skatīties tiešraidi</string>
-    <string name="years_old">%1$d gadus vecs</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d gadus vecs</item>
+    </plurals>
     <string name="play_with_transcoding">Atskaņot ar transkodēšanu</string>
     <string name="media_information">Informācija par failu</string>
     <string name="show_clock">Rādīt Pulksteni</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -135,7 +135,9 @@
     <string name="video">Video</string>
     <string name="videos">Videoer</string>
     <string name="watch_live">Se direkte</string>
-    <string name="years_old">%1$d år gammel</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d år gammel</item>
+    </plurals>
     <string name="play_with_transcoding">Spill av med transkoding</string>
     <string name="media_information">Mediainformasjon</string>
     <string name="show_clock">Vis klokke</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -138,7 +138,9 @@
     <string name="video">Video</string>
     <string name="videos">Video\'s</string>
     <string name="watch_live">Live kijken</string>
-    <string name="years_old">%1$d jaar oud</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d jaar oud</item>
+    </plurals>
     <string name="play_with_transcoding">Afspelen met transcodering</string>
     <string name="show_clock">Klok tonen</string>
     <string name="aired_episode_order">Volgorde van uitgezonden afleveringen</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -138,7 +138,9 @@
     <string name="video">Video</string>
     <string name="videos">Videoar</string>
     <string name="watch_live">Sjå direkte</string>
-    <string name="years_old">%1$d år gammal</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d år gammal</item>
+    </plurals>
     <string name="play_with_transcoding">Spel av med transkoding</string>
     <string name="media_information">Mediainformasjon</string>
     <string name="show_clock">Vis klokke</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -263,7 +263,9 @@
     <string name="people_title">Obsada</string>
     <string name="none">Brak</string>
     <string name="unknown">Nieznany</string>
-    <string name="years_old">%1$d lat temu</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d lat temu</item>
+    </plurals>
     <string name="success">Powodzenie</string>
     <string name="official_rating">Ocena rodzicielska</string>
     <string name="extras_title">Dodatki</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -166,7 +166,9 @@
     <string name="video">Vídeo</string>
     <string name="videos">Vídeos</string>
     <string name="watch_live">Assista ao vivo</string>
-    <string name="years_old">%1$d anos de idade</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d anos de idade</item>
+    </plurals>
     <string name="play_with_transcoding">Reproduzir com transcodificação</string>
     <string name="media_information">Informação de Mídia</string>
     <string name="show_clock">Mostrar Relógio</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -137,7 +137,9 @@
     <string name="video">Vídeo</string>
     <string name="videos">Vídeos</string>
     <string name="watch_live">Ver em directo</string>
-    <string name="years_old">%1$d anos</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d anos</item>
+    </plurals>
     <string name="play_with_transcoding">Reproduzir com transcodificação</string>
     <string name="show_clock">Mostrar Relógio</string>
     <string name="aired_episode_order">Ordem de Emissão</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -217,7 +217,9 @@
     <string name="updates">Actualizări</string>
     <string name="version">Versiune</string>
     <string name="show_clock">Arată ceasul</string>
-    <string name="years_old">%1$d ani vechime</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d ani vechime</item>
+    </plurals>
     <string name="tv_guide">Ghid</string>
     <string name="one_click_pause">Pauză cu un click</string>
     <plurals name="interviews">

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -111,7 +111,9 @@
     <string name="video_scale">Масштаб видео</string>
     <string name="video">Видео</string>
     <string name="videos">Видео</string>
-    <string name="years_old">%1$d возраст</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d возраст</item>
+    </plurals>
     <string name="play_with_transcoding">Воспроизвести с перекодированием</string>
     <string name="show_clock">Показывать часы</string>
     <string name="create_playlist">Создать новый плейлист</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -167,7 +167,9 @@
     <string name="video">Video</string>
     <string name="videos">Videá</string>
     <string name="watch_live">Sledovať naživo</string>
-    <string name="years_old">%1$d rokov</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d rokov</item>
+    </plurals>
     <string name="play_with_transcoding">Prehrávať s prekódovaním</string>
     <string name="media_information">Informácie o médiu</string>
     <string name="show_clock">Zobraziť hodiny</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -164,7 +164,9 @@
     <string name="video">Video</string>
     <string name="videos">Videji</string>
     <string name="watch_live">Glej v živo</string>
-    <string name="years_old">%1$d let staro</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d let staro</item>
+    </plurals>
     <string name="play_with_transcoding">Igrajte s transkodiranjem</string>
     <string name="media_information">Informacije o mediji</string>
     <string name="show_clock">Prikaži uro</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -89,7 +89,9 @@
     <string name="video">Video</string>
     <string name="videos">Videor</string>
     <string name="watch_live">Titta live</string>
-    <string name="years_old">%1$d år gammal</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d år gammal</item>
+    </plurals>
     <string name="play_with_transcoding">Spela med transkodning</string>
     <string name="show_clock">Visa klocka</string>
     <string name="aired_episode_order">Sändningsordning</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -165,7 +165,9 @@
     <string name="video">วิดีโอ</string>
     <string name="videos">วิดีโอ</string>
     <string name="watch_live">ชมสด</string>
-    <string name="years_old">%1$d ปี</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d ปี</item>
+    </plurals>
     <string name="play_with_transcoding">เล่นโดยใช้การแปลงรหัส</string>
     <string name="media_information">ข้อมูลสื่อ</string>
     <string name="show_clock">แสดงนาฬิกา</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -169,7 +169,9 @@
     <string name="video">Video</string>
     <string name="videos">Videolar</string>
     <string name="watch_live">Canlı izle</string>
-    <string name="years_old">%1$d yaşında</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d yaşında</item>
+    </plurals>
     <string name="play_with_transcoding">Kod dönüştürerek oynat</string>
     <string name="media_information">Medya Bilgisi</string>
     <string name="show_clock">Saati göster</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -177,7 +177,9 @@
     <string name="video">Відео</string>
     <string name="videos">Відоси</string>
     <string name="watch_live">Дивитись онлайн</string>
-    <string name="years_old">%1$d років</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d років</item>
+    </plurals>
     <string name="play_with_transcoding">Відтворити з перекодуванням</string>
     <string name="media_information">Інформація</string>
     <string name="show_clock">Показати годиник</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -137,7 +137,9 @@
     <string name="video">视频</string>
     <string name="videos">视频</string>
     <string name="watch_live">观看直播</string>
-    <string name="years_old">%1$d 岁</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d 岁</item>
+    </plurals>
     <string name="play_with_transcoding">转码播放</string>
     <string name="show_clock">显示时钟</string>
     <string name="aired_episode_order">剧集播出顺序</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -203,7 +203,9 @@
     <string name="tv_dvr_schedule">錄影排程</string>
     <string name="tv_shows_title">電視劇</string>
     <string name="ui_interface">介面</string>
-    <string name="years_old">%1$d 歲</string>
+    <plurals name="years_old">
+        <item quantity="other">%1$d 歲</item>
+    </plurals>
     <string name="play_with_transcoding">轉碼播放</string>
     <string name="one_click_pause_summary_on">按下方向鍵中央以暫停/播放</string>
     <plurals name="deleted_scenes">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -166,8 +166,12 @@
     <string name="video_scale">Video Scale</string>
     <string name="video">Video</string>
     <string name="videos">Videos</string>
-    <string name="watch_live">Watch live</string>
-    <string name="years_old">%1$d years old</string>
+    <string name="watch_live">Watch live</string>g
+    <plurals name="years_old">
+        <item quantity="zero">%1$d years old</item>
+        <item quantity="one">%1$d year old</item>
+        <item quantity="other">%1$d years old</item>
+    </plurals>
     <string name="play_with_transcoding">Play with transcoding</string>
     <string name="media_information">Media Information</string>
     <string name="show_clock">Show Clock</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -402,7 +402,7 @@
     <string name="incorrect">Incorrect</string>
     <string name="pin_too_short">PIN must be 4 keys or longer</string>
     <string name="will_remove_pin">Will remove PIN</string>
-    <string name="pin_digits_hint">[0-9]</string>
+    <string name="pin_digits_hint">[0–9]</string>
     <string name="image_cache_size">Image disk cache size (MB)</string>
     <string name="view_options">View options</string>
     <string name="columns">Columns</string>
@@ -503,7 +503,7 @@
     <string name="image_subtitle_opacity">Image subtitle opacity</string>
 
     <string name="brightness">Brightness</string>
-    <string name="contrast">Constrast</string>
+    <string name="contrast">Contrast</string>
     <string name="saturation">Saturation</string>
     <string name="hue">Hue</string>
     <string name="red">Red</string>


### PR DESCRIPTION
## Description
Gathering several small bug fixes:
- Clear the backdrop when manually reloading the home page
- Convert the "# years old" string resource to plural
- Fix a spelling error in the source English strings
- Ensure #1680 is respected when searching for subtitles to download
- Slightly adjust padding for the header in collection details to match other headers

### Related issues
Fixes string issues reported in https://github.com/damontecres/Wholphin/issues/1705#issuecomment-4982909931

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None