### PR TITLE
Update wholphin-extensions & media3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -178,7 +178,7 @@ configure<ApplicationExtension> {
             isEnable = !isBuildingBundle.get()
 
             reset()
-            include("armeabi-v7a", "arm64-v8a")
+            include("armeabi-v7a", "arm64-v8a", "x86_64")
             isUniversalApk = true
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ tvFoundation = "1.0.0"
 tvMaterial = "1.1.0-alpha01"
 lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
-androidx-media3 = "1.10.1"
+androidx-media3 = "1.11.0"
 coil = "3.5.0"
 jellyfin-sdk = "1.7.1"
 nav3Core = "1.1.3"
@@ -40,12 +40,12 @@ preferenceKtx = "1.2.1"
 tvprovider = "1.1.0"
 workRuntimeKtx = "2.11.2"
 paletteKtx = "1.0.0"
-assMedia = "0.5.0"
+libass-android = "0.5.1"
 kotlinxCoroutinesTest = "1.11.0"
 coreTesting = "2.2.0"
 openapi-generator = "7.23.0"
 runner = "1.7.0"
-wholphin-extensions = "0.2.1"
+wholphin-extensions = "0.2.2"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
@@ -141,7 +141,7 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 androidx-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "coreTesting" }
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }
 
-ass-media = { group = "io.github.peerless2012", name = "ass-media", version.ref = "assMedia" }
+ass-media = { group = "io.github.peerless2012", name = "ass-media", version.ref = "libass-android" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
Updates playback dependencies:
- `wholphin-extensions` to `v0.2.2`
- `media3` to `1.11.0`
- `libass-android` to `0.5.1`