### PR TITLE
Route multichannel FLAC to the FFmpeg decoder instead of the AOSP decoder (SHIELD)

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/PlayerFactory.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/PlayerFactory.kt
@@ -39,6 +39,7 @@ import com.github.damontecres.wholphin.preferences.PlayerBackend
 import com.github.damontecres.wholphin.preferences.get
 import com.github.damontecres.wholphin.services.hilt.AuthOkHttpClient
 import com.github.damontecres.wholphin.util.WholphinDispatchers
+import com.github.damontecres.wholphin.util.profile.KnownDefects
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.peerless2012.ass.media.AssHandler
 import io.github.peerless2012.ass.media.factory.AssRenderersFactory
@@ -336,11 +337,13 @@ class WholphinRenderersFactory(
             eventListener,
             out,
         )
-        // Replace the platform audio renderer with one that reports multichannel FLAC as
-        // unsupported, so the track selector routes it to the FFmpeg decoder instead. The AOSP
-        // software FLAC decoder (OMX.google.flac / c2.android.flac) claims to support it but fails
-        // at runtime with "no streaminfo metadata block"; stereo FLAC and vendor decoders are left
-        // alone. Via supportsFormat -- that, not getDecoderInfos, is what track selection consults.
+        // Devices in KnownDefects.multichannelFlacBug can't decode multichannel FLAC with the
+        // platform decoder. Replace the platform audio renderer with one that reports >2-channel
+        // FLAC as unsupported, so the track selector routes it to the bundled FFmpeg decoder;
+        // stereo FLAC and every other format keep the platform decoder, unchanged. Replaced in
+        // place (not appended) to preserve renderer order, and done via supportsFormat -- that,
+        // not getDecoderInfos, is what track selection consults.
+        if (!KnownDefects.multichannelFlacBug) return
         val platformIndex = out.indexOfFirst { it is MediaCodecAudioRenderer }
         if (platformIndex < 0) return
         out[platformIndex] =
@@ -357,16 +360,8 @@ class WholphinRenderersFactory(
                     mediaCodecSelector: MediaCodecSelector,
                     format: Format,
                 ): Int {
-                    if (MimeTypes.AUDIO_FLAC == format.sampleMimeType && format.channelCount > 2) {
-                        val decoders = super.getDecoderInfos(mediaCodecSelector, format, false)
-                        val aospSoftwareOnly =
-                            decoders.isNotEmpty() &&
-                                decoders.all {
-                                    it.name.startsWith("OMX.google.") || it.name.startsWith("c2.android.")
-                                }
-                        if (aospSoftwareOnly) {
-                            return RendererCapabilities.create(C.FORMAT_UNSUPPORTED_SUBTYPE)
-                        }
+                    if (format.sampleMimeType == MimeTypes.AUDIO_FLAC && format.channelCount > 2) {
+                        return RendererCapabilities.create(C.FORMAT_UNSUPPORTED_SUBTYPE)
                     }
                     return super.supportsFormat(mediaCodecSelector, format)
                 }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/PlayerFactory.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/PlayerFactory.kt
@@ -8,6 +8,8 @@ import android.os.Handler
 import androidx.annotation.OptIn
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.common.TrackSelectionParameters.AudioOffloadPreferences
 import androidx.media3.common.util.ExperimentalApi
@@ -17,7 +19,11 @@ import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.RendererCapabilities
 import androidx.media3.exoplayer.RenderersFactory
+import androidx.media3.exoplayer.audio.AudioRendererEventListener
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
@@ -308,5 +314,62 @@ class WholphinRenderersFactory(
                 throw java.lang.IllegalStateException("Error instantiating AV1 extension", e)
             }
         }
+    }
+
+    override fun buildAudioRenderers(
+        context: Context,
+        extensionRendererMode: Int,
+        mediaCodecSelector: MediaCodecSelector,
+        enableDecoderFallback: Boolean,
+        audioSink: AudioSink,
+        eventHandler: Handler,
+        eventListener: AudioRendererEventListener,
+        out: ArrayList<Renderer>,
+    ) {
+        super.buildAudioRenderers(
+            context,
+            extensionRendererMode,
+            mediaCodecSelector,
+            enableDecoderFallback,
+            audioSink,
+            eventHandler,
+            eventListener,
+            out,
+        )
+        // Replace the platform audio renderer with one that reports multichannel FLAC as
+        // unsupported, so the track selector routes it to the FFmpeg decoder instead. The AOSP
+        // software FLAC decoder (OMX.google.flac / c2.android.flac) claims to support it but fails
+        // at runtime with "no streaminfo metadata block"; stereo FLAC and vendor decoders are left
+        // alone. Via supportsFormat -- that, not getDecoderInfos, is what track selection consults.
+        val platformIndex = out.indexOfFirst { it is MediaCodecAudioRenderer }
+        if (platformIndex < 0) return
+        out[platformIndex] =
+            object : MediaCodecAudioRenderer(
+                context,
+                codecAdapterFactory,
+                mediaCodecSelector,
+                enableDecoderFallback,
+                eventHandler,
+                eventListener,
+                audioSink,
+            ) {
+                override fun supportsFormat(
+                    mediaCodecSelector: MediaCodecSelector,
+                    format: Format,
+                ): Int {
+                    if (MimeTypes.AUDIO_FLAC == format.sampleMimeType && format.channelCount > 2) {
+                        val decoders = super.getDecoderInfos(mediaCodecSelector, format, false)
+                        val aospSoftwareOnly =
+                            decoders.isNotEmpty() &&
+                                decoders.all {
+                                    it.name.startsWith("OMX.google.") || it.name.startsWith("c2.android.")
+                                }
+                        if (aospSoftwareOnly) {
+                            return RendererCapabilities.create(C.FORMAT_UNSUPPORTED_SUBTYPE)
+                        }
+                    }
+                    return super.supportsFormat(mediaCodecSelector, format)
+                }
+            }
     }
 }

--- a/app/src/main/java/com/github/damontecres/wholphin/util/profile/KnownDefects.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/profile/KnownDefects.kt
@@ -23,6 +23,17 @@ private val modelsWithEac3TsPassthroughBug =
     )
 
 /**
+ * List of device codenames whose platform FLAC decoder advertises multichannel support but fails
+ * at runtime on multichannel (>2 channel) FLAC with "no streaminfo metadata block". Keyed on
+ * Build.DEVICE, not Build.MODEL: every SHIELD TV reports the same model ("SHIELD Android TV"), so
+ * the codename is what isolates the affected 2019 (non-Pro) unit from the Pro and older models.
+ */
+private val devicesWithMultichannelFlacBug =
+    listOf(
+        "sif", // NVIDIA SHIELD TV 2019 (non-Pro, 2GB "Tube")
+    )
+
+/**
  * List of device models that support H264 Hi10P 5.2, but don't advertise it
  *
  * Amazon devices from https://developer.amazon.com/docs/device-specs/device-specifications-fire-tv-streaming-media-player.html
@@ -39,5 +50,6 @@ private val modelsWithHi10P52Support =
 object KnownDefects {
     val hevcDoviHdr10PlusBug = Build.MODEL in modelsWithDoViHdr10PlusBug
     val eac3HlsPassthroughBug = Build.MODEL in modelsWithEac3TsPassthroughBug
+    val multichannelFlacBug = Build.DEVICE in devicesWithMultichannelFlacBug
     val supportsHi10P52 = Build.MODEL in modelsWithHi10P52Support
 }


### PR DESCRIPTION
The AOSP software FLAC decoder (c2.android.flac / OMX.google.flac) advertises multichannel support on the 2019 nvidia shield "sif" but 5.1 FLAC can't Direct Play and stalls or falls back to transcoding. 
<!-- By submitting this pull request, you acknowledge that you have read the [contributing guide](https://github.com/damontecres/Wholphin/blob/main/CONTRIBUTING.md, including the AI/LLM policy, and [developer's guide](https://github.com/damontecres/Wholphin/blob/main/DEVELOPMENT.md) -->

## Description
<!-- Describe the changes in detail -->

This reports multichannel FLAC as unsupported in a MediaCodecAudioRenderer subclass so the track selector routes it to the bundled FFmpeg extension decoder, but only when the device is a 2019 nvidia shield non pro (sif).

### Related issues
<!-- If this is a new feature or a change, there must be a discussion in an issue first, reference the issue here -->
<!-- If fixing a bug, reference the bug issue here, or describe the bug, including steps to reproduce -->
Fixes #1719

play a file with FLAC 5.1 audio on an nvidia shield and wait

### Testing
<!-- Describe how this change was tested and on what device(s) -->

Tested on my NVIDIA SHIELD Android TV 2019. I have been running this fix and it allows previously broken files to play across multiple series compared to the unmodified client. It does not alter the clients ability to play any other audio types or cause them to fall back to transcoding.

Files with multichannel FLAC audio fall back to the ffmpeg decoder while FLAC 2.0 files continue to use the default decoder. Nothing else changes.

## Screenshots
<!-- Please include screenshots if the PR alters any UI elements -->

no ui changes

## AI or LLM usage
<!-- If you used any AI or LLM assistance, please list where in the code and how you tested it -->
Diagnosis and the initial patch were assisted with AI.