### PR TITLE
Add option for dpad skipping with no seek bar

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/AppPreference.kt
@@ -664,7 +664,7 @@ sealed interface AppPreference<Pref, T> {
         val DpadSeekModePref =
             AppChoicePreference<AppPreferences, DpadSeekMode>(
                 title = R.string.d_pad_seek_mode_title,
-                defaultValue = DpadSeekMode.SKIP_TIME,
+                defaultValue = DpadSeekMode.SEEKBAR_MINIMAL,
                 getter = { it.playbackPreferences.dpadSeekMode },
                 setter = { prefs, value ->
                     prefs.updatePlaybackPreferences { dpadSeekMode = value }
@@ -672,6 +672,7 @@ sealed interface AppPreference<Pref, T> {
                 displayValues = R.array.dpad_seek_mode_options,
                 indexToValue = { DpadSeekMode.forNumber(it) },
                 valueToIndex = { if (it != DpadSeekMode.UNRECOGNIZED) it.number else 0 },
+                subtitles = R.array.dpad_seek_mode_summaries,
             )
 
         val GlobalContentScale =

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
@@ -193,7 +193,7 @@ class PlaybackKeyHandler(
 
     private fun seekBy(duration: Duration) {
         val durationMs = duration.inWholeMilliseconds
-        if (dpadSeekMode == DpadSeekMode.TRICKPLAY) {
+        if (dpadSeekMode == DpadSeekMode.SEEKBAR_TRICKPLAY) {
             onDpadSeek.invoke(durationMs)
         } else {
             if (duration < Duration.ZERO) {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -265,7 +265,7 @@ fun PlaybackPageContent(
                 },
                 onPlaybackDialogTypeClick = { playbackDialog = it },
                 isDpadSeekVisible = {
-                    prefs.dpadSeekMode == DpadSeekMode.TRICKPLAY && skipIndicatorDuration != 0L
+                    prefs.dpadSeekMode == DpadSeekMode.SEEKBAR_TRICKPLAY && skipIndicatorDuration != 0L
                 },
                 onDpadSeek = onDpadSeek,
                 dpadSeekMode = prefs.dpadSeekMode,
@@ -382,7 +382,7 @@ fun PlaybackPageContent(
                 visible =
                     !controllerViewState.controlsVisible &&
                         skipIndicatorDuration != 0L &&
-                        prefs.dpadSeekMode == DpadSeekMode.TRICKPLAY,
+                        prefs.dpadSeekMode == DpadSeekMode.SEEKBAR_TRICKPLAY,
                 enter = fadeIn() + slideInVertically { it / 2 },
                 exit = fadeOut() + slideOutVertically { it },
                 modifier =
@@ -408,7 +408,9 @@ fun PlaybackPageContent(
             }
 
             // If D-pad skipping, show the amount skipped in an animation
-            if (!controllerViewState.controlsVisible && skipIndicatorDuration != 0L && prefs.dpadSeekMode != DpadSeekMode.TRICKPLAY) {
+            if (!controllerViewState.controlsVisible && skipIndicatorDuration != 0L &&
+                prefs.dpadSeekMode != DpadSeekMode.SEEKBAR_TRICKPLAY
+            ) {
                 // Skip time mode: show seek distance indicator
                 SkipIndicator(
                     durationMs = skipIndicatorDuration,
@@ -421,8 +423,7 @@ fun PlaybackPageContent(
                             .padding(bottom = 70.dp),
                 )
                 // Show a small progress bar along the bottom of the screen
-                val showSkipProgress = true // TODO get from preferences
-                if (showSkipProgress) {
+                if (prefs.dpadSeekMode == DpadSeekMode.SEEKBAR_MINIMAL) {
                     val percent = skipPosition.toFloat() / player.duration.toFloat()
                     Box(
                         modifier =

--- a/app/src/main/proto/WholphinDataStore.proto
+++ b/app/src/main/proto/WholphinDataStore.proto
@@ -91,8 +91,9 @@ message PlaybackPreferences {
 }
 
 enum DpadSeekMode {
-  SKIP_TIME = 0;
-  TRICKPLAY = 1;
+  SEEKBAR_MINIMAL = 0;
+  SEEKBAR_TRICKPLAY = 1;
+  SEEKBAR_NONE = 2;
 }
 
 message HomePagePreferences{

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -857,7 +857,7 @@
         <item>@string/none</item>
     </string-array>
     <string name="dpad_seek_mode_minimal_summary">Small seek bar along the bottom of the screen (default)</string>
-    <string name="dpad_seek_mode_trickplay_summary">Seek bar with trick play preview images</string>
+    <string name="dpad_seek_mode_trickplay_summary">Seek bar with trickplay preview images</string>
     <string name="dpad_seek_mode_none_summary">No seek bar</string>
     <string-array name="dpad_seek_mode_summaries">
         <item>@string/dpad_seek_mode_minimal_summary</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,9 +180,6 @@
     <string name="add_to_playlist">Add to playlist</string>
     <string name="one_click_pause">Pause with one click</string>
     <string name="one_click_pause_summary_on">Press D-Pad center to pause/play</string>
-    <string name="d_pad_seek_mode_title">D-Pad seek mode</string>
-    <string name="dpad_seek_mode_skip_time">Skip time</string>
-    <string name="dpad_seek_mode_trickplay">Trickplay previews</string>
     <string name="italic_font">Italicize font</string>
     <string name="font">Font</string>
     <string name="background">Background</string>
@@ -850,9 +847,22 @@
     <string name="confirm_enable_experimental_title">Enable experimental settings?</string>
     <string name="confirm_enable_experimental_body">Experimental settings may be unstable!\n\n These may removed or changed in any release.</string>
     <string name="video_tunneling">Video tunneling</string>
+
+    <string name="d_pad_seek_mode_title">D-Pad seek bar mode</string>
+    <string name="dpad_seek_mode_minimal">Minimal</string>
+    <string name="dpad_seek_mode_trickplay">Trickplay</string>
     <string-array name="dpad_seek_mode_options">
-        <item>@string/dpad_seek_mode_skip_time</item>
+        <item>@string/dpad_seek_mode_minimal</item>
         <item>@string/dpad_seek_mode_trickplay</item>
+        <item>@string/none</item>
+    </string-array>
+    <string name="dpad_seek_mode_minimal_summary">Small seek bar along the bottom of the screen (default)</string>
+    <string name="dpad_seek_mode_trickplay_summary">Seek bar with trick play preview images</string>
+    <string name="dpad_seek_mode_none_summary">No seek bar</string>
+    <string-array name="dpad_seek_mode_summaries">
+        <item>@string/dpad_seek_mode_minimal_summary</item>
+        <item>@string/dpad_seek_mode_trickplay_summary</item>
+        <item>@string/dpad_seek_mode_none_summary</item>
     </string-array>
 
     <string name="blocklisted">Blocklisted</string>


### PR DESCRIPTION
## Description
Adds a third option for d-pad seeking to not show any seek bar which only shows the skip indicator and not the seek bar along the bottom

### Related issues
Original work to add other mode in #1650
Closes #1520

### Testing
Emulator testing

## Screenshots
<img width="546" height="347" alt="image" src="https://github.com/user-attachments/assets/2872566e-4598-4284-92cb-95a45b307835" />

## AI or LLM usage
None
