### PR TITLE
Fix resume query for Jellyfin 12

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/LatestNextUpService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/LatestNextUpService.kt
@@ -9,7 +9,6 @@ import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.ui.SlimItemFields
 import com.github.damontecres.wholphin.util.LocalDateTimeSerializer
 import com.github.damontecres.wholphin.util.WholphinDispatchers
-import com.github.damontecres.wholphin.util.supportItemKinds
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.sync.Semaphore
@@ -23,6 +22,7 @@ import org.jellyfin.sdk.api.client.extensions.itemsApi
 import org.jellyfin.sdk.api.client.extensions.tvShowsApi
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ItemSortBy
+import org.jellyfin.sdk.model.api.MediaType
 import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.api.request.GetNextUpRequest
 import org.jellyfin.sdk.model.api.request.GetResumeItemsRequest
@@ -60,16 +60,8 @@ class LatestNextUpService
                     userId = userId,
                     fields = SlimItemFields,
                     limit = limit,
-                    includeItemTypes =
-                        if (includeEpisodes) {
-                            supportItemKinds
-                        } else {
-                            supportItemKinds
-                                .toMutableSet()
-                                .apply {
-                                    remove(BaseItemKind.EPISODE)
-                                }
-                        },
+                    mediaTypes = listOf(MediaType.VIDEO),
+                    excludeItemTypes = if (!includeEpisodes) listOf(BaseItemKind.EPISODE) else null,
                     enableTotalRecordCount = false,
                 )
             val items =


### PR DESCRIPTION
## Description
Fixes querying for resume item (continue watching) for Jellyfin 12 so that whole series are not included. The patch is also compatible with Jellyfin 10.11.

### Related issues
Fixes #1689

I couldn't find an issue in Jellyfin that mentions this behavior change, so I'm guessing it was a side effect. But since the old query did ask to include Series, I don't think it's a bug in the server.

### Testing
Manual API queries & emulator on both Jellyfin 11 & 12-rc2 servers

## Screenshots
N/A

## AI or LLM usage
None