### PR TITLE
Add live TV channel button controls

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/LiveTvChannelService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/LiveTvChannelService.kt
@@ -1,0 +1,45 @@
+package com.github.damontecres.wholphin.services
+
+import com.github.damontecres.wholphin.data.ServerRepository
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.liveTvApi
+import org.jellyfin.sdk.model.api.BaseItemDto
+import org.jellyfin.sdk.model.api.ItemSortBy
+import org.jellyfin.sdk.model.api.SortOrder
+import org.jellyfin.sdk.model.api.request.GetLiveTvChannelsRequest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Fetches the live TV channel list.
+ *
+ * Both the TV guide and playback need the channel list in the same order, so that channel
+ * up/down during playback moves through channels the way the guide displays them.
+ */
+@Singleton
+class LiveTvChannelService
+    @Inject
+    constructor(
+        private val api: ApiClient,
+        private val serverRepository: ServerRepository,
+    ) {
+        /**
+         * @param sortByRecentlyWatched order by the most recently watched channel first
+         * @param favoriteChannelsAtBeginning list favorite channels before the rest
+         */
+        suspend fun getChannels(
+            sortByRecentlyWatched: Boolean,
+            favoriteChannelsAtBeginning: Boolean,
+        ): List<BaseItemDto> =
+            api.liveTvApi
+                .getLiveTvChannels(
+                    GetLiveTvChannelsRequest(
+                        startIndex = 0,
+                        userId = serverRepository.currentUser?.id,
+                        enableFavoriteSorting = favoriteChannelsAtBeginning,
+                        sortBy = if (sortByRecentlyWatched) listOf(ItemSortBy.DATE_PLAYED) else null,
+                        sortOrder = if (sortByRecentlyWatched) SortOrder.DESCENDING else null,
+                        addCurrentProgram = false,
+                    ),
+                ).content.items
+    }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/LiveTvViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/LiveTvViewModel.kt
@@ -15,6 +15,7 @@ import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.ImageUrlService
+import com.github.damontecres.wholphin.services.LiveTvChannelService
 import com.github.damontecres.wholphin.services.LiveTvService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.ui.AppColors
@@ -82,6 +83,7 @@ class LiveTvViewModel
         private val serverRepository: ServerRepository,
         private val imageUrlService: ImageUrlService,
         private val favoriteWatchManager: FavoriteWatchManager,
