### PR TITLE
Fix playlist & collection random sorting on home page

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
@@ -859,18 +859,28 @@ class HomeSettingsService
                             sortBy =
                                 row.sort?.let {
                                     buildList {
-                                        add(it.sort)
-                                        if (it.sort != ItemSortBy.SORT_NAME) {
+                                        if (it.sort == ItemSortBy.RANDOM) {
                                             add(ItemSortBy.SORT_NAME)
+                                            add(ItemSortBy.RANDOM)
+                                        } else {
+                                            add(it.sort)
+                                            if (it.sort != ItemSortBy.SORT_NAME) {
+                                                add(ItemSortBy.SORT_NAME)
+                                            }
                                         }
                                     }
                                 },
                             sortOrder =
                                 row.sort?.let {
                                     buildList {
-                                        add(it.direction)
-                                        if (it.sort != ItemSortBy.SORT_NAME) {
+                                        if (it.sort == ItemSortBy.RANDOM) {
                                             add(SortOrder.ASCENDING)
+                                            add(it.direction)
+                                        } else {
+                                            add(it.direction)
+                                            if (it.sort != ItemSortBy.SORT_NAME) {
+                                                add(SortOrder.ASCENDING)
+                                            }
                                         }
                                     }
                                 },


### PR DESCRIPTION
## Description
Ensure that a playlist or collection's items are random sorted on the home page, if applicable.

Previously, the request did sort by random then by sort name resulting in only sorting by sort name.

However, there are still issues with random sorting in general, see #1819 

### Related issues
Technically fixes #1806
Further bugs in #1819

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None