### PR TITLE
Correct sort order when "Date Played" is selected in TV library.

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/data/SortAndDirection.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/data/SortAndDirection.kt
@@ -48,7 +48,7 @@ val SeriesSortOptions =
         ItemSortBy.PREMIERE_DATE,
         ItemSortBy.DATE_CREATED,
         ItemSortBy.DATE_LAST_CONTENT_ADDED,
-        ItemSortBy.DATE_PLAYED,
+        ItemSortBy.SERIES_DATE_PLAYED,
         ItemSortBy.COMMUNITY_RATING,
         ItemSortBy.CRITIC_RATING,
         ItemSortBy.OFFICIAL_RATING,


### PR DESCRIPTION
## Description
The TV library page offers the option to sort by date played, however when selected it reverts to the default (alphabetical).  This appears to be due to the use of `ItemSortBy.DATE_PLAYED` rather than the correct `ItemSortBy.SERIES_DATE_PLAYED`. See [BrowseGridFragment](https://github.com/jellyfin/jellyfin-androidtv/blob/master/app/src/main/java/org/jellyfin/androidtv/ui/browsing/BrowseGridFragment.java#L169) for the usage in the official Android TV client.

### Related issues
N/A

### Testing
Emulator against personal Jellyfin server.

## Screenshots
N/A

## AI or LLM usage
None
