### PR TITLE
Fix loading a canceled discover tv show

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/filter/DiscoverFilter.kt
@@ -6,7 +6,7 @@ import com.github.damontecres.wholphin.api.seerr.SearchApi
 import com.github.damontecres.wholphin.api.seerr.SearchApi.CertificationModeDiscoverTvGet
 import com.github.damontecres.wholphin.api.seerr.model.DiscoverMoviesGet200Response
 import com.github.damontecres.wholphin.api.seerr.model.DiscoverTvGet200Response
-import com.github.damontecres.wholphin.api.seerr.model.TvDetails
+import com.github.damontecres.wholphin.api.seerr.model.TvShowStatus
 import com.github.damontecres.wholphin.ui.data.flip
 import kotlinx.serialization.Serializable
 import org.jellyfin.sdk.model.api.SortOrder
@@ -63,7 +63,7 @@ data class DiscoverFilter(
     val watchRegion: String? = null, // US
     // networkIds?
     // val watchProviders: String? = null,
-    val status: List<TvDetails.Status>? = null,
+    val status: List<TvShowStatus>? = null,
     val certification: List<String>? = null,
 //    val certificationGte: String? = null,
 //    val certificationLte: String? = null,
@@ -233,15 +233,15 @@ data object DiscoverTvStudiosFilter : DiscoverFilterBy<List<Int>> {
     ): DiscoverFilter = filter.copy(networkIds = value)
 }
 
-data object DiscoverTvStatusFilter : DiscoverFilterBy<List<TvDetails.Status>> {
+data object DiscoverTvStatusFilter : DiscoverFilterBy<List<TvShowStatus>> {
     override val stringRes: Int = R.string.production_status
 
     override val supportMultiple: Boolean = true
 
-    override fun get(filter: DiscoverFilter): List<TvDetails.Status>? = filter.status
+    override fun get(filter: DiscoverFilter): List<TvShowStatus>? = filter.status
 
     override fun set(
-        value: List<TvDetails.Status>?,
+        value: List<TvShowStatus>?,
         filter: DiscoverFilter,
     ): DiscoverFilter = filter.copy(status = value)
 }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/FilterOptionCache.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/FilterOptionCache.kt
@@ -1,7 +1,7 @@
 package com.github.damontecres.wholphin.services
 
 import android.content.Context
-import com.github.damontecres.wholphin.api.seerr.model.TvDetails
+import com.github.damontecres.wholphin.api.seerr.model.TvShowStatus
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.filter.CommunityRatingFilter
 import com.github.damontecres.wholphin.data.filter.DecadeFilter
@@ -239,7 +239,7 @@ class FilterOptionCache
                 }
 
                 DiscoverTvStatusFilter -> {
-                    TvDetails.Status.entries.map {
+                    TvShowStatus.entries.map {
                         FilterValueOption(it.value, it)
                     }
                 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/FilterByButton.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/FilterByButton.kt
@@ -38,6 +38,7 @@ import androidx.tv.material3.Text
 import androidx.tv.material3.surfaceColorAtElevation
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.api.seerr.model.TvDetails
+import com.github.damontecres.wholphin.api.seerr.model.TvShowStatus
 import com.github.damontecres.wholphin.data.filter.CommunityRatingFilter
 import com.github.damontecres.wholphin.data.filter.DecadeFilter
 import com.github.damontecres.wholphin.data.filter.DiscoverFilter
@@ -598,7 +599,7 @@ fun DiscoverFilterByButton(
                                     }
 
                                     DiscoverTvStatusFilter -> {
-                                        (currentValue as? List<TvDetails.Status>)
+                                        (currentValue as? List<TvShowStatus>)
                                             .orEmpty()
                                             .contains(value.value)
                                     }
@@ -665,7 +666,7 @@ fun DiscoverFilterByButton(
 
                                         DiscoverTvStatusFilter -> {
                                             val list =
-                                                (currentValue as? List<TvDetails.Status>).orEmpty()
+                                                (currentValue as? List<TvShowStatus>).orEmpty()
                                             val newValue =
                                                 list
                                                     .toMutableList()
@@ -673,7 +674,7 @@ fun DiscoverFilterByButton(
                                                         if (isSelected) {
                                                             remove(value.value!!)
                                                         } else {
-                                                            add(value.value!! as TvDetails.Status)
+                                                            add(value.value!! as TvShowStatus)
                                                         }
                                                     }.takeIf { it.isNotEmpty() }
                                             filterOption.set(newValue, current)

--- a/app/src/main/seerr/seerr-api.yml
+++ b/app/src/main/seerr/seerr-api.yml
@@ -1092,6 +1092,9 @@ components:
           example: 0
           description: Status of the request. 1 = PENDING APPROVAL, 2 = APPROVED, 3 = DECLINED
           readOnly: true
+    TvShowStatus:
+        type: string
+        enum: ["Returning Series", "Planned", "In Production", "Ended", "Canceled", "Pilot"]
     TvDetails:
       type: object
       properties:
@@ -1197,9 +1200,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Season'
-        status:
-          type: string
-          enum: ["Returning Series", "Planned", "In Production", "Ended", "Cancelled", "Pilot"]
         tagline:
           type: string
         type:


### PR DESCRIPTION
## Description
#1614 added filtering by a TV production status. I pulled the enum values from a comment in Seerr's code which spelled it as `Cancelled`, but the actual API uses `Canceled`. This PR corrects the spelling.

Also, since this value isn't actually used yet, I've removed it from `TvDetails` for now.

### Related issues
Fixes #1703

### Testing
Emulator, filter by production status as canceled and open any result

## Screenshots
N/A

## AI or LLM usage
None
