### PR TITLE
Fix empty album list on the artist details page

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/music/ArtistDetailsPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/music/ArtistDetailsPage.kt
@@ -154,7 +154,9 @@ class ArtistViewModel
                         async {
                             val request =
                                 GetItemsRequest(
-                                    parentId = itemId,
+                                    albumArtistIds = listOf(itemId),
+                                    // Without this the query is scoped to the root folder's children, ie the libraries
+                                    recursive = true,
                                     fields = DefaultItemFields,
                                     includeItemTypes = listOf(BaseItemKind.MUSIC_ALBUM),
                                     sortBy =


### PR DESCRIPTION
## Description
The artist page queried its albums with parentId set to the artist's ID, but an artist is not an ancestor of its albums in Jellyfin's library tree. The artist item is a metadata stub under /config/metadata/artists while the albums live under the music library folder, so the query matched nothing and the Albums section rendered empty.

Query by albumArtistIds instead, which gives the section what it wants: the albums credited to that artist. That needs recursive, since with no parentId the search is otherwise scoped to the root folder's children, which are the libraries themselves.

### Related issues
https://github.com/damontecres/Wholphin/issues/1760

### Testing
Device: Sony Bravia 4K VH21

Select a music library -> Go to Artist tab -> Select an artist with music albums in your library

## Screenshots
Before:
<img width="1920" height="1080" alt="Screenshot_20260728_172226" src="https://github.com/user-attachments/assets/7dbd2ad4-189a-4efc-a619-3ed4b65760ac" />


After:
<img width="1920" height="1080" alt="Screenshot_20260728_172618" src="https://github.com/user-attachments/assets/424604e6-0103-45f7-aed2-ed4cff606f4c" />


## AI or LLM usage
I used Cursor and Claude Code for planning, implementation and code review.
