### PR TITLE
Fix preference text overflow/clipping

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/NavDrawerPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/NavDrawerPreference.kt
@@ -227,7 +227,7 @@ fun NavDrawerPreferenceListItem(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .heightIn(min = 40.dp, max = 88.dp),
+                    .heightIn(min = 40.dp),
         ) {
             ListItem(
                 selected = false,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/SliderPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/SliderPreference.kt
@@ -8,9 +8,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -18,7 +18,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.ProvideTextStyle
@@ -36,7 +35,6 @@ fun SliderPreference(
     modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     summaryBelow: Boolean = false,
-    heightAdjustment: Dp = 0.dp,
     additionalSummary: @Composable (ColumnScope.() -> Unit)? = null,
 ) {
     val focused = interactionSource.collectIsFocusedAsState().value
@@ -49,16 +47,15 @@ fun SliderPreference(
     val contentColor = contentColorFor(background)
 
     Column(
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.SpaceEvenly,
         modifier =
             modifier
-//                .height(80.dp) // not dense
-                .height(72.dp + heightAdjustment) // dense
+                .defaultMinSize(minHeight = 72.dp)
                 .fillMaxWidth()
                 .background(background, shape = RoundedCornerShape(8.dp))
-                .padding(PaddingValues(horizontal = 12.dp, vertical = 10.dp)), // dense,
+                .padding(PaddingValues(horizontal = 16.dp, vertical = 12.dp)),
     ) {
-        PreferenceTitle(title, color = contentColor)
+        PreferenceTitle(title, color = contentColor, modifier = Modifier.padding(bottom = 8.dp))
 
         ProvideTextStyle(PreferenceSummaryStyle.copy(color = contentColor)) {
             additionalSummary?.invoke(this)


### PR DESCRIPTION
## Description
Removes the max height constraints for slider preferences and navigation drawer preferences so that longer text (possibly in other languages or a long library name) won't cut off any content

### Related issues
Fixes #1784 

### Testing
Emulator with manual long text

## Screenshots
N/A, no significant change except sliders can be slightly taller if needed

## AI or LLM usage
None