### PR TITLE
Save sort & filter within a genre or studio

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/BaseItem.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/BaseItem.kt
@@ -23,6 +23,7 @@ import com.github.damontecres.wholphin.ui.seasonEpisode
 import com.github.damontecres.wholphin.ui.seasonEpisodePadded
 import com.github.damontecres.wholphin.ui.seriesProductionYears
 import com.github.damontecres.wholphin.ui.timeRemaining
+import com.github.damontecres.wholphin.ui.toServerString
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import org.jellyfin.sdk.api.client.ApiClient
@@ -333,7 +334,8 @@ fun createGenreDestination(
                     genres = listOf(genreId),
                     includeItemTypes = includeItemTypes,
                 ),
-            useSavedLibraryDisplayInfo = false,
+            useSavedLibraryDisplayInfo = true,
+            libraryDisplayInfoIdOverride = "${parentId.toServerString()}_genres",
         ),
     recursive = true,
     collectionType = collectionType,
@@ -360,7 +362,8 @@ fun createStudioDestination(
                     studios = listOf(studioId),
                     includeItemTypes = includeItemTypes,
                 ),
-            useSavedLibraryDisplayInfo = false,
+            useSavedLibraryDisplayInfo = true,
+            libraryDisplayInfoIdOverride = "${parentId.toServerString()}_studios",
         ),
     recursive = true,
     collectionType = CollectionType.UNKNOWN,

--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/GetItemsFilter.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/GetItemsFilter.kt
@@ -22,9 +22,13 @@ data class CollectionFolderFilter(
     val nameOverride: String? = null,
     val filter: GetItemsFilter = GetItemsFilter(),
     /**
-     * Whether to use the libray's saved sort & filter
+     * Whether to use the library's saved sort & filter
      */
     val useSavedLibraryDisplayInfo: Boolean = true,
+    /**
+     * Use a different ID for the library's saved sort & filter, such as for library's genres
+     */
+    val libraryDisplayInfoIdOverride: String? = null,
 )
 
 /**

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderView.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderView.kt
@@ -160,7 +160,8 @@ class CollectionFolderViewModel
 
                     val libraryDisplayInfo =
                         serverRepository.currentUser?.let { user ->
-                            libraryDisplayInfoDao.getItem(user, itemId)
+                            val id = collectionFilter.libraryDisplayInfoIdOverride ?: itemId
+                            libraryDisplayInfoDao.getItem(user, id)
                         }
                     _state.update {
                         it.copy(
@@ -237,7 +238,7 @@ class CollectionFolderViewModel
                         val libraryDisplayInfo =
                             LibraryDisplayInfo(
                                 userId = user.rowId,
-                                itemId = itemId,
+                                itemId = collectionFilter.libraryDisplayInfoIdOverride ?: itemId,
                                 sort = newSort.sort,
                                 direction = newSort.direction,
                                 filter = newFilter,


### PR DESCRIPTION
## Description
Saves the sort and filter of items within a genre or studio (Movies->Genres tab->Click genre) across genres or studios. So if you open "Action" movies and change the sort, the sort will be used for "Animation" or "Horror" movies.

This is saved separate from the sort/filter on the Library tab.

### Related issues
Closes https://github.com/damontecres/Wholphin/issues/1253

### Testing
Emulator by switching sorts

## Screenshots
N/A

## AI or LLM usage
None