### PR TITLE
Fix errors when a plural translation is missing

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/ExtrasService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/ExtrasService.kt
@@ -5,6 +5,8 @@ import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.ExtrasItem
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.pluralRes
+import com.github.damontecres.wholphin.data.stringRes
+import com.github.damontecres.wholphin.ui.isNotNullOrBlank
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
@@ -48,9 +50,10 @@ class ExtrasService
                         if (items.size == 1) {
                             val item = items.first()
                             val title =
-                                item.title ?: context.resources.getQuantityString(type.pluralRes, 1)
+                                item.title.takeIf { it.isNotNullOrBlank() }
+                                    ?: context.resources.getQuantityString(type.pluralRes, 1)
                             val subtitle =
-                                if (item.title == null) {
+                                if (item.title.isNotNullOrBlank()) {
                                     context.resources.getQuantityString(type.pluralRes, 1)
                                 } else {
                                     null
@@ -64,8 +67,7 @@ class ExtrasService
                                 imageUrl = imageUrlService.getItemImageUrl(item, ImageType.PRIMARY),
                             )
                         } else if (items.size > 1) {
-                            val title =
-                                context.resources.getQuantityString(type.pluralRes, items.size)
+                            val title = context.resources.getString(type.stringRes)
                             val subtitle =
                                 context.resources.getQuantityString(
                                     R.plurals.items,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -31,7 +31,7 @@
     <string name="director">المخرج</string>
     <string name="disabled">مُعطّل</string>
     <string name="discovered_servers">الخوادم المكتشفة</string>
-    <string name="download_and_update"><![CDATA[تنزيل وتحديث]]></string>
+    <string name="download_and_update">تنزيل وتحديث</string>
     <string name="downloading">تنزيل…</string>
     <string name="enabled">مُفعّل</string>
     <string name="ends_at">ينتهي عند %1$s</string>
@@ -66,6 +66,7 @@
     <string name="more">المزيد</string>
     <plurals name="movies">
         <item quantity="zero">الأفلام</item>
+        <item quantity="other">الأفلام</item>
     </plurals>
     <string name="name">الاسم</string>
     <string name="next_up">التالي</string>
@@ -80,6 +81,7 @@
     <string name="path">المسار</string>
     <plurals name="people">
         <item quantity="zero">الأشخاص</item>
+        <item quantity="other">الأشخاص</item>
     </plurals>
     <string name="play_count">عدد مرات التشغيل</string>
     <string name="play_from_here">تشغيل من هنا</string>
@@ -104,7 +106,7 @@
     <string name="restart">إعادة تشغيل</string>
     <string name="resume">استئناف</string>
     <string name="save">حفظ</string>
-    <string name="search_and_download"><![CDATA[بحث وتنزيل]]></string>
+    <string name="search_and_download">بحث وتنزيل</string>
     <string name="search">بحث</string>
     <string name="searching">جارٍ البحث…</string>
     <string name="voice_search">البحث الصوتي</string>
@@ -151,32 +153,41 @@
     <string name="show_clock">إظهار الساعة</string>
     <plurals name="behind_the_scenes">
         <item quantity="zero">الكواليس</item>
+        <item quantity="other">الكواليس</item>
     </plurals>
     <string name="official_rating">التصنيف العمري</string>
     <string name="runtime_sort">مدة العرض</string>
     <string name="extras_title">إضافات</string>
     <plurals name="other_extras">
         <item quantity="zero">أخرى</item>
+        <item quantity="other">أخرى</item>
     </plurals>
     <plurals name="theme_songs">
         <item quantity="zero">الأغاني الرئيسية</item>
+        <item quantity="other">الأغاني الرئيسية</item>
     </plurals>
     <plurals name="clips">
         <item quantity="zero">مقاطع</item>
+        <item quantity="other">مقاطع</item>
     </plurals>
     <plurals name="deleted_scenes">
         <item quantity="zero">مشاهد محذوفة</item>
+        <item quantity="other">مشاهد محذوفة</item>
     </plurals>
     <plurals name="interviews">
         <item quantity="zero">مقابلات</item>
+        <item quantity="other">مقابلات</item>
     </plurals>
     <plurals name="scenes">
         <item quantity="zero">مشاهد</item>
+        <item quantity="other">مشاهد</item>
     </plurals>
     <plurals name="featurettes">
         <item quantity="zero">مقاطع خاصة</item>
+        <item quantity="other">مقاطع خاصة</item>
     </plurals>
     <plurals name="shorts">
         <item quantity="zero">مقاطع قصيرة</item>
+        <item quantity="other">مقاطع قصيرة</item>
     </plurals>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -63,6 +63,7 @@
     <string name="more">Více</string>
     <plurals name="movies">
         <item quantity="one">Filmy</item>
+        <item quantity="other">Filmy</item>
     </plurals>
     <string name="name">Jméno</string>
     <string name="next_up">Další v pořadí</string>
@@ -77,6 +78,7 @@
     <string name="path">Cesta</string>
     <plurals name="people">
         <item quantity="one">Lidé</item>
+        <item quantity="other">Lidé</item>
     </plurals>
     <string name="play_count">Počet přehrání</string>
     <string name="play_from_here">Přehrát odtud</string>
@@ -145,6 +147,7 @@
     <string name="top_unwatched">Nejlépe hodnocené Nezhlédnuté</string>
     <plurals name="trailers">
         <item quantity="one">Upoutávky</item>
+        <item quantity="other">Upoutávky</item>
     </plurals>
     <string name="tv_dvr_schedule">Harmonogram nahrávání</string>
     <string name="tv_guide">Televizní program</string>
@@ -152,6 +155,7 @@
     <string name="tv_seasons">Sezóny</string>
     <plurals name="tv_shows">
         <item quantity="one">Seriály</item>
+        <item quantity="other">Seriály</item>
     </plurals>
     <string name="ui_interface">Prostředí</string>
     <string name="unknown">Neznámý</string>
@@ -178,30 +182,39 @@
     <string name="extras_title">Doplňky</string>
     <plurals name="other_extras">
         <item quantity="one">Jiný</item>
+        <item quantity="other">Jiný</item>
     </plurals>
     <plurals name="behind_the_scenes">
         <item quantity="one">V zákulisí</item>
+        <item quantity="other">V zákulisí</item>
     </plurals>
     <plurals name="theme_songs">
         <item quantity="one">Znělky</item>
+        <item quantity="other">Znělky</item>
     </plurals>
     <plurals name="theme_videos">
         <item quantity="one">Tématická videa</item>
+        <item quantity="other">Tématická videa</item>
     </plurals>
     <plurals name="clips">
         <item quantity="one">Klipy</item>
+        <item quantity="other">Klipy</item>
     </plurals>
     <plurals name="deleted_scenes">
         <item quantity="one">Vymazané scény</item>
+        <item quantity="other">Vymazané scény</item>
     </plurals>
     <plurals name="interviews">
         <item quantity="one">Rozhovory</item>
+        <item quantity="other">Rozhovory</item>
     </plurals>
     <plurals name="scenes">
         <item quantity="one">Scény</item>
+        <item quantity="other">Scény</item>
     </plurals>
     <plurals name="featurettes">
         <item quantity="one">Krátkometrážní filmy</item>
+        <item quantity="other">Krátkometrážní filmy</item>
     </plurals>
     <plurals name="hours">
         <item quantity="one">%d hodina</item>
@@ -383,15 +396,17 @@
     <string name="request_4k">Žádost ve 4K</string>
     <string name="software_decoding_av1">Softwarové dekódování AV1</string>
     <string name="commercial">Komerční</string>
-    <string name="download_and_update"><![CDATA[Download & Update]]></string>
+    <string name="download_and_update">Download &amp; Update</string>
     <string name="immediate">Bezprostředně</string>
-    <string name="search_and_download"><![CDATA[Search & Download]]></string>
+    <string name="search_and_download">Search &amp; Download</string>
     <string name="runtime_sort">Trvání</string>
     <plurals name="samples">
         <item quantity="one">Vzorky</item>
+        <item quantity="other">Vzorky</item>
     </plurals>
     <plurals name="shorts">
         <item quantity="one">Krátká videa</item>
+        <item quantity="other">Krátká videa</item>
     </plurals>
     <plurals name="downloads">
         <item quantity="one">%s Stažen</item>
@@ -399,11 +414,11 @@
         <item quantity="many">%s Stažení</item>
         <item quantity="other">%s Stažení</item>
     </plurals>
-    <string name="combine_continue_next"><![CDATA[Combine Continue Watching & Next Up]]></string>
+    <string name="combine_continue_next">Combine Continue Watching &amp; Next Up</string>
     <string name="direct_play_ass">Direct play ASS titulky</string>
     <string name="direct_play_pgs">Direct play PGS titulky</string>
     <string name="player_backend">Přehrávání Backendu</string>
-    <string name="cast_and_crew"><![CDATA[Cast & Crew]]></string>
+    <string name="cast_and_crew">Cast &amp; Crew</string>
     <string name="anamorphic">Anamorfní</string>
     <string name="interlaced">Prokládané</string>
     <string name="color_code_programs">Color code programs</string>
@@ -513,12 +528,12 @@
     <string name="image_type_thumb">Náhled</string>
     <string name="backdrop_style_dynamic">Obrázek s dynamickou barvou</string>
     <string name="backdrop_style_image">Pouze obrázek</string>
-    <string name="enter_url_api_key"><![CDATA[Zadejte adresu a klíč API]]></string>
+    <string name="enter_url_api_key">Zadejte adresu a klíč API</string>
     <string name="api_key">Klíč API</string>
     <string name="seerr_login">Přihlásit se k serveru Seerr</string>
     <string name="seerr_jellyfin_user">Uživatel Jellyfin</string>
     <string name="seerr_local_user">Lokální uživatel</string>
-    <string name="search_and_download_subtitles"><![CDATA[Hledat a stáhnout titulky]]></string>
+    <string name="search_and_download_subtitles">Hledat a stáhnout titulky</string>
     <string name="no_subtitles_found">Nenalezeny žádné vzdálené titulky</string>
     <string name="series_continueing">Současnost</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -30,7 +30,7 @@
     <string name="director">Instruktør</string>
     <string name="disabled">Deaktiveret</string>
     <string name="discovered_servers">Opdagede servere</string>
-    <string name="download_and_update"><![CDATA[Download og opdater]]></string>
+    <string name="download_and_update">Download og opdater</string>
     <string name="downloading">Downloader…</string>
     <string name="enabled">Aktiveret</string>
     <string name="ends_at">Slutter %1$s</string>
@@ -65,6 +65,7 @@
     <string name="more">Mere</string>
     <plurals name="movies">
         <item quantity="one">Film</item>
+        <item quantity="other">Film</item>
     </plurals>
     <string name="name">Navn</string>
     <string name="next_up">Næste</string>
@@ -79,6 +80,7 @@
     <string name="path">Filsti</string>
     <plurals name="people">
         <item quantity="one">Personer</item>
+        <item quantity="other">Personer</item>
     </plurals>
     <string name="play_count">Antal afspilninger</string>
     <string name="play_from_here">Afspil herfra</string>
@@ -103,7 +105,7 @@
     <string name="restart">Genstart</string>
     <string name="resume">Fortsæt</string>
     <string name="save">Gem</string>
-    <string name="search_and_download"><![CDATA[Søg og download]]></string>
+    <string name="search_and_download">Søg og download</string>
     <string name="search">Søg</string>
     <string name="searching">Søger…</string>
     <string name="voice_search">Stemmesøgning</string>
@@ -148,6 +150,7 @@
     <string name="top_unwatched">Bedst bedømte usete</string>
     <plurals name="trailers">
         <item quantity="one">Trailere</item>
+        <item quantity="other">Trailere</item>
     </plurals>
     <string name="tv_dvr_schedule">DVR-plan</string>
     <string name="tv_guide">TV-guide</string>
@@ -155,6 +158,7 @@
     <string name="tv_seasons">Sæsoner</string>
     <plurals name="tv_shows">
         <item quantity="one">TV-serier</item>
+        <item quantity="other">TV-serier</item>
     </plurals>
     <string name="ui_interface">Grænseflade</string>
     <string name="unknown">Ukendt</string>
@@ -182,36 +186,47 @@
     <string name="extras_title">Ekstra</string>
     <plurals name="other_extras">
         <item quantity="one">Andet</item>
+        <item quantity="other">Andet</item>
     </plurals>
     <plurals name="behind_the_scenes">
         <item quantity="one">Bag kulisserne</item>
+        <item quantity="other">Bag kulisserne</item>
     </plurals>
     <plurals name="theme_songs">
         <item quantity="one">Temasange</item>
+        <item quantity="other">Temasange</item>
     </plurals>
     <plurals name="theme_videos">
         <item quantity="one">Temavideoer</item>
+        <item quantity="other">Temavideoer</item>
     </plurals>
     <plurals name="clips">
         <item quantity="one">Klip</item>
+        <item quantity="other">Klip</item>
     </plurals>
     <plurals name="deleted_scenes">
         <item quantity="one">Slettede scener</item>
+        <item quantity="other">Slettede scener</item>
     </plurals>
     <plurals name="interviews">
         <item quantity="one">Interview</item>
+        <item quantity="other">Interview</item>
     </plurals>
     <plurals name="scenes">
         <item quantity="one">Scener</item>
+        <item quantity="other">Scener</item>
     </plurals>
     <plurals name="samples">
         <item quantity="one">Prøver</item>
+        <item quantity="other">Prøver</item>
     </plurals>
     <plurals name="featurettes">
         <item quantity="one">Specialindslag</item>
+        <item quantity="other">Specialindslag</item>
     </plurals>
     <plurals name="shorts">
         <item quantity="one">Kortfilm</item>
+        <item quantity="other">Kortfilm</item>
     </plurals>
     <plurals name="downloads">
         <item quantity="one">%s download</item>
@@ -242,7 +257,7 @@
     <string name="auto_play_next">Afspil næste automatisk</string>
     <string name="check_for_updates">Søg efter opdateringer</string>
     <string name="combine_continue_next_summary">Gælder kun for tv-serier</string>
-    <string name="combine_continue_next"><![CDATA[Kombiner Fortsæt med at se & Næste]]></string>
+    <string name="combine_continue_next">Kombiner Fortsæt med at se &amp; Næste</string>
     <string name="direct_play_ass">Direkte afspilning af ASS-undertekster</string>
     <string name="direct_play_pgs">Direkte afspilning af PGS-undertekster</string>
     <string name="downmix_stereo">Mix altid ned til stereo</string>
@@ -327,7 +342,7 @@
     <string name="aspect_ratio">Aspektforhold</string>
     <string name="show_details">Vis detaljer</string>
     <string name="image_type">Billedtype</string>
-    <string name="cast_and_crew"><![CDATA[Skuespillere og filmhold]]></string>
+    <string name="cast_and_crew">Skuespillere og filmhold</string>
     <string name="guest_stars">Gæsteroller</string>
     <string name="edge_size">Kantstørrelse</string>
     <string name="refresh_rate_switching">Skift af billedopdateringsfrekvens</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -19,9 +19,11 @@
     <string name="background">Παρασκήνιο</string>
     <plurals name="theme_songs">
         <item quantity="one">Θεματικά τραγούδια</item>
+        <item quantity="other">Θεματικά τραγούδια</item>
     </plurals>
     <plurals name="theme_videos">
         <item quantity="one">Θεματικά βίντεο</item>
+        <item quantity="other">Θεματικά βίντεο</item>
     </plurals>
     <string name="next_up">Επόμενο</string>
     <string name="rewatch_next_up">Ενεργοποιήστε την επανάληψη παρακολούθησης στα \'Επόμενα\'</string>
@@ -40,7 +42,7 @@
     <string name="director">Σκηνοθέτης</string>
     <string name="studios">Στούντιο</string>
     <string name="sdr">SDR</string>
-    <string name="cast_and_crew"><![CDATA[Ηθοποιοί και Συνεργείο]]></string>
+    <string name="cast_and_crew">Ηθοποιοί και Συνεργείο</string>
     <string name="more_like_this">Περισσότερα Σαν Αυτό</string>
     <string name="episodes">Επεισόδια</string>
     <string name="jump_letters">#ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ</string>
@@ -169,27 +171,35 @@
     <string name="extras_title">Επιπρόσθετα</string>
     <plurals name="other_extras">
         <item quantity="one">Άλλο</item>
+        <item quantity="other">Άλλο</item>
     </plurals>
     <plurals name="behind_the_scenes">
         <item quantity="one">Παρασκήνια</item>
+        <item quantity="other">Παρασκήνια</item>
     </plurals>
     <plurals name="clips">
         <item quantity="one">Αποσπάσματα</item>
+        <item quantity="other">Αποσπάσματα</item>
     </plurals>
     <plurals name="deleted_scenes">
         <item quantity="one">Διαγραμμένες σκηνές</item>
+        <item quantity="other">Διαγραμμένες σκηνές</item>
     </plurals>
     <plurals name="interviews">
         <item quantity="one">Συνεντεύξεις</item>
+        <item quantity="other">Συνεντεύξεις</item>
     </plurals>
     <plurals name="scenes">
         <item quantity="one">Σκηνές</item>
+        <item quantity="other">Σκηνές</item>
     </plurals>
     <plurals name="samples">
         <item quantity="one">Δείγματα</item>
+        <item quantity="other">Δείγματα</item>
     </plurals>
     <plurals name="featurettes">
         <item quantity="one">Χαρακτηριστικά</item>
+        <item quantity="other">Χαρακτηριστικά</item>
     </plurals>
     <string name="auto_check_for_updates">Αυτόματος έλεγχος για ενημερώσεις</string>
     <string name="auto_play_next_delay">Καθυστέρηση πριν την έναρξη του επόμενου</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -25,7 +25,7 @@
     <string name="director">Rendező</string>
     <string name="disabled">Letiltva</string>
     <string name="discovered_servers">Felfedezett szerverek</string>
-    <string name="download_and_update"><![CDATA[Letöltés & Frissítés]]></string>
+    <string name="download_and_update">Letöltés &amp; Frissítés</string>
     <string name="downloading">Letöltés folyamatban…</string>
     <string name="enabled">Engedélyezve</string>
     <string name="enter_server_url">Adja meg a szerver IP-t vagy URL-t</string>
@@ -95,7 +95,7 @@
     <string name="restart">Újraindítás</string>
     <string name="resume">Folytatás</string>
     <string name="save">Mentés</string>
-    <string name="search_and_download"><![CDATA[Keresés & Letöltés]]></string>
+    <string name="search_and_download">Keresés &amp; Letöltés</string>
     <string name="search">Keresés</string>
     <string name="searching">Keresés…</string>
     <string name="select_server">Szerver kiválasztása</string>
@@ -122,6 +122,7 @@
     <string name="top_unwatched">Legjobbra értékelt, nem megnézett</string>
     <plurals name="trailers">
         <item quantity="one">Előzetesek</item>
+        <item quantity="other">Előzetesek</item>
     </plurals>
     <string name="tv_dvr_schedule">DVR Időzítés</string>
     <string name="tv_guide">Műsorújság</string>
@@ -157,6 +158,7 @@
     </plurals>
     <plurals name="behind_the_scenes">
         <item quantity="one">Színfalak mögött</item>
+        <item quantity="other">Színfalak mögött</item>
     </plurals>
     <plurals name="theme_songs">
         <item quantity="one">Főcímdal</item>
@@ -350,10 +352,10 @@
     <string name="subtitle_delay">Felirat késleltetése</string>
     <string name="backdrop_display">Háttér stílusa</string>
     <string name="enter_server_address">Adja meg a szerver címét</string>
-    <string name="combine_continue_next"><![CDATA[Folytatás & Következő menü összevonása]]></string>
+    <string name="combine_continue_next">Folytatás &amp; Következő menü összevonása</string>
     <string name="player_backend">Lejátszás backend</string>
     <string name="image_cache_size">Kép-gyorsítótár mérete (MB)</string>
-    <string name="cast_and_crew"><![CDATA[Stábtagok]]></string>
+    <string name="cast_and_crew">Stábtagok</string>
     <string name="nav_drawer_switch_on_focus">Navigációs menü oldalainak váltása fókusznál</string>
     <string name="playback_overrides">Lejátszás felülbírálatai</string>
     <string name="resolution_switching">Felbontásváltás</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -31,7 +31,7 @@
     <string name="director">Režisors</string>
     <string name="disabled">Atslēgts</string>
     <string name="discovered_servers">Atrastie serveri</string>
-    <string name="download_and_update"><![CDATA[Lejupielādēt & Atjaunināt]]></string>
+    <string name="download_and_update">Lejupielādēt &amp; Atjaunināt</string>
     <string name="downloading">Lejupielādē…</string>
     <string name="enabled">Ieslēgts</string>
     <string name="ends_at">Beigsies %1$s</string>
@@ -65,6 +65,7 @@
     <string name="more">Vairāk</string>
     <plurals name="movies">
         <item quantity="zero">Filmas</item>
+        <item quantity="other">Filmas</item>
     </plurals>
     <string name="name">Nosaukums</string>
     <string name="next_up">Rindā</string>
@@ -79,6 +80,7 @@
     <string name="path">Ceļš</string>
     <plurals name="people">
         <item quantity="zero">Cilvēki</item>
+        <item quantity="other">Cilvēki</item>
     </plurals>
     <string name="play_count">Skatījumu skaits</string>
     <string name="play_from_here">Atskaņot no šejienes</string>
@@ -103,7 +105,7 @@
     <string name="restart">Restartēt</string>
     <string name="resume">Turpināt</string>
     <string name="save">Saglabāt</string>
-    <string name="search_and_download"><![CDATA[Meklēt & Lejupielādēt]]></string>
+    <string name="search_and_download">Meklēt &amp; Lejupielādēt</string>
     <string name="search">Meklēt</string>
     <string name="searching">Meklē…</string>
     <string name="voice_search">Balss meklēšana</string>
@@ -148,6 +150,7 @@
     <string name="top_unwatched">Augstāk novērtētie un neredzētie</string>
     <plurals name="trailers">
         <item quantity="zero">Treileri</item>
+        <item quantity="other">Treileri</item>
     </plurals>
     <string name="tv_dvr_schedule">Ierakstu plāns</string>
     <string name="tv_guide">Programma</string>
@@ -155,6 +158,7 @@
     <string name="tv_seasons">Sezonas</string>
     <plurals name="tv_shows">
         <item quantity="zero">TV Šovi</item>
+        <item quantity="other">TV Šovi</item>
     </plurals>
     <string name="ui_interface">Saskarne</string>
     <string name="unknown">Nezināms</string>
@@ -182,36 +186,47 @@
     <string name="extras_title">Ekstras</string>
     <plurals name="other_extras">
         <item quantity="zero">Cits</item>
+        <item quantity="other">Cits</item>
     </plurals>
     <plurals name="behind_the_scenes">
         <item quantity="zero">Aizkadri</item>
+        <item quantity="other">Aizkadri</item>
     </plurals>
     <plurals name="theme_songs">
         <item quantity="zero">Tituldziesmas</item>
+        <item quantity="other">Tituldziesmas</item>
     </plurals>
     <plurals name="theme_videos">
         <item quantity="zero">Titulvideo</item>
+        <item quantity="other">Titulvideo</item>
     </plurals>
     <plurals name="clips">
         <item quantity="zero">Klipi</item>
+        <item quantity="other">Klipi</item>
     </plurals>
     <plurals name="deleted_scenes">
         <item quantity="zero">Izgrieztās ainas</item>
+        <item quantity="other">Izgrieztās ainas</item>
     </plurals>
     <plurals name="interviews">
         <item quantity="zero">Intervijas</item>
+        <item quantity="other">Intervijas</item>
     </plurals>
     <plurals name="scenes">
         <item quantity="zero">Ainas</item>
+        <item quantity="other">Ainas</item>
     </plurals>
     <plurals name="samples">
         <item quantity="zero">Paraugi</item>
+        <item quantity="other">Paraugi</item>
     </plurals>
     <plurals name="featurettes">
         <item quantity="zero">Īssižeti</item>
+        <item quantity="other">Īssižeti</item>
     </plurals>
     <plurals name="shorts">
         <item quantity="zero">Īsie rullīši</item>
+        <item quantity="other">Īsie rullīši</item>
     </plurals>
     <string name="favorite_items_title">Izlase %s</string>
     <plurals name="downloads">

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -27,7 +27,7 @@
     <string name="director">Regissør</string>
     <string name="disabled">Deaktivert</string>
     <string name="discovered_servers">Oppdagede servere</string>
-    <string name="download_and_update"><![CDATA[Last ned og oppdater]]></string>
+    <string name="download_and_update">Last ned og oppdater</string>
     <string name="downloading">Laster ned…</string>
     <string name="enabled">Aktivert</string>
     <string name="enter_server_url">Oppgi server-IP eller URL</string>
@@ -94,7 +94,7 @@
     <string name="restart">Start på nytt</string>
     <string name="resume">Fortsett</string>
     <string name="save">Lagre</string>
-    <string name="search_and_download"><![CDATA[Søk og last ned]]></string>
+    <string name="search_and_download">Søk og last ned</string>
     <string name="search">Søk</string>
     <string name="searching">Søker…</string>
     <string name="select_server">Velg server</string>
@@ -121,6 +121,7 @@
     <string name="top_unwatched">Best vurderte usette</string>
     <plurals name="trailers">
         <item quantity="one">Trailere</item>
+        <item quantity="other">Trailere</item>
     </plurals>
     <string name="tv_dvr_schedule">DVR-plan</string>
     <string name="tv_guide">Programoversikt</string>
@@ -153,36 +154,47 @@
     <string name="extras_title">Ekstramateriale</string>
     <plurals name="other_extras">
         <item quantity="one">Annet</item>
+        <item quantity="other">Annet</item>
     </plurals>
     <plurals name="behind_the_scenes">
         <item quantity="one">Bak kulissene</item>
+        <item quantity="other">Bak kulissene</item>
     </plurals>
     <plurals name="theme_songs">
         <item quantity="one">Temasanger</item>
+        <item quantity="other">Temasanger</item>
     </plurals>
     <plurals name="theme_videos">
         <item quantity="one">Temavideoer</item>
+        <item quantity="other">Temavideoer</item>
     </plurals>
     <plurals name="clips">
         <item quantity="one">Klipp</item>
+        <item quantity="other">Klipp</item>
     </plurals>
     <plurals name="deleted_scenes">
         <item quantity="one">Slettede scener</item>
+        <item quantity="other">Slettede scener</item>
     </plurals>
     <plurals name="interviews">
         <item quantity="one">Intervjuer</item>
+        <item quantity="other">Intervjuer</item>
     </plurals>
     <plurals name="scenes">
         <item quantity="one">Scener</item>
+        <item quantity="other">Scener</item>
     </plurals>
     <plurals name="samples">
         <item quantity="one">Smakebiter</item>
+        <item quantity="other">Smakebiter</item>
     </plurals>
     <plurals name="featurettes">
         <item quantity="one">Bakomfilmer</item>
+        <item quantity="other">Bakomfilmer</item>
     </plurals>
     <plurals name="shorts">
         <item quantity="one">Kortfilmer</item>
+        <item quantity="other">Kortfilmer</item>
     </plurals>
     <plurals name="downloads">
         <item quantity="one">%s nedlasting</item>
@@ -208,7 +220,7 @@
     <string name="auto_play_next">Spill neste automatisk</string>
     <string name="check_for_updates">Sjekk etter oppdateringer</string>
     <string name="combine_continue_next_summary">Gjelder kun TV-serier</string>
-    <string name="combine_continue_next"><![CDATA[Slå sammen \'Fortsett å se\' og \'Neste\']]></string>
+    <string name="combine_continue_next">Slå sammen \'Fortsett å se\' og \'Neste\'</string>
     <string name="direct_play_ass">Direkteavspilling av ASS-undertekster</string>
     <string name="direct_play_pgs">Direkteavspilling av PGS-undertekster</string>
     <string name="downmix_stereo">Alltid nedmiks til stereo</string>
@@ -293,7 +305,7 @@
     <string name="aspect_ratio">Bildeforhold</string>
     <string name="show_details">Vis detaljer</string>
     <string name="image_type">Bildetype</string>
-    <string name="cast_and_crew"><![CDATA[Skuespillere og medarbeidere]]></string>
+    <string name="cast_and_crew">Skuespillere og medarbeidere</string>
     <string name="guest_stars">Gjesteroller</string>
     <string name="edge_size">Kantstørrelse</string>
     <string name="refresh_rate_switching">Bytting av bildeoppdateringsfrekvens</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -32,7 +32,7 @@
     <string name="director">Regissør</string>
     <string name="disabled">Deaktivert</string>
     <string name="discovered_servers">Funne servarar</string>
-    <string name="download_and_update"><![CDATA[Last ned og oppdater]]></string>
+    <string name="download_and_update">Last ned og oppdater</string>
     <string name="downloading">Lastar ned…</string>
     <string name="enabled">Aktivert</string>
     <string name="enter_server_url">Oppgi servar-IP eller URL</string>
@@ -98,7 +98,7 @@
     <string name="restart">Start på nytt</string>
     <string name="resume">Hald fram</string>
     <string name="save">Lagre</string>
-    <string name="search_and_download"><![CDATA[Søk og last ned]]></string>
+    <string name="search_and_download">Søk og last ned</string>
     <string name="search">Søk</string>
     <string name="searching">Søker…</string>
     <string name="select_server">Vel servar</string>
@@ -124,6 +124,7 @@
     <string name="top_unwatched">Best vurderte usette</string>
     <plurals name="trailers">
         <item quantity="one">Trailerar</item>
+        <item quantity="other">Trailerar</item>
     </plurals>
     <string name="tv_dvr_schedule">DVR-plan</string>
     <string name="tv_guide">Programoversikt</string>
@@ -156,36 +157,47 @@
     <string name="extras_title">Ekstra</string>
     <plurals name="other_extras">
         <item quantity="one">Anna</item>
+        <item quantity="other">Anna</item>
     </plurals>
     <plurals name="behind_the_scenes">
         <item quantity="one">Bak kulissane</item>
+        <item quantity="other">Bak kulissane</item>
     </plurals>
     <plurals name="theme_songs">
         <item quantity="one">Temasongar</item>
+        <item quantity="other">Temasongar</item>
     </plurals>
     <plurals name="theme_videos">
         <item quantity="one">Temavideoar</item>
+        <item quantity="other">Temavideoar</item>
     </plurals>
     <plurals name="clips">
         <item quantity="one">Klipp</item>
+        <item quantity="other">Klipp</item>
     </plurals>
     <plurals name="deleted_scenes">
         <item quantity="one">Sletta sener</item>
+        <item quantity="other">Sletta sener</item>
     </plurals>
     <plurals name="interviews">
         <item quantity="one">Intervju</item>
+        <item quantity="other">Intervju</item>
     </plurals>
     <plurals name="scenes">
         <item quantity="one">Scener</item>
+        <item quantity="other">Scener</item>
     </plurals>
     <plurals name="samples">
         <item quantity="one">Smakebitar</item>
+        <item quantity="other">Smakebitar</item>
     </plurals>
     <plurals name="featurettes">
         <item quantity="one">Bakomfilmar</item>
+        <item quantity="other">Bakomfilmar</item>
     </plurals>
     <plurals name="shorts">
         <item quantity="one">Kortfilmar</item>
+        <item quantity="other">Kortfilmar</item>
     </plurals>
     <string name="advanced_settings">Avanserte innstillingar</string>
     <string name="advanced_ui">Avansert grensesnitt</string>
@@ -195,7 +207,7 @@
     <string name="auto_play_next">Spel neste automatisk</string>
     <string name="check_for_updates">Sjekk etter oppdateringar</string>
     <string name="combine_continue_next_summary">Gjeld berre TV-seriar</string>
-    <string name="combine_continue_next"><![CDATA[Slå saman \'Hald fram med å sjå\' og \'Neste\']]></string>
+    <string name="combine_continue_next">Slå saman \'Hald fram med å sjå\' og \'Neste\'</string>
     <string name="direct_play_ass">Direkteavspeling av ASS-undertekstar</string>
     <string name="direct_play_pgs">Direkteavspeling av PGS-undertekstar</string>
     <string name="downmix_stereo">Alltid nedmiks til stereo</string>
@@ -279,7 +291,7 @@
     <string name="aspect_ratio">Bileteforhold</string>
     <string name="show_details">Vis detaljar</string>
     <string name="image_type">Bilettype</string>
-    <string name="cast_and_crew"><![CDATA[Skodespelarar og medarbeidarar]]></string>
+    <string name="cast_and_crew">Skodespelarar og medarbeidarar</string>
     <string name="guest_stars">Gjesteroller</string>
     <string name="edge_size">Kantstorleik</string>
     <string name="refresh_rate_switching">Byting av bildeoppdateringsfrekvens</string>
@@ -505,12 +517,12 @@
     <string name="image_type_thumb">Miniatyr</string>
     <string name="backdrop_style_dynamic">Bilete med dynamisk farge</string>
     <string name="backdrop_style_image">Berre bilete</string>
-    <string name="enter_url_api_key"><![CDATA[Skriv inn URL og API-nøkkel]]></string>
+    <string name="enter_url_api_key">Skriv inn URL og API-nøkkel</string>
     <string name="api_key">API-nøkkel</string>
     <string name="seerr_login">Logg inn på Seerr-tenar</string>
     <string name="seerr_jellyfin_user">Jellyfin-brukar</string>
     <string name="seerr_local_user">Lokal brukar</string>
-    <string name="search_and_download_subtitles"><![CDATA[Søk og last ned undertekstar]]></string>
+    <string name="search_and_download_subtitles">Søk og last ned undertekstar</string>
     <string name="no_subtitles_found">Fann ingen eksterne undertekstar</string>
     <string name="series_continueing">No</string>
     <string name="in_app_screensaver">Bruk skjermsparar i appen</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -561,18 +561,19 @@
     <string name="mixer">Mixagem</string>
     <plurals name="featurettes">
         <item quantity="one">Bastidores</item>
+        <item quantity="other">Bastidores</item>
     </plurals>
     <plurals name="minutes">
         <item quantity="one">%s minuto</item>
         <item quantity="many">%s minutos</item>
         <item quantity="other">%s minutos</item>
     </plurals>
-    <string name="enter_url_api_key"><![CDATA[Insira a URL e a chave de API]]></string>
-    <string name="search_and_download_subtitles"><![CDATA[Procurar e baixar legendas]]></string>
-    <string name="download_and_update"><![CDATA[Baixar e atualizar]]></string>
-    <string name="search_and_download"><![CDATA[Procurar e baixar]]></string>
-    <string name="combine_continue_next"><![CDATA[Combinar \"Continue Assistindo\" e \"A Seguir\"]]></string>
-    <string name="cast_and_crew"><![CDATA[Elenco e equipe]]></string>
+    <string name="enter_url_api_key">Insira a URL e a chave de API</string>
+    <string name="search_and_download_subtitles">Procurar e baixar legendas</string>
+    <string name="download_and_update">Baixar e atualizar</string>
+    <string name="search_and_download">Procurar e baixar</string>
+    <string name="combine_continue_next">Combinar \"Continue Assistindo\" e \"A Seguir\"</string>
+    <string name="cast_and_crew">Elenco e equipe</string>
     <string name="albums">Álbuns</string>
     <string name="artists">Artistas</string>
     <string name="songs">Músicas</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -42,6 +42,7 @@
     <string name="no_update_available">Nu este disponibilă nicio actualizare</string>
     <plurals name="movies">
         <item quantity="one">Filme</item>
+        <item quantity="other">Filme</item>
     </plurals>
     <string name="library">Librărie</string>
     <string name="go_to">Mergi la</string>
@@ -53,6 +54,7 @@
     <string name="mark_watched">Marchează ca vizionat</string>
     <plurals name="people">
         <item quantity="one">Persoane</item>
+        <item quantity="other">Persoane</item>
     </plurals>
     <string name="play_count">Număr de redări</string>
     <string name="more">Mai mult</string>
@@ -84,7 +86,7 @@
     <string name="aspect_ratio">Rată de aspect</string>
     <string name="show_details">Înregistrare detaliată</string>
     <string name="image_type">Tip imagine</string>
-    <string name="cast_and_crew"><![CDATA[Distribuție și echipă]]></string>
+    <string name="cast_and_crew">Distribuție și echipă</string>
     <string name="guest_stars">Vedete invitate</string>
     <string name="level">Nivel</string>
     <string name="channels">Canale</string>
@@ -169,7 +171,7 @@
     <string name="api_key">Cheie API</string>
     <string name="seerr_login">Conectează-te la serverul Seerr</string>
     <string name="discovered_servers">Servere descoperite</string>
-    <string name="download_and_update"><![CDATA[Descarcă & Actualizează]]></string>
+    <string name="download_and_update">Descarcă &amp; Actualizează</string>
     <string name="commercial">Reclamă</string>
     <string name="community_rating">Evaluarea comunității</string>
     <string name="compose_error_message_title">A apărut o eroare! Apasă butonul pentru a trimite jurnalele către serverul tău.</string>
@@ -211,6 +213,7 @@
     <string name="tv_seasons">Sezoane</string>
     <plurals name="tv_shows">
         <item quantity="one">Seriale TV</item>
+        <item quantity="other">Seriale TV</item>
     </plurals>
     <string name="ui_interface">Interfață</string>
     <string name="unknown">Necunoscut</string>
@@ -222,6 +225,7 @@
     <string name="one_click_pause">Pauză cu un click</string>
     <plurals name="interviews">
         <item quantity="one">Interviuri</item>
+        <item quantity="other">Interviuri</item>
     </plurals>
     <string name="background">Fundal</string>
     <plurals name="downloads">
@@ -289,7 +293,7 @@
     <string name="skip_ask">Cere să sari peste</string>
     <string name="seerr_jellyfin_user">Utilizator Jellyfin</string>
     <string name="seerr_local_user">Utilizator local</string>
-    <string name="search_and_download_subtitles"><![CDATA[Caută & descarcă subtitrări]]></string>
+    <string name="search_and_download_subtitles">Caută &amp; descarcă subtitrări</string>
     <string name="composer">Compozitor</string>
     <string name="writer">Scriitor</string>
     <string name="lyrics">Versuri</string>
@@ -311,7 +315,7 @@
     <string name="playback_debug_info">Afișează informații de depanare privind redarea</string>
     <string name="only_forced_subtitles">Doar subtitrări forțate</string>
     <string name="save">Salvează</string>
-    <string name="search_and_download"><![CDATA[Caută & Descarcă]]></string>
+    <string name="search_and_download">Caută &amp; Descarcă</string>
     <string name="resume">Reia</string>
     <string name="voice_starting">Începe</string>
     <string name="voice_search_prompt">Vorbește pentru a căuta</string>
@@ -321,6 +325,7 @@
     <string name="top_unwatched">Cele mai bine cotate, nevizionate</string>
     <plurals name="trailers">
         <item quantity="one">Trailere</item>
+        <item quantity="other">Trailere</item>
     </plurals>
     <string name="play_with_transcoding">Redă cu transcodare</string>
     <string name="media_information">Informații media</string>
@@ -328,21 +333,26 @@
     <string name="add_to_playlist">Adaugă în lista de redare</string>
     <plurals name="other_extras">
         <item quantity="one">Altele</item>
+        <item quantity="other">Altele</item>
     </plurals>
     <plurals name="behind_the_scenes">
         <item quantity="one">În spatele scenelor</item>
+        <item quantity="other">În spatele scenelor</item>
     </plurals>
     <plurals name="theme_songs">
         <item quantity="one">Melodii tematice</item>
+        <item quantity="other">Melodii tematice</item>
     </plurals>
     <plurals name="deleted_scenes">
         <item quantity="one">Scene șterse</item>
+        <item quantity="other">Scene șterse</item>
     </plurals>
     <string name="official_rating">Evaluare parentală</string>
     <string name="runtime_sort">Timp de execuție</string>
     <string name="extras_title">Extra</string>
     <plurals name="clips">
         <item quantity="one">Clipuri</item>
+        <item quantity="other">Clipuri</item>
     </plurals>
     <string name="favorite_items_title">%s favorit</string>
     <string name="app_theme">Temă aplicație</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -27,7 +27,7 @@
     <string name="directed_by">Режиссёр %1$s</string>
     <string name="director">Режиссёр</string>
     <string name="discovered_servers">Обнаруженные серверы</string>
-    <string name="download_and_update"><![CDATA[Загрузить и Обновить]]></string>
+    <string name="download_and_update">Загрузить и Обновить</string>
     <string name="downloading">Скачивание…</string>
     <string name="enter_server_url">Введите IP или URL сервера</string>
     <string name="episodes">Эпизоды</string>
@@ -73,7 +73,7 @@
     <string name="remove_favorite">Убрать из избранного</string>
     <string name="resume">Продолжить</string>
     <string name="save">Сохранить</string>
-    <string name="search_and_download"><![CDATA[Найти и скачать]]></string>
+    <string name="search_and_download">Найти и скачать</string>
     <string name="search">Найти</string>
     <string name="searching">Поиск…</string>
     <string name="select_server">Выберите сервер</string>
@@ -132,6 +132,7 @@
     </plurals>
     <plurals name="behind_the_scenes">
         <item quantity="one">За кадром</item>
+        <item quantity="other">За кадром</item>
     </plurals>
     <plurals name="clips">
         <item quantity="one">Клип</item>
@@ -199,7 +200,7 @@
     <string name="watch_live">Смотреть прямой эфир</string>
     <string name="aired_episode_order">Порядок выхода эпизодов</string>
     <string name="reset">Сброс</string>
-    <string name="cast_and_crew"><![CDATA[Снимались и снимали]]></string>
+    <string name="cast_and_crew">Снимались и снимали</string>
     <string name="guest_stars">Приглашённые звёзды</string>
     <string name="aspect_ratio">Соотношение сторон</string>
     <string name="show_details">Показать подробности</string>
@@ -271,7 +272,7 @@
     <string name="auto_play_next_delay">Задержка перед воспроизведением следующей серии</string>
     <string name="auto_play_next">Автовоспроизведение следующей серии</string>
     <string name="combine_continue_next_summary">Применяется только к Телешоу</string>
-    <string name="combine_continue_next"><![CDATA[Объединить Продолжить просмотр и Далее]]></string>
+    <string name="combine_continue_next">Объединить Продолжить просмотр и Далее</string>
     <string name="direct_play_ass">Прямое воспроизведение ASS-субтитров</string>
     <string name="direct_play_pgs">Прямое воспроизведение PGS-субтитров</string>
     <string name="font_size">Размер шрифта</string>
@@ -295,9 +296,11 @@
     </plurals>
     <plurals name="samples">
         <item quantity="one">Отрывки</item>
+        <item quantity="other">Отрывки</item>
     </plurals>
     <plurals name="featurettes">
         <item quantity="one">Дополнительные материалы</item>
+        <item quantity="other">Дополнительные материалы</item>
     </plurals>
     <string name="player_backend">Выбор плеера</string>
     <string name="edge_size">Толщина обводки</string>
@@ -306,9 +309,11 @@
     <string name="forced_track">Форсированные</string>
     <plurals name="theme_songs">
         <item quantity="one">Саундтреки</item>
+        <item quantity="other">Саундтреки</item>
     </plurals>
     <plurals name="theme_videos">
         <item quantity="one">Видеоролики</item>
+        <item quantity="other">Видеоролики</item>
     </plurals>
     <string name="nav_drawer_pins">Настроить элементы боковой панели</string>
     <string name="nav_drawer_pins_summary">Выберите элементы для показа на панели, остальные элементы будут скрыты</string>
@@ -323,6 +328,7 @@
     <string name="pass_out_protection">Остановка воспроизведения при бездействии</string>
     <plurals name="shorts">
         <item quantity="one">Короткометражки</item>
+        <item quantity="other">Короткометражки</item>
     </plurals>
     <string name="ends_at">Конец в %1$s</string>
     <string name="enter_server_address">Введите адрес сервера</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -31,7 +31,7 @@
     <string name="director">Režiser</string>
     <string name="disabled">Onemogočeno</string>
     <string name="discovered_servers">Najdeni strežniki</string>
-    <string name="download_and_update"><![CDATA[Prenesi in posodobi]]></string>
+    <string name="download_and_update">Prenesi in posodobi</string>
     <string name="downloading">Prenos poteka…</string>
     <string name="enabled">Omogočeno</string>
     <string name="ends_at">Konča se ob %1$s</string>
@@ -66,6 +66,7 @@
     <string name="more">Več</string>
     <plurals name="movies">
         <item quantity="one">Filmi</item>
+        <item quantity="other">Filmi</item>
     </plurals>
     <string name="name">Ime</string>
     <string name="next_up">Naslednjo</string>
@@ -80,6 +81,7 @@
     <string name="path">Pot</string>
     <plurals name="people">
         <item quantity="one">Osebe</item>
+        <item quantity="other">Osebe</item>
     </plurals>
     <string name="play_count">Število predvajanj</string>
     <string name="play_from_here">Predvajaj od tu</string>
@@ -104,7 +106,7 @@
     <string name="restart">Zaženi znova</string>
     <string name="resume">Nadaljuj</string>
     <string name="save">Shrani</string>
-    <string name="search_and_download"><![CDATA[Poišči in prenesi]]></string>
+    <string name="search_and_download">Poišči in prenesi</string>
     <string name="search">Išči</string>
     <string name="searching">Iskanje…</string>
     <string name="voice_search">Glasovno iskanje</string>
@@ -148,6 +150,7 @@
     <string name="top_unwatched">Najbolje ocenjeno, neogledano</string>
     <plurals name="trailers">
         <item quantity="one">Napovedniki</item>
+        <item quantity="other">Napovedniki</item>
     </plurals>
     <string name="tv_dvr_schedule">Program snemalnika</string>
     <string name="tv_guide">Vodnik</string>
@@ -155,6 +158,7 @@
     <string name="tv_seasons">Sezone</string>
     <plurals name="tv_shows">
         <item quantity="one">TV oddaje</item>
+        <item quantity="other">TV oddaje</item>
     </plurals>
     <string name="ui_interface">Vmesnik</string>
     <string name="unknown">Neznano</string>
@@ -182,36 +186,47 @@
     <string name="extras_title">Dodatki</string>
     <plurals name="other_extras">
         <item quantity="one">Ostalo</item>
+        <item quantity="other">Ostalo</item>
     </plurals>
     <plurals name="behind_the_scenes">
         <item quantity="one">V zakulisju</item>
+        <item quantity="other">V zakulisju</item>
     </plurals>
     <plurals name="theme_songs">
         <item quantity="one">Tematske pesmi</item>
+        <item quantity="other">Tematske pesmi</item>
     </plurals>
     <plurals name="theme_videos">
         <item quantity="one">Tematski videi</item>
+        <item quantity="other">Tematski videi</item>
     </plurals>
     <plurals name="clips">
         <item quantity="one">Posnetki</item>
+        <item quantity="other">Posnetki</item>
     </plurals>
     <plurals name="deleted_scenes">
         <item quantity="one">Izbrisane scene</item>
+        <item quantity="other">Izbrisane scene</item>
     </plurals>
     <plurals name="interviews">
         <item quantity="one">Intervjuji</item>
+        <item quantity="other">Intervjuji</item>
     </plurals>
     <plurals name="scenes">
         <item quantity="one">Prizori</item>
+        <item quantity="other">Prizori</item>
     </plurals>
     <plurals name="samples">
         <item quantity="one">Vzorci</item>
+        <item quantity="other">Vzorci</item>
     </plurals>
     <plurals name="featurettes">
         <item quantity="one">Kratki filmi</item>
+        <item quantity="other">Kratki filmi</item>
     </plurals>
     <plurals name="shorts">
         <item quantity="one">Kratki filmi</item>
+        <item quantity="other">Kratki filmi</item>
     </plurals>
     <string name="favorite_items_title">Dodaj %s med priljubljene</string>
     <plurals name="downloads">
@@ -259,7 +274,7 @@
     <string name="auto_play_next">Samodejno predvajanje naslednjega</string>
     <string name="check_for_updates">Preveri za posodobitve</string>
     <string name="combine_continue_next_summary">Velja samo za televizijske serije</string>
-    <string name="combine_continue_next"><![CDATA[Združi »Nadaljuj z ogledom« in »Naslednje«]]></string>
+    <string name="combine_continue_next">Združi »Nadaljuj z ogledom« in »Naslednje«</string>
     <string name="direct_play_ass">Za podnapise v formatu ASS uporabite knjižnico libass</string>
     <string name="direct_play_pgs">Neposredno predvajanje podnapisov PGS</string>
     <string name="downmix_stereo">Vedno pretvori v stereo</string>
@@ -343,7 +358,7 @@
     <string name="aspect_ratio">Razmerje stranic</string>
     <string name="show_details">Pokaži podrobnosti</string>
     <string name="image_type">Vrsta slike</string>
-    <string name="cast_and_crew"><![CDATA[Igralska zasedba in ekipa]]></string>
+    <string name="cast_and_crew">Igralska zasedba in ekipa</string>
     <string name="guest_stars">Gostujoči igralci</string>
     <string name="edge_size">Velikost roba</string>
     <string name="refresh_rate_switching">Preklapljanje hitrosti osveževanja</string>
@@ -540,12 +555,12 @@
     <string name="image_type_thumb">Thumb</string>
     <string name="backdrop_style_dynamic">Slika z dinamičnimi barvami</string>
     <string name="backdrop_style_image">Samo slika</string>
-    <string name="enter_url_api_key"><![CDATA[Vnesite URL in API ključ]]></string>
+    <string name="enter_url_api_key">Vnesite URL in API ključ</string>
     <string name="api_key">API ključ</string>
     <string name="seerr_login">Prijava na strežnik Seerr</string>
     <string name="seerr_jellyfin_user">Jellyfin uporabnik</string>
     <string name="seerr_local_user">Lokalni uporabnik</string>
-    <string name="search_and_download_subtitles"><![CDATA[Išči in prenesi podnapise]]></string>
+    <string name="search_and_download_subtitles">Išči in prenesi podnapise</string>
     <string name="no_subtitles_found">Ni bilo najdenih podnapisov</string>
     <string name="series_continueing">danes</string>
     <string name="in_app_screensaver">Uporabite ohranjevalnik zaslona aplikacije</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -75,6 +75,7 @@
     <string name="top_unwatched">Topprankade osedda</string>
     <plurals name="trailers">
         <item quantity="one">Förhandsvisningar</item>
+        <item quantity="other">Förhandsvisningar</item>
     </plurals>
     <string name="tv_dvr_schedule">DVR-schema</string>
     <string name="tv_guide">TV Guide</string>
@@ -106,36 +107,47 @@
     <string name="extras_title">Extramaterial</string>
     <plurals name="other_extras">
         <item quantity="one">Annat</item>
+        <item quantity="other">Annat</item>
     </plurals>
     <plurals name="behind_the_scenes">
         <item quantity="one">Bakom kulisserna</item>
+        <item quantity="other">Bakom kulisserna</item>
     </plurals>
     <plurals name="theme_songs">
         <item quantity="one">Temalåtar</item>
+        <item quantity="other">Temalåtar</item>
     </plurals>
     <plurals name="theme_videos">
         <item quantity="one">Temavideor</item>
+        <item quantity="other">Temavideor</item>
     </plurals>
     <plurals name="clips">
         <item quantity="one">Klipp</item>
+        <item quantity="other">Klipp</item>
     </plurals>
     <plurals name="deleted_scenes">
         <item quantity="one">Borttagna scener</item>
+        <item quantity="other">Borttagna scener</item>
     </plurals>
     <plurals name="interviews">
         <item quantity="one">Intervjuer</item>
+        <item quantity="other">Intervjuer</item>
     </plurals>
     <plurals name="scenes">
         <item quantity="one">Scener</item>
+        <item quantity="other">Scener</item>
     </plurals>
     <plurals name="samples">
         <item quantity="one">Exempel</item>
+        <item quantity="other">Exempel</item>
     </plurals>
     <plurals name="featurettes">
         <item quantity="one">Specialinslag</item>
+        <item quantity="other">Specialinslag</item>
     </plurals>
     <plurals name="shorts">
         <item quantity="one">Kortfilmer</item>
+        <item quantity="other">Kortfilmer</item>
     </plurals>
     <plurals name="downloads">
         <item quantity="one">%s nedladdning</item>
@@ -231,7 +243,7 @@
     <string name="disable_if_crash">Inaktivera om du upplever krascher</string>
     <string name="mpv_options">MPV inställningar</string>
     <string name="exoplayer_options">ExoPlayer inställningar</string>
-    <string name="download_and_update"><![CDATA[Ladda ner och uppdatera]]></string>
+    <string name="download_and_update">Ladda ner och uppdatera</string>
     <string name="skip_segment_intro">Hoppa över intro</string>
     <string name="skip_segment_outro">Hoppa över eftertexter</string>
     <string name="skip_segment_unknown">Hoppa över segment</string>
@@ -362,8 +374,8 @@
     <string name="skip_ask">Fråga om att hoppa över</string>
     <string name="skip_automatically">Hoppa över automatiskt</string>
     <string name="send_app_logs_summary">Användbart för felsökning</string>
-    <string name="search_and_download_subtitles"><![CDATA[Sök och ladda ner undertexter]]></string>
-    <string name="search_and_download"><![CDATA[Sök och ladda ner]]></string>
+    <string name="search_and_download_subtitles">Sök och ladda ner undertexter</string>
+    <string name="search_and_download">Sök och ladda ner</string>
     <string name="saturation">Mättnad</string>
     <string name="save_for_album">Spara till album</string>
     <string name="save_to_server">Spara till serverns användarprofil</string>
@@ -443,7 +455,7 @@
     <string name="view_options_type_grid">Rutnät</string>
     <string name="view_options_type_list">Lista</string>
     <string name="view_options_type_list_compact">Kompakt lista</string>
-    <string name="enter_url_api_key"><![CDATA[Ange URL och API-nyckel]]></string>
+    <string name="enter_url_api_key">Ange URL och API-nyckel</string>
     <string name="no_subtitles_found">Inga externa undertexter hittades</string>
     <string name="in_app_screensaver">Använd skärmsläckare i appen</string>
     <string name="lyricist">Textförfattare</string>
@@ -501,13 +513,13 @@
     <string name="no_servers_found">Inga servrar hittades</string>
     <string name="only_forced_subtitles">Endast tvingade undertexter</string>
     <string name="no_trailers">Inga trailrar</string>
-    <string name="combine_continue_next"><![CDATA[Kombinera Fortsätt titta och kommande avsnitt]]></string>
+    <string name="combine_continue_next">Kombinera Fortsätt titta och kommande avsnitt</string>
     <string name="framerate">Bildfrekvens</string>
     <string name="bit_depth">Bitdjup</string>
     <string name="video_range">Videoomfång</string>
     <string name="video_range_type">Typ av videoomfång</string>
     <string name="color_space">Färgrymd</string>
-    <string name="cast_and_crew"><![CDATA[Rollista och team]]></string>
+    <string name="cast_and_crew">Rollista och team</string>
     <string name="genres_in">Genrer i %1$s</string>
     <string name="remove_continue_watching">Ta bort från Fortsätt titta</string>
     <string name="local">Lokal</string>

--- a/app/src/test/java/com/github/damontecres/wholphin/services/ExtrasServiceTest.kt
+++ b/app/src/test/java/com/github/damontecres/wholphin/services/ExtrasServiceTest.kt
@@ -2,7 +2,6 @@ package com.github.damontecres.wholphin.services
 
 import android.content.Context
 import android.content.res.Resources
-import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.ExtrasItem
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.ui.successResponse
@@ -47,12 +46,9 @@ class ExtrasServiceTest {
 
         every { mockApiClient.userLibraryApi } returns mockUserLibraryApi
         every { mockContext.resources } returns mockResources
-        every { mockResources.getQuantityString(R.plurals.interviews, any()) } returns "Interviews"
-        every { mockResources.getQuantityString(R.plurals.clips, any()) } returns "Clips"
-        every { mockResources.getQuantityString(R.plurals.interviews, any(), any<Int>()) } returns "Interviews"
-        every { mockResources.getQuantityString(R.plurals.clips, any(), any<Int>()) } returns "Clips"
-
-        every { mockResources.getQuantityString(R.plurals.items, any(), any<Int>()) } returns "Items"
+        every { mockResources.getString(any()) } returns "Interviews"
+        every { mockResources.getQuantityString(any(), any()) } returns "Interviews"
+        every { mockResources.getQuantityString(any(), any(), any<Int>()) } returns "Interviews"
 
         every { mockImageUrlService.getItemImageUrl(any<BaseItem>(), ImageType.PRIMARY, any(), any(), any()) } returns
             "https://localhost/image.jpg"


### PR DESCRIPTION
## Description
Previously not every plural translation had full coverage and some did not have the fallback "other" quantity translation. So for some languages this would cause an error when trying to display the string depending on the quantity. This PR ensures every plural translation has the "other" fallback.

Note: the "other" fallback is copied from an existing translation so I'm sure some will not be grammatically correct!

Dev note: I used a python script to parse and fix the entries, so it also rewrote some of the unrelated `CDATA` entries.

### Related issues
Fixes #1676

### Testing
On the emulator, I reproduced the error in the issue with the Danish translation, verified it was fixed after the patch was applied

## Screenshots
N/A

## AI or LLM usage
None