+        private val liveTvChannelService: LiveTvChannelService,
         private val liveTvService: LiveTvService,
     ) : ViewModel() {
         private lateinit var channelsIdToIndex: Map<UUID, Int>
@@ -121,28 +123,13 @@ class LiveTvViewModel
                     val guideTimes = buildGuideTimes()
                     _state.update { it.copy(guideTimes = guideTimes) }
                     val guideStart = guideTimes.first()
-                    val channelData by api.liveTvApi.getLiveTvChannels(
-                        GetLiveTvChannelsRequest(
-                            startIndex = 0,
-                            userId = serverRepository.currentUser?.id,
-                            enableFavoriteSorting = favoriteChannelsAtBeginning,
-                            sortBy =
-                                if (sortByRecentlyWatched) {
-                                    listOf(ItemSortBy.DATE_PLAYED)
-                                } else {
-                                    null
-                                },
-                            sortOrder =
-                                if (sortByRecentlyWatched) {
-                                    SortOrder.DESCENDING
-                                } else {
-                                    null
-                                },
-                            addCurrentProgram = false,
-                        ),
-                    )
+                    val channelItems =
+                        liveTvChannelService.getChannels(
+                            sortByRecentlyWatched = sortByRecentlyWatched,
+                            favoriteChannelsAtBeginning = favoriteChannelsAtBeginning,
+                        )
                     val channels =
-                        channelData.items
+                        channelItems
                             .map {
                                 TvChannel(
                                     id = it.id,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/KeyIdentifier.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/KeyIdentifier.kt
@@ -64,6 +64,8 @@ fun isMedia(event: KeyEvent): Boolean =
         event.key == Key.MediaAudioTrack ||
         event.key == Key.MediaStop
 
+fun isChannelKey(event: KeyEvent): Boolean = event.key == Key.ChannelUp || event.key == Key.ChannelDown
+
 fun isBackwardButton(event: KeyEvent): Boolean =
     event.key == Key.PageUp ||
         event.key == Key.ChannelUp ||

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
@@ -34,6 +34,12 @@ class PlaybackKeyHandler(
     private val isDpadSeekVisible: () -> Boolean = { false },
     private val onDpadSeek: (Long) -> Unit = { },
     private val dpadSeekMode: DpadSeekMode,
+    /**
+     * Whether channel up/down (and next/previous) should change live TV channels
+     */
+    private val channelKeysEnabled: () -> Boolean = { false },
+    private val onChannelUp: () -> Unit = { },
+    private val onChannelDown: () -> Unit = { },
 ) {
     private var leftHandledByRepeat = false
     private var rightHandledByRepeat = false
@@ -81,6 +87,12 @@ class PlaybackKeyHandler(
             } else {
                 // When controller is visible, its buttons will handle pulsing
             }
+        } else if (isChannelKey(it) && channelKeysEnabled.invoke()) {
+            if (it.key == Key.ChannelUp) {
+                onChannelUp.invoke()
+            } else {
+                onChannelDown.invoke()
+            }
         } else if (isMedia(it)) {
             when (it.key) {
                 Key.MediaPlay, Key.MediaPause, Key.MediaPlayPause -> {
@@ -98,11 +110,19 @@ class PlaybackKeyHandler(
                 }
 
                 Key.MediaNext -> {
-                    if (player.isCommandAvailable(Player.COMMAND_SEEK_TO_NEXT)) player.seekToNext()
+                    if (channelKeysEnabled.invoke()) {
+                        onChannelUp.invoke()
+                    } else if (player.isCommandAvailable(Player.COMMAND_SEEK_TO_NEXT)) {
+                        player.seekToNext()
+                    }
                 }
 
                 Key.MediaPrevious -> {
-                    if (player.isCommandAvailable(Player.COMMAND_SEEK_TO_PREVIOUS)) player.seekToPrevious()
+                    if (channelKeysEnabled.invoke()) {
+                        onChannelDown.invoke()
+                    } else if (player.isCommandAvailable(Player.COMMAND_SEEK_TO_PREVIOUS)) {
+                        player.seekToPrevious()
+                    }
                 }
 
                 Key.Captions -> {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackKeyHandler.kt
@@ -34,6 +34,11 @@ class PlaybackKeyHandler(
     private val isDpadSeekVisible: () -> Boolean = { false },
     private val onDpadSeek: (Long) -> Unit = { },
     private val dpadSeekMode: DpadSeekMode,
+    /**
+     * Whether channel up/down (and next/previous) should change live TV channels
+     */
+    private val channelKeysEnabled: () -> Boolean = { false },
+    private val onChangeChannel: (delta: Int) -> Unit = { },
 ) {
     private var leftHandledByRepeat = false
     private var rightHandledByRepeat = false
@@ -81,6 +86,8 @@ class PlaybackKeyHandler(
             } else {
                 // When controller is visible, its buttons will handle pulsing
             }
+        } else if (isChannelKey(it) && channelKeysEnabled.invoke()) {
+            onChangeChannel.invoke(if (it.key == Key.ChannelUp) 1 else -1)
         } else if (isMedia(it)) {
             when (it.key) {
                 Key.MediaPlay, Key.MediaPause, Key.MediaPlayPause -> {
@@ -98,11 +105,19 @@ class PlaybackKeyHandler(
                 }
 
                 Key.MediaNext -> {
-                    if (player.isCommandAvailable(Player.COMMAND_SEEK_TO_NEXT)) player.seekToNext()
+                    if (channelKeysEnabled.invoke()) {
+                        onChangeChannel.invoke(1)
+                    } else if (player.isCommandAvailable(Player.COMMAND_SEEK_TO_NEXT)) {
+                        player.seekToNext()
+                    }
                 }
 
                 Key.MediaPrevious -> {
-                    if (player.isCommandAvailable(Player.COMMAND_SEEK_TO_PREVIOUS)) player.seekToPrevious()
+                    if (channelKeysEnabled.invoke()) {
+                        onChangeChannel.invoke(-1)
+                    } else if (player.isCommandAvailable(Player.COMMAND_SEEK_TO_PREVIOUS)) {
+                        player.seekToPrevious()
+                    }
                 }
 
                 Key.Captions -> {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -269,6 +269,10 @@ fun PlaybackPageContent(
                 },
                 onDpadSeek = onDpadSeek,
                 dpadSeekMode = prefs.dpadSeekMode,
+                // Read the flow directly so this isn't stale when the handler is remembered
+                channelKeysEnabled = { viewModel.state.value.isLiveTv },
+                onChannelUp = { viewModel.changeChannel(1) },
+                onChannelDown = { viewModel.changeChannel(-1) },
             )
         }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackPage.kt
@@ -270,6 +270,9 @@ fun PlaybackPageContent(
                 },
                 onDpadSeek = onDpadSeek,
                 dpadSeekMode = prefs.dpadSeekMode,
+                // Read the flow directly so this isn't stale when the handler is remembered
+                channelKeysEnabled = { viewModel.state.value.isLiveTv },
+                onChangeChannel = viewModel::changeChannel,
             )
         }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackState.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackState.kt
@@ -24,6 +24,7 @@ data class PlaybackState(
     val nextUp: BaseItem? = null,
     val playlistIndex: Int = 0,
     val playlist: Playlist = Playlist(emptyList()),
+    val isLiveTv: Boolean = false,
 ) {
     val hasNext: Boolean get() = (playlistIndex + 1) < playlist.items.size
     val hasPrevious: Boolean get() = playlistIndex > 0

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -95,6 +95,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.liveTvApi
 import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
 import org.jellyfin.sdk.api.client.extensions.mediaSegmentsApi
 import org.jellyfin.sdk.api.client.extensions.sessionApi
@@ -105,6 +106,7 @@ import org.jellyfin.sdk.api.sockets.subscribe
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ImageType
+import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.MediaSegmentType
 import org.jellyfin.sdk.model.api.MediaStreamType
 import org.jellyfin.sdk.model.api.MediaType
@@ -112,9 +114,11 @@ import org.jellyfin.sdk.model.api.PlayMethod
 import org.jellyfin.sdk.model.api.PlaybackInfoDto
 import org.jellyfin.sdk.model.api.PlaystateCommand
 import org.jellyfin.sdk.model.api.PlaystateMessage
+import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.api.TrickplayInfo
 import org.jellyfin.sdk.model.api.VideoRange
 import org.jellyfin.sdk.model.api.VideoRangeType
+import org.jellyfin.sdk.model.api.request.GetLiveTvChannelsRequest
 import org.jellyfin.sdk.model.extensions.inWholeTicks
 import org.jellyfin.sdk.model.extensions.ticks
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
@@ -391,7 +395,10 @@ class PlaybackViewModel
                 playNextUp()
             }
 
-            if (!isPlaylist) {
+            if (queriedItem.type == BaseItemKind.TV_CHANNEL) {
+                // For live TV, the "playlist" is the channel list so that channel up/down can surf it
+                loadChannelPlaylist(queriedItem.id)
+            } else if (!isPlaylist) {
                 val result = playlistCreator.createFrom(queriedItem)
                 if (result is PlaylistCreationResult.Success && result.playlist.items.isNotEmpty()) {
                     _state.update {
@@ -399,6 +406,83 @@ class PlaybackViewModel
                             playlist = Playlist(it.playlist.items + result.playlist.items),
                         )
                     }
+                }
+            }
+        }
+
+        /**
+         * Load the live TV channel list into the playlist so that channel up/down can move through it.
+         *
+         * Uses the same sorting as the TV guide so surfing order matches what the user sees there.
+         */
+        private suspend fun loadChannelPlaylist(currentChannelId: UUID) {
+            try {
+                val liveTvPrefs =
+                    preferences.appPreferences.interfacePreferences.liveTvPreferences
+                val sortByRecent = liveTvPrefs.sortByRecentlyWatched
+                val channels =
+                    api.liveTvApi
+                        .getLiveTvChannels(
+                            GetLiveTvChannelsRequest(
+                                startIndex = 0,
+                                userId = serverRepository.currentUser?.id,
+                                enableFavoriteSorting = liveTvPrefs.favoriteChannelsAtBeginning,
+                                sortBy = if (sortByRecent) listOf(ItemSortBy.DATE_PLAYED) else null,
+                                sortOrder = if (sortByRecent) SortOrder.DESCENDING else null,
+                                addCurrentProgram = false,
+                            ),
+                        ).content.items
+                        .map { PlaylistItem.Media(BaseItem(it, false)) }
+                if (channels.isEmpty()) {
+                    Timber.w("No live TV channels returned, channel surfing disabled")
+                    return
+                }
+                val index = channels.indexOfFirst { it.id == currentChannelId }.coerceAtLeast(0)
+                Timber.d("Loaded %d channels, current index %d", channels.size, index)
+                _state.update {
+                    it.copy(playlist = Playlist(channels), playlistIndex = index)
+                }
+            } catch (ex: Exception) {
+                Timber.e(ex, "Failed to load channel list, channel surfing disabled")
+            }
+        }
+
+        /**
+         * Move [delta] channels through the live TV channel list, wrapping around at either end.
+         *
+         * @param attempt guards against looping forever if no channel is playable
+         */
+        fun changeChannel(
+            delta: Int,
+            attempt: Int = 0,
+        ) {
+            if (delta == 0) return
+            viewModelScope.launchDefault {
+                playlistMutex.withLock {
+                    val state = state.value
+                    val items = state.playlist.items
+                    if (!state.isLiveTv || items.size < 2) {
+                        Timber.v("Not live TV or nothing to surf, ignoring channel change")
+                        return@withLock
+                    }
+                    if (attempt >= items.size) {
+                        Timber.w("No playable channel found after %d attempts", attempt)
+                        return@withLock
+                    }
+                    val size = items.size
+                    val newIndex = ((state.playlistIndex + delta) % size + size) % size
+                    val item = items[newIndex]
+                    Timber.i("Changing channel to index %d: %s", newIndex, item.id)
+                    _state.update { it.copy(playlistIndex = newIndex, nextUp = null) }
+                    playlistJob?.cancel()
+                    playlistJob =
+                        viewModelScope.launchDefault {
+                            val played = play(item, 0)
+                            if (!played) {
+                                // Skip over a channel that failed to start
+                                changeChannel(delta, attempt + 1)
+                            }
+                        }
                 }
             }
         }
@@ -452,6 +536,7 @@ class PlaybackViewModel
                 this@PlaybackViewModel.itemId = item.id
 
                 val isLiveTv = item.type == BaseItemKind.TV_CHANNEL
+                _state.update { it.copy(isLiveTv = isLiveTv) }
                 val base = item.data
 
                 // Use the provided playback parameters or else check if the database has some
@@ -1044,6 +1129,13 @@ class PlaybackViewModel
             }
 
         override fun onPlaybackStateChanged(playbackState: Int) {
+            if (playbackState == Player.STATE_ENDED && state.value.isLiveTv) {
+                // The channel list is the playlist during live TV, so don't treat a dead
+                // stream as "next up" and zap the user to another channel
+                Timber.d("Live TV stream ended")
+                navigationManager.goBack()
+                return
+            }
             if (playbackState == Player.STATE_ENDED) {
                 Timber.v("Playback state is STATE_ENDED")
                 viewModelScope.launchDefault {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -26,6 +26,7 @@ import androidx.media3.session.MediaSession
 import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.size.Size
+import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.ItemPlaybackDao
 import com.github.damontecres.wholphin.data.ItemPlaybackRepository
 import com.github.damontecres.wholphin.data.ServerRepository
@@ -44,6 +45,7 @@ import com.github.damontecres.wholphin.preferences.enabled
 import com.github.damontecres.wholphin.services.DatePlayedService
 import com.github.damontecres.wholphin.services.DeviceProfileService
 import com.github.damontecres.wholphin.services.ImageUrlService
+import com.github.damontecres.wholphin.services.LiveTvChannelService
 import com.github.damontecres.wholphin.services.MusicService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.PlayerFactory
@@ -96,6 +98,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.liveTvApi
 import org.jellyfin.sdk.api.client.extensions.mediaInfoApi
 import org.jellyfin.sdk.api.client.extensions.mediaSegmentsApi
 import org.jellyfin.sdk.api.client.extensions.sessionApi
@@ -106,6 +109,7 @@ import org.jellyfin.sdk.api.sockets.subscribe
 import org.jellyfin.sdk.model.DeviceInfo
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.ImageType
+import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.MediaSegmentType
 import org.jellyfin.sdk.model.api.MediaStreamType
 import org.jellyfin.sdk.model.api.MediaType
@@ -113,9 +117,11 @@ import org.jellyfin.sdk.model.api.PlayMethod
 import org.jellyfin.sdk.model.api.PlaybackInfoDto
 import org.jellyfin.sdk.model.api.PlaystateCommand
 import org.jellyfin.sdk.model.api.PlaystateMessage
+import org.jellyfin.sdk.model.api.SortOrder
 import org.jellyfin.sdk.model.api.TrickplayInfo
 import org.jellyfin.sdk.model.api.VideoRange
 import org.jellyfin.sdk.model.api.VideoRangeType
+import org.jellyfin.sdk.model.api.request.GetLiveTvChannelsRequest
 import org.jellyfin.sdk.model.extensions.inWholeTicks
 import org.jellyfin.sdk.model.extensions.ticks
 import org.jellyfin.sdk.model.serializer.toUUIDOrNull
@@ -152,6 +158,7 @@ class PlaybackViewModel
         private val imageUrlService: ImageUrlService,
         private val screensaverService: ScreensaverService,
         private val musicService: MusicService,
+        private val liveTvChannelService: LiveTvChannelService,
         @Assisted private val destination: Destination,
     ) : ViewModel(),
         Player.Listener,
@@ -403,7 +410,10 @@ class PlaybackViewModel
                 playNextUp()
             }
 
-            if (!isPlaylist) {
+            if (queriedItem.type == BaseItemKind.TV_CHANNEL) {
+                // For live TV, the "playlist" is the channel list so that channel up/down can surf it
+                loadChannelPlaylist(queriedItem.id)
+            } else if (!isPlaylist) {
                 val result = playlistCreator.createFrom(queriedItem)
                 if (result is PlaylistCreationResult.Success && result.playlist.items.isNotEmpty()) {
                     _state.update {
@@ -411,6 +421,63 @@ class PlaybackViewModel
                             playlist = Playlist(it.playlist.items + result.playlist.items),
                         )
                     }
+                }
+            }
+        }
+
+        /**
+         * Load the live TV channel list into the playlist so that channel up/down can move through it.
+         *
+         * Uses the same sorting as the TV guide so surfing order matches what the user sees there.
+         */
+        private suspend fun loadChannelPlaylist(currentChannelId: UUID) {
+            try {
+                val liveTvPrefs =
+                    preferences.appPreferences.interfacePreferences.liveTvPreferences
+                val sortByRecent = liveTvPrefs.sortByRecentlyWatched
+                val channels =
+                    liveTvChannelService
+                        .getChannels(
+                            sortByRecentlyWatched = sortByRecent,
+                            favoriteChannelsAtBeginning = liveTvPrefs.favoriteChannelsAtBeginning,
+                        ).map { PlaylistItem.Media(BaseItem(it, false)) }
+                if (channels.isEmpty()) {
+                    Timber.w("No live TV channels returned, channel surfing disabled")
+                    return
+                }
+                val index = channels.indexOfFirst { it.id == currentChannelId }.coerceAtLeast(0)
+                Timber.d("Loaded %d channels, current index %d", channels.size, index)
+                _state.update {
+                    it.copy(playlist = Playlist(channels), playlistIndex = index)
+                }
+            } catch (ex: Exception) {
+                Timber.e(ex, "Failed to load channel list, channel surfing disabled")
+            }
+        }
+
+        /**
+         * Move [delta] channels through the live TV channel list, stopping at either end.
+         */
+        fun changeChannel(delta: Int) {
+            if (delta == 0) return
+            viewModelScope.launchDefault {
+                playlistMutex.withLock {
+                    val state = state.value
+                    val items = state.playlist.items
+                    if (!state.isLiveTv || items.size < 2) {
+                        Timber.v("Not live TV or nothing to surf, ignoring channel change")
+                        return@withLock
+                    }
+                    val newIndex = state.playlistIndex + delta
+                    if (newIndex !in items.indices) {
+                        Timber.v("Already at the %s of the channel list", if (delta > 0) "end" else "start")
+                        return@withLock
+                    }
+                    val item = items[newIndex]
+                    Timber.i("Changing channel to index %d: %s", newIndex, item.id)
+                    _state.update { it.copy(playlistIndex = newIndex, nextUp = null) }
+                    playlistJob?.cancel()
+                    playlistJob = viewModelScope.launchDefault { play(item, 0) }
                 }
             }
         }
@@ -464,6 +531,7 @@ class PlaybackViewModel
                 this@PlaybackViewModel.itemId = item.id
 
                 val isLiveTv = item.type == BaseItemKind.TV_CHANNEL
+                _state.update { it.copy(isLiveTv = isLiveTv) }
                 val base = item.data
 
                 // Use the provided playback parameters or else check if the database has some
@@ -1063,6 +1131,16 @@ class PlaybackViewModel
             }
 
         override fun onPlaybackStateChanged(playbackState: Int) {
+            if (playbackState == Player.STATE_ENDED && state.value.isLiveTv) {
+                // The channel list is the playlist during live TV, so don't treat a dead
+                // stream as "next up" and zap the user to another channel
+                Timber.d("Live TV stream ended")
+                viewModelScope.launchDefault {
+                    showToast(context, context.getString(R.string.live_tv_stream_ended), Toast.LENGTH_SHORT)
+                }
+                navigationManager.goBack()
+                return
+            }
             if (playbackState == Player.STATE_ENDED) {
                 Timber.v("Playback state is STATE_ENDED")
                 viewModelScope.launchDefault {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -922,4 +922,5 @@
     <string name="dim_screen">Dim screen</string>
     <string name="photo_albums">Photo albums</string>
     <string name="no_favorites_found">No favorites found!</string>
+    <string name="live_tv_stream_ended">Live TV stream ended</string>
 </resources>


### PR DESCRIPTION
<!-- By submitting this pull request, you acknowledge that you have read the [contributing guide](https://github.com/damontecres/Wholphin/blob/main/CONTRIBUTING.md, including the AI/LLM policy, and [developer's guide](https://github.com/damontecres/Wholphin/blob/main/DEVELOPMENT.md) -->

## Description
Detects Channel Up/Down buttons, plus Media Next/Previous.
Only reuses those buttons while live TV is playing but normal videos keep their existing behavior.
Downloads the Jellyfin channel list in roughly the same order as the TV guide, then wraps from the last channel back to the first.
If a channel cannot start, it tries the next one; if a live stream ends naturally, it exits playback instead of automatically “surfing.”

### Related issues
Fixes #509 

### Testing
Compiled in GitBash then stream installed to "onn. 4K streaming box" 
Android TV OS version: 14 
Security patch level: March 1st, 2026
Kernel: 5.15.196-android14-11-g94532862e2fa
Android TV OS build: UR04.260304.011.b1.15051976

## Screenshots
Not Applicable

## AI or LLM usage
Patch was built using Claude Fable 5. Double checked with ChatGPT 5.6 Sol. Installed and tested working as designed on personal streaming box. 