### PR TITLE
Fix library freeze if first item's title starts with a character not in the alphabet string

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderList.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderList.kt
@@ -103,9 +103,11 @@ fun CollectionFolderList(
 
     fun jumpTo(newPosition: Int) {
         scope.launch {
-            position = newPosition
-            listState.animateScrollToItem(newPosition)
-            positionFocusRequester.tryRequestFocus()
+            if (newPosition >= 0) {
+                position = newPosition
+                listState.animateScrollToItem(newPosition)
+                positionFocusRequester.tryRequestFocus()
+            }
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CardGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/CardGrid.kt
@@ -515,7 +515,7 @@ fun AlphabetButtons(
     val scope = rememberCoroutineScope()
     val listState = rememberLazyListState()
 
-    val index = letters.indexOf(currentLetter)
+    val index = remember(letters, currentLetter) { letters.indexOf(currentLetter) }
     LaunchedEffect(currentLetter) {
         scope.launch(ExceptionHandler()) {
             val firstVisibleItemIndex = listState.firstVisibleItemIndex
@@ -523,7 +523,7 @@ fun AlphabetButtons(
                 listState.layoutInfo.visibleItemsInfo
                     .lastOrNull()
                     ?.index ?: -1
-            if (index !in firstVisibleItemIndex..lastVisibleItemIndex) {
+            if (index >= 0 && index !in firstVisibleItemIndex..lastVisibleItemIndex) {
                 listState.animateScrollToItem(index)
             }
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/music/LyricsContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/music/LyricsContent.kt
@@ -58,7 +58,7 @@ fun LyricsContent(
         LaunchedEffect(currentLyricPosition) {
             if (currentLyricPosition != null) {
                 listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index?.let {
-                    if (currentLyricPosition !in listState.firstVisibleItemIndex..it) {
+                    if (currentLyricPosition >= 0 && currentLyricPosition !in listState.firstVisibleItemIndex..it) {
                         listState.animateScrollToItem(currentLyricPosition)
                     }
                 }


### PR DESCRIPTION
## Description
A library's grid page tries to highlight the first letter of the focused item. But if the first letter was a not in the alphabet string (which varies by language), a exception was thrown on the main thread causing a freeze.

This PR ensures only a non-negative index is highlighted on the letter buttons.

### Related issues
Fixes #1361
Need to create an issue to improve alphabet letter button handling for non-English alphabets

### Testing
Emulator, I manually passed a non-`[0-9A-Z]` character to replicate the freeze

## Screenshots
N/A

## AI or LLM usage
None