### PR TITLE
Use squared cards for Music rows in Home screen

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
@@ -11,15 +11,21 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.CollectionType
 import org.jellyfin.sdk.model.api.request.GetItemsRequest
 import org.jellyfin.sdk.model.serializer.UUIDSerializer
 import java.util.UUID
 
 @Serializable
 sealed interface HomeRowConfig {
-    val viewOptions: HomeRowViewOptions
+    /**
+     * The view options the user explicitly chose, or null to follow the default
+     *
+     * Null is the normal state: a row nobody has sized deserializes to it.
+     */
+    val viewOptions: HomeRowViewOptions?
 
-    fun updateViewOptions(viewOptions: HomeRowViewOptions): HomeRowConfig
+    fun updateViewOptions(viewOptions: HomeRowViewOptions?): HomeRowConfig
 
     /**
      * Continue watching media that the user has started but not finished
@@ -27,9 +33,9 @@ sealed interface HomeRowConfig {
     @Serializable
     @SerialName("ContinueWatching")
     data class ContinueWatching(
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): ContinueWatching = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): ContinueWatching = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -38,9 +44,9 @@ sealed interface HomeRowConfig {
     @Serializable
     @SerialName("NextUp")
     data class NextUp(
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): NextUp = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): NextUp = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -49,9 +55,9 @@ sealed interface HomeRowConfig {
     @Serializable
     @SerialName("ContinueWatchingCombined")
     data class ContinueWatchingCombined(
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): ContinueWatchingCombined = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): ContinueWatchingCombined = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -61,9 +67,9 @@ sealed interface HomeRowConfig {
     @SerialName("RecentlyAdded")
     data class RecentlyAdded(
         val parentId: UUID,
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): RecentlyAdded = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): RecentlyAdded = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -73,9 +79,9 @@ sealed interface HomeRowConfig {
     @SerialName("RecentlyReleased")
     data class RecentlyReleased(
         val parentId: UUID,
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): RecentlyReleased = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): RecentlyReleased = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -85,9 +91,9 @@ sealed interface HomeRowConfig {
     @SerialName("Genres")
     data class Genres(
         val parentId: UUID,
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions.genreDefault,
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): Genres = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): Genres = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -97,9 +103,9 @@ sealed interface HomeRowConfig {
     @SerialName("Studios")
     data class Studios(
         val parentId: UUID,
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions.genreDefault,
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): Studios = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): Studios = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -109,17 +115,9 @@ sealed interface HomeRowConfig {
     @SerialName("Favorite")
     data class Favorite(
         val kind: BaseItemKind,
-        override val viewOptions: HomeRowViewOptions =
-            if (kind == BaseItemKind.EPISODE) {
-                HomeRowViewOptions(
-                    heightDp = Cards.HEIGHT_EPISODE,
-                    aspectRatio = AspectRatio.WIDE,
-                )
-            } else {
-                HomeRowViewOptions()
-            },
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): Favorite = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): Favorite = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -128,9 +126,9 @@ sealed interface HomeRowConfig {
     @Serializable
     @SerialName("Recordings")
     data class Recordings(
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): Recordings = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): Recordings = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -139,9 +137,9 @@ sealed interface HomeRowConfig {
     @Serializable
     @SerialName("TvPrograms")
     data class TvPrograms(
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions.liveTvDefault,
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): TvPrograms = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): TvPrograms = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -150,9 +148,9 @@ sealed interface HomeRowConfig {
     @Serializable
     @SerialName("TvChannels")
     data class TvChannels(
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions.liveTvDefault,
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): TvChannels = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): TvChannels = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -162,9 +160,9 @@ sealed interface HomeRowConfig {
     @SerialName("Suggestions")
     data class Suggestions(
         val parentId: UUID,
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): Suggestions = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): Suggestions = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -176,9 +174,9 @@ sealed interface HomeRowConfig {
         val parentId: UUID,
         val recursive: Boolean = false,
         val sort: SortAndDirection? = null,
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): ByParent = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): ByParent = this.copy(viewOptions = viewOptions)
     }
 
     /**
@@ -189,9 +187,9 @@ sealed interface HomeRowConfig {
     data class GetItems(
         val name: String,
         val getItems: GetItemsRequest,
-        override val viewOptions: HomeRowViewOptions = HomeRowViewOptions(),
+        override val viewOptions: HomeRowViewOptions? = null,
     ) : HomeRowConfig {
-        override fun updateViewOptions(viewOptions: HomeRowViewOptions): GetItems = this.copy(viewOptions = viewOptions)
+        override fun updateViewOptions(viewOptions: HomeRowViewOptions?): GetItems = this.copy(viewOptions = viewOptions)
     }
 }
 
@@ -247,6 +245,39 @@ data class HomeRowViewOptions(
                 aspectRatio = AspectRatio.WIDE,
                 contentScale = PrefContentScale.FIT,
             )
+
+        val musicDefault =
+            HomeRowViewOptions(
+                heightDp = Cards.HEIGHT_EPISODE,
+                aspectRatio = AspectRatio.SQUARE,
+            )
+
+        val episodeDefault =
+            HomeRowViewOptions(
+                heightDp = Cards.HEIGHT_EPISODE,
+                aspectRatio = AspectRatio.WIDE,
+            )
+
+        fun forCollectionType(collectionType: CollectionType?): HomeRowViewOptions =
+            when (collectionType) {
+                CollectionType.MUSIC -> {
+                    musicDefault
+                }
+
+                CollectionType.HOMEVIDEOS,
+                CollectionType.MUSICVIDEOS,
+                -> {
+                    HomeRowViewOptions(aspectRatio = AspectRatio.WIDE)
+                }
+
+                CollectionType.LIVETV -> {
+                    liveTvDefault
+                }
+
+                else -> {
+                    HomeRowViewOptions()
+                }
+            }
     }
 }
 
@@ -278,3 +309,51 @@ val HomeRowConfig.parentItemId: UUID?
             is HomeRowConfig.TvPrograms,
             -> null
         }
+
+/**
+ * [collectionType] is that of the row's [parentItemId], and is ignored by rows whose shape does
+ * not depend on what they are pointed at. Listed exhaustively so that a new [HomeRowConfig] has
+ * to say which it is.
+ */
+fun HomeRowConfig.defaultViewOptions(collectionType: CollectionType?): HomeRowViewOptions =
+    when (this) {
+        is HomeRowConfig.ByParent,
+        is HomeRowConfig.RecentlyAdded,
+        is HomeRowConfig.RecentlyReleased,
+        is HomeRowConfig.Suggestions,
+        -> {
+            HomeRowViewOptions.forCollectionType(collectionType)
+        }
+
+        is HomeRowConfig.Genres,
+        is HomeRowConfig.Studios,
+        -> {
+            HomeRowViewOptions.genreDefault
+        }
+
+        is HomeRowConfig.TvChannels,
+        is HomeRowConfig.TvPrograms,
+        -> {
+            HomeRowViewOptions.liveTvDefault
+        }
+
+        is HomeRowConfig.Favorite -> {
+            if (kind == BaseItemKind.EPISODE) {
+                HomeRowViewOptions.episodeDefault
+            } else {
+                HomeRowViewOptions()
+            }
+        }
+
+        is HomeRowConfig.ContinueWatching,
+        is HomeRowConfig.ContinueWatchingCombined,
+        is HomeRowConfig.GetItems,
+        is HomeRowConfig.NextUp,
+        is HomeRowConfig.Recordings,
+        -> {
+            HomeRowViewOptions()
+        }
+    }
+
+fun HomeRowConfig.resolveViewOptions(collectionType: CollectionType?): HomeRowViewOptions =
+    viewOptions ?: defaultViewOptions(collectionType)

--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
@@ -249,3 +249,32 @@ data class HomeRowViewOptions(
             )
     }
 }
+
+/**
+ * Listed exhaustively so that a new [HomeRowConfig] has to say whether it is scoped to an item
+ */
+val HomeRowConfig.parentItemId: UUID?
+    get() =
+        when (this) {
+            is HomeRowConfig.ByParent -> parentId
+
+            is HomeRowConfig.Genres -> parentId
+
+            is HomeRowConfig.RecentlyAdded -> parentId
+
+            is HomeRowConfig.RecentlyReleased -> parentId
+
+            is HomeRowConfig.Studios -> parentId
+
+            is HomeRowConfig.Suggestions -> parentId
+
+            is HomeRowConfig.ContinueWatching,
+            is HomeRowConfig.ContinueWatchingCombined,
+            is HomeRowConfig.Favorite,
+            is HomeRowConfig.GetItems,
+            is HomeRowConfig.NextUp,
+            is HomeRowConfig.Recordings,
+            is HomeRowConfig.TvChannels,
+            is HomeRowConfig.TvPrograms,
+            -> null
+        }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
@@ -10,6 +10,7 @@ import com.github.damontecres.wholphin.data.model.HomeRowConfig
 import com.github.damontecres.wholphin.data.model.SUPPORTED_HOME_PAGE_SETTINGS_VERSION
 import com.github.damontecres.wholphin.data.model.createGenreDestination
 import com.github.damontecres.wholphin.data.model.createStudioDestination
+import com.github.damontecres.wholphin.data.model.parentItemId
 import com.github.damontecres.wholphin.preferences.DefaultUserConfiguration
 import com.github.damontecres.wholphin.preferences.HomePagePreferences
 import com.github.damontecres.wholphin.ui.HomeItemFields
@@ -57,6 +58,7 @@ import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.api.client.extensions.userViewsApi
 import org.jellyfin.sdk.model.DateTime
 import org.jellyfin.sdk.model.UUID
+import org.jellyfin.sdk.model.api.BaseItemDto
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.CollectionType
 import org.jellyfin.sdk.model.api.GetProgramsDto
@@ -428,146 +430,104 @@ class HomeSettingsService
         suspend fun resolve(
             id: Int,
             config: HomeRowConfig,
-        ): HomeRowConfigDisplay =
-            when (config) {
-                is HomeRowConfig.ByParent -> {
-                    val name = getItemName(null, config.parentId)
-                    HomeRowConfigDisplay(
-                        id,
-                        name,
-                        config,
-                    )
-                }
+        ): HomeRowConfigDisplay {
+            val parentItem = config.parentItemId?.let { getItem(it) }
+            val title =
+                when (config) {
+                    is HomeRowConfig.ByParent -> {
+                        nameOf(parentItem, null)
+                    }
 
-                is HomeRowConfig.ContinueWatching -> {
-                    HomeRowConfigDisplay(
-                        id,
-                        ResStringProvider(R.string.continue_watching),
-                        config,
-                    )
-                }
+                    is HomeRowConfig.ContinueWatching -> {
+                        ResStringProvider(R.string.continue_watching)
+                    }
 
-                is HomeRowConfig.ContinueWatchingCombined -> {
-                    HomeRowConfigDisplay(
-                        id,
-                        ResStringProvider(R.string.combine_continue_next),
-                        config,
-                    )
-                }
+                    is HomeRowConfig.ContinueWatchingCombined -> {
+                        ResStringProvider(R.string.combine_continue_next)
+                    }
 
-                is HomeRowConfig.Genres -> {
-                    val title = getItemName(R.string.genres_in, config.parentId)
-                    HomeRowConfigDisplay(
-                        id,
-                        title,
-                        config,
-                    )
-                }
+                    is HomeRowConfig.Genres -> {
+                        nameOf(parentItem, R.string.genres_in)
+                    }
 
-                is HomeRowConfig.Studios -> {
-                    val title = getItemName(R.string.studios_in, config.parentId)
-                    HomeRowConfigDisplay(
-                        id,
-                        title,
-                        config,
-                    )
-                }
+                    is HomeRowConfig.Studios -> {
+                        nameOf(parentItem, R.string.studios_in)
+                    }
 
-                is HomeRowConfig.GetItems -> {
-                    HomeRowConfigDisplay(id, StringStringProvider(config.name), config)
-                }
+                    is HomeRowConfig.GetItems -> {
+                        StringStringProvider(config.name)
+                    }
 
-                is HomeRowConfig.NextUp -> {
-                    HomeRowConfigDisplay(
-                        id,
-                        ResStringProvider(R.string.next_up),
-                        config,
-                    )
-                }
+                    is HomeRowConfig.NextUp -> {
+                        ResStringProvider(R.string.next_up)
+                    }
 
-                is HomeRowConfig.RecentlyAdded -> {
-                    val title = getItemName(R.string.recently_added_in, config.parentId)
-                    HomeRowConfigDisplay(
-                        id,
-                        title,
-                        config,
-                    )
-                }
+                    is HomeRowConfig.RecentlyAdded -> {
+                        nameOf(parentItem, R.string.recently_added_in)
+                    }
 
-                is HomeRowConfig.RecentlyReleased -> {
-                    val title = getItemName(R.string.recently_released_in, config.parentId)
-                    HomeRowConfigDisplay(
-                        id,
-                        title,
-                        config,
-                    )
-                }
+                    is HomeRowConfig.RecentlyReleased -> {
+                        nameOf(parentItem, R.string.recently_released_in)
+                    }
 
-                is HomeRowConfig.Favorite -> {
-                    val name =
+                    is HomeRowConfig.Favorite -> {
                         ResProviderStringProvider(
                             R.string.favorite_items_title,
                             ResStringProvider(favoriteOptions[config.kind]!!),
                         )
-                    HomeRowConfigDisplay(id, name, config)
-                }
+                    }
 
-                is HomeRowConfig.Recordings -> {
-                    HomeRowConfigDisplay(
-                        id = id,
-                        title = ResStringProvider(R.string.active_recordings),
-                        config,
-                    )
-                }
+                    is HomeRowConfig.Recordings -> {
+                        ResStringProvider(R.string.active_recordings)
+                    }
 
-                is HomeRowConfig.TvPrograms -> {
-                    HomeRowConfigDisplay(
-                        id = id,
-                        title = ResStringProvider(R.string.watch_live),
-                        config,
-                    )
-                }
+                    is HomeRowConfig.TvPrograms -> {
+                        ResStringProvider(R.string.watch_live)
+                    }
 
-                is HomeRowConfig.TvChannels -> {
-                    HomeRowConfigDisplay(
-                        id = id,
-                        title = ResStringProvider(R.string.channels),
-                        config,
-                    )
-                }
+                    is HomeRowConfig.TvChannels -> {
+                        ResStringProvider(R.string.channels)
+                    }
 
-                is HomeRowConfig.Suggestions -> {
-                    val title = getItemName(R.string.suggestions_for, config.parentId)
-                    HomeRowConfigDisplay(
-                        id = id,
-                        title = title,
-                        config,
-                    )
+                    is HomeRowConfig.Suggestions -> {
+                        nameOf(parentItem, R.string.suggestions_for)
+                    }
                 }
-            }
+            return HomeRowConfigDisplay(
+                id = id,
+                title = title,
+                config = config,
+            )
+        }
 
-        private suspend fun getItemName(
-            @StringRes stringRes: Int?,
-            itemId: UUID,
-            default: StringProvider = StringStringProvider(""),
-        ): StringProvider =
+        private suspend fun getItem(itemId: UUID): BaseItemDto? =
             try {
                 api.userLibraryApi
                     .getItem(
                         userId = serverRepository.currentUser?.id,
                         itemId = itemId,
-                    ).content.name
-                    ?.let {
-                        if (stringRes == null) {
-                            StringStringProvider(it)
-                        } else {
-                            ResArgStringProvider(stringRes, it)
-                        }
-                    } ?: default
+                    ).content
             } catch (ex: Exception) {
-                Timber.e(ex, "Could not get name for %s", itemId)
-                ResStringProvider(R.string.unknown)
+                Timber.e(ex, "Could not get item %s", itemId)
+                null
             }
+
+        private fun nameOf(
+            item: BaseItemDto?,
+            @StringRes stringRes: Int?,
+            default: StringProvider = StringStringProvider(""),
+        ): StringProvider {
+            if (item == null) {
+                return ResStringProvider(R.string.unknown)
+            }
+            return item.name?.let {
+                if (stringRes == null) {
+                    StringStringProvider(it)
+                } else {
+                    ResArgStringProvider(stringRes, it)
+                }
+            } ?: default
+        }
 
         /**
          * Fetch the data from the server for a given [HomeRowConfig]
@@ -581,21 +541,22 @@ class HomeSettingsService
             limit: Int = prefs.maxItemsPerRow,
             isRefresh: Boolean,
             usePaging: Boolean = false,
-        ): HomeRowLoadingState =
-            when (row) {
+        ): HomeRowLoadingState {
+            val viewOptions = row.viewOptions
+            return when (row) {
                 is HomeRowConfig.ContinueWatching -> {
                     val resume =
                         latestNextUpService.getResume(
                             userDto.id,
                             limit,
                             true,
-                            row.viewOptions.useSeries,
+                            viewOptions.useSeries,
                         )
 
                     Success(
                         title = ResStringProvider(R.string.continue_watching),
                         items = resume,
-                        viewOptions = row.viewOptions,
+                        viewOptions = viewOptions,
                         rowType = row,
                         showViewMore = resume.size >= limit,
                     )
@@ -609,13 +570,13 @@ class HomeSettingsService
                             prefs.enableRewatchingNextUp,
                             false,
                             prefs.maxDaysNextUp,
-                            row.viewOptions.useSeries,
+                            viewOptions.useSeries,
                         )
 
                     Success(
                         title = ResStringProvider(R.string.next_up),
                         items = nextUp,
-                        viewOptions = row.viewOptions,
+                        viewOptions = viewOptions,
                         rowType = row,
                         showViewMore = nextUp.size >= limit,
                     )
@@ -627,7 +588,7 @@ class HomeSettingsService
                             userDto.id,
                             limit,
                             true,
-                            row.viewOptions.useSeries,
+                            viewOptions.useSeries,
                         )
                     val nextUp =
                         latestNextUpService.getNextUp(
@@ -636,14 +597,14 @@ class HomeSettingsService
                             prefs.enableRewatchingNextUp,
                             false,
                             prefs.maxDaysNextUp,
-                            row.viewOptions.useSeries,
+                            viewOptions.useSeries,
                         )
                     val combined = latestNextUpService.buildCombined(resume, nextUp)
 
                     Success(
                         title = ResStringProvider(R.string.continue_watching),
                         items = combined.take(limit),
-                        viewOptions = row.viewOptions,
+                        viewOptions = viewOptions,
                         rowType = row,
                         showViewMore = combined.size >= limit,
                     )
@@ -707,7 +668,7 @@ class HomeSettingsService
                     Success(
                         title,
                         genres,
-                        viewOptions = row.viewOptions,
+                        viewOptions = viewOptions,
                         rowType = row,
                         showViewMore = genres.size >= limit,
                     )
@@ -760,7 +721,7 @@ class HomeSettingsService
                     Success(
                         title,
                         studios,
-                        viewOptions = row.viewOptions,
+                        viewOptions = viewOptions,
                         showViewMore = studios.size >= limit,
                     )
                 }
@@ -781,12 +742,12 @@ class HomeSettingsService
                         api.userLibraryApi
                             .getLatestMedia(request)
                             .content
-                            .map { BaseItem(it, row.viewOptions.useSeries) }
+                            .map { BaseItem(it, viewOptions.useSeries) }
                             .let {
                                 Success(
                                     title,
                                     it,
-                                    row.viewOptions,
+                                    viewOptions,
                                     rowType = row,
                                     showViewMore = it.size >= limit,
                                 )
@@ -827,18 +788,18 @@ class HomeSettingsService
                             request,
                             GetItemsRequestHandler,
                             scope,
-                            useSeriesForPrimary = row.viewOptions.useSeries,
+                            useSeriesForPrimary = viewOptions.useSeries,
                         ).init()
                     } else {
                         GetItemsRequestHandler
                             .execute(api, request)
                             .content.items
-                            .map { BaseItem.from(it, api, row.viewOptions.useSeries) }
+                            .map { BaseItem.from(it, api, viewOptions.useSeries) }
                     }.let {
                         Success(
                             title,
                             it,
-                            row.viewOptions,
+                            viewOptions,
                             rowType = row,
                             showViewMore = it.size >= limit,
                         )
@@ -884,7 +845,7 @@ class HomeSettingsService
                             fields = library.itemFields,
                         )
 
-                    // Not using getItemName because we want to throw the 404
+                    // Not using getItem because we want to throw the 404
                     val title =
                         api.userLibraryApi
                             .getItem(
@@ -899,18 +860,18 @@ class HomeSettingsService
                             request,
                             GetItemsRequestHandler,
                             scope,
-                            useSeriesForPrimary = row.viewOptions.useSeries,
+                            useSeriesForPrimary = viewOptions.useSeries,
                         ).init()
                     } else {
                         GetItemsRequestHandler
                             .execute(api, request)
                             .content.items
-                            .map { BaseItem(it, row.viewOptions.useSeries) }
+                            .map { BaseItem(it, viewOptions.useSeries) }
                     }.let {
                         Success(
                             title,
                             it,
-                            row.viewOptions,
+                            viewOptions,
                             rowType = row,
                             showViewMore = it.size >= limit,
                         )
@@ -937,18 +898,18 @@ class HomeSettingsService
                             request,
                             GetItemsRequestHandler,
                             scope,
-                            useSeriesForPrimary = row.viewOptions.useSeries,
+                            useSeriesForPrimary = viewOptions.useSeries,
                         ).init()
                     } else {
                         GetItemsRequestHandler
                             .execute(api, request)
                             .content.items
-                            .map { BaseItem(it, row.viewOptions.useSeries) }
+                            .map { BaseItem(it, viewOptions.useSeries) }
                     }.let {
                         Success(
                             StringStringProvider(row.name),
                             it,
-                            row.viewOptions,
+                            viewOptions,
                             rowType = row,
                             showViewMore = it.size >= limit,
                         )
@@ -979,7 +940,7 @@ class HomeSettingsService
                                 Success(
                                     title,
                                     it,
-                                    row.viewOptions,
+                                    viewOptions,
                                     showViewMore = it.size >= limit,
                                 )
                             }
@@ -1005,18 +966,18 @@ class HomeSettingsService
                                 request,
                                 GetItemsRequestHandler,
                                 scope,
-                                useSeriesForPrimary = row.viewOptions.useSeries,
+                                useSeriesForPrimary = viewOptions.useSeries,
                             ).init()
                         } else {
                             GetItemsRequestHandler
                                 .execute(api, request)
                                 .content.items
-                                .map { BaseItem(it, row.viewOptions.useSeries) }
+                                .map { BaseItem(it, viewOptions.useSeries) }
                         }.let {
                             Success(
                                 title,
                                 it,
-                                row.viewOptions,
+                                viewOptions,
                                 rowType = row,
                                 showViewMore = it.size >= limit,
                             )
@@ -1041,18 +1002,18 @@ class HomeSettingsService
                             request,
                             GetRecordingsRequestHandler,
                             scope,
-                            useSeriesForPrimary = row.viewOptions.useSeries,
+                            useSeriesForPrimary = viewOptions.useSeries,
                         ).init()
                     } else {
                         api.liveTvApi
                             .getRecordings(request)
                             .content.items
-                            .map { BaseItem(it, row.viewOptions.useSeries) }
+                            .map { BaseItem(it, viewOptions.useSeries) }
                     }.let {
                         Success(
                             ResStringProvider(R.string.active_recordings),
                             it,
-                            row.viewOptions,
+                            viewOptions,
                             rowType = row,
                             showViewMore = it.size >= limit,
                         )
@@ -1078,18 +1039,18 @@ class HomeSettingsService
                             request,
                             GetProgramsDtoHandler,
                             scope,
-                            useSeriesForPrimary = row.viewOptions.useSeries,
+                            useSeriesForPrimary = viewOptions.useSeries,
                         ).init()
                     } else {
                         api.liveTvApi
                             .getPrograms(request)
                             .content.items
-                            .map { BaseItem(it, row.viewOptions.useSeries) }
+                            .map { BaseItem(it, viewOptions.useSeries) }
                     }.let {
                         Success(
                             ResStringProvider(R.string.watch_live),
                             it,
-                            row.viewOptions,
+                            viewOptions,
                             rowType = row,
                             showViewMore = it.size >= limit,
                         )
@@ -1110,17 +1071,17 @@ class HomeSettingsService
                             request,
                             GetLiveTvChannelsRequestHandler,
                             scope,
-                            useSeriesForPrimary = row.viewOptions.useSeries,
+                            useSeriesForPrimary = viewOptions.useSeries,
                         ).init()
                     } else {
                         api.liveTvApi
                             .getLiveTvChannels(request)
-                            .toBaseItems(api, row.viewOptions.useSeries)
+                            .toBaseItems(api, viewOptions.useSeries)
                     }.let {
                         Success(
                             ResStringProvider(R.string.channels),
                             it,
-                            row.viewOptions,
+                            viewOptions,
                             rowType = row,
                             showViewMore = it.size >= limit,
                         )
@@ -1144,7 +1105,7 @@ class HomeSettingsService
                                 Success(
                                     title,
                                     listOf(),
-                                    row.viewOptions,
+                                    viewOptions,
                                     rowType = row,
                                 )
                             }
@@ -1153,7 +1114,7 @@ class HomeSettingsService
                                 Success(
                                     title,
                                     suggestions.items,
-                                    row.viewOptions,
+                                    viewOptions,
                                     rowType = row,
                                     showViewMore = suggestions.items.size >= limit,
                                 )
@@ -1173,6 +1134,7 @@ class HomeSettingsService
                     }
                 }
             }
+        }
 
         companion object {
             const val CUSTOM_PREF_ID = "home_settings"

--- a/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
@@ -7,10 +7,12 @@ import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.HomePageSettings
 import com.github.damontecres.wholphin.data.model.HomeRowConfig
+import com.github.damontecres.wholphin.data.model.HomeRowViewOptions
 import com.github.damontecres.wholphin.data.model.SUPPORTED_HOME_PAGE_SETTINGS_VERSION
 import com.github.damontecres.wholphin.data.model.createGenreDestination
 import com.github.damontecres.wholphin.data.model.createStudioDestination
 import com.github.damontecres.wholphin.data.model.parentItemId
+import com.github.damontecres.wholphin.data.model.resolveViewOptions
 import com.github.damontecres.wholphin.preferences.DefaultUserConfiguration
 import com.github.damontecres.wholphin.preferences.HomePagePreferences
 import com.github.damontecres.wholphin.ui.HomeItemFields
@@ -290,10 +292,12 @@ class HomeSettingsService
                                 config = HomeRowConfig.TvPrograms(),
                             )
                         } else {
+                            val config = HomeRowConfig.RecentlyAdded(parentId)
                             HomeRowConfigDisplay(
                                 id = index,
                                 title = title,
-                                config = HomeRowConfig.RecentlyAdded(parentId),
+                                config = config,
+                                viewOptions = config.resolveViewOptions(it.collectionType),
                             )
                         }
                     }
@@ -402,6 +406,7 @@ class HomeSettingsService
                                 }
                             if (sectionType == HomeSectionType.LATEST_MEDIA) {
                                 libraries.map {
+                                    val config = HomeRowConfig.RecentlyAdded(it.id)
                                     HomeRowConfigDisplay(
                                         id = id++,
                                         title =
@@ -409,7 +414,8 @@ class HomeSettingsService
                                                 R.string.recently_added_in,
                                                 it.name ?: "",
                                             ),
-                                        config = HomeRowConfig.RecentlyAdded(it.id),
+                                        config = config,
+                                        viewOptions = config.resolveViewOptions(it.collectionType),
                                     )
                                 }
                             } else if (config != null) {
@@ -497,6 +503,7 @@ class HomeSettingsService
                 id = id,
                 title = title,
                 config = config,
+                viewOptions = config.resolveViewOptions(parentItem?.collectionType),
             )
         }
 
@@ -542,7 +549,7 @@ class HomeSettingsService
             isRefresh: Boolean,
             usePaging: Boolean = false,
         ): HomeRowLoadingState {
-            val viewOptions = row.viewOptions
+            val viewOptions = row.resolveViewOptions(libraries)
             return when (row) {
                 is HomeRowConfig.ContinueWatching -> {
                     val resume =
@@ -1148,7 +1155,28 @@ data class HomeRowConfigDisplay(
     val id: Int,
     val title: StringProvider,
     val config: HomeRowConfig,
+    /**
+     * The default resolves without a parent, which is correct only for rows that have none.
+     * Anything with a [parentItemId] has to pass the parent's collection type.
+     */
+    val viewOptions: HomeRowViewOptions = config.resolveViewOptions(null),
 )
+
+fun HomeRowConfig.resolveViewOptions(libraries: List<Library>): HomeRowViewOptions =
+    resolveViewOptions(libraries.firstOrNull { it.itemId == parentItemId }?.collectionType)
+
+/**
+ * A null [viewOptions] clears the choice rather than storing one
+ *
+ * Updates the stored choice and the resolved value together so the two cannot drift apart.
+ */
+fun HomeRowConfigDisplay.withViewOptions(
+    viewOptions: HomeRowViewOptions?,
+    libraries: List<Library>,
+): HomeRowConfigDisplay {
+    val newConfig = config.updateViewOptions(viewOptions)
+    return copy(config = newConfig, viewOptions = newConfig.resolveViewOptions(libraries))
+}
 
 /**
  * List of resolved [HomeRowConfig]s as [HomeRowConfigDisplay]s

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedMusic.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedMusic.kt
@@ -6,8 +6,6 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.model.HomeRowViewOptions
 import com.github.damontecres.wholphin.preferences.UserPreferences
-import com.github.damontecres.wholphin.ui.AspectRatio
-import com.github.damontecres.wholphin.ui.Cards
 import com.github.damontecres.wholphin.ui.SlimItemFields
 import com.github.damontecres.wholphin.ui.data.RowColumn
 import com.github.damontecres.wholphin.util.GetItemsRequestHandler
@@ -90,12 +88,7 @@ fun RecommendedMusic(
                     parentId = parentId,
                     suggestionsType = BaseItemKind.MUSIC_ALBUM,
                     recommendedRows = getRecommendedRows(parentId),
-                    viewOptions =
-                        HomeRowViewOptions(
-                            aspectRatio = AspectRatio.SQUARE,
-                            heightDp = Cards.HEIGHT_EPISODE,
-                            showTitles = true,
-                        ),
+                    viewOptions = HomeRowViewOptions.musicDefault.copy(showTitles = true),
                 )
             },
         ),

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/HomeRowGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/HomeRowGrid.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.viewModelScope
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.HomeRowConfig
+import com.github.damontecres.wholphin.data.model.resolveViewOptions
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.services.BackdropService
@@ -112,7 +113,8 @@ class HomeRowGridViewModel
                                     HomeRowLoadingState.Success(
                                         title,
                                         emptyList(),
-                                        rowConfig.viewOptions,
+                                        // Genres and studios do not take their shape from a parent
+                                        rowConfig.resolveViewOptions(null),
                                     ),
                             )
                         }
@@ -236,7 +238,6 @@ fun HomeRowGrid(
     val state by viewModel.state.collectAsState()
     val contextMenu = rememberContextMenu(preferences, viewModel)
     val gridFocusRequester = remember { FocusRequester() }
-    val viewOptions = destination.config.viewOptions
 
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -256,6 +257,8 @@ fun HomeRowGrid(
             }
 
             is HomeRowLoadingState.Success -> {
+                // Already resolved against the row's library when the data was fetched
+                val viewOptions = st.viewOptions
                 when (destination.config) {
                     is HomeRowConfig.Genres -> {
                         GenreCardGrid(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionRows.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionRows.kt
@@ -66,9 +66,7 @@ fun CollectionRows(
                                     BaseItemKind.PLAYLIST,
                                     BaseItemKind.AUDIO,
                                     -> {
-                                        HomeRowViewOptions(
-                                            heightDp = Cards.HEIGHT_EPISODE,
-                                            aspectRatio = AspectRatio.SQUARE,
+                                        HomeRowViewOptions.musicDefault.copy(
                                             showTitles = cardViewOptions.showTitles,
                                         )
                                     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowPresets.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowPresets.kt
@@ -74,10 +74,7 @@ data class HomeRowPresets(
                         aspectRatio = AspectRatio.WIDE,
                         contentScale = PrefContentScale.CROP,
                     ),
-                musicLibrary =
-                    HomeRowViewOptions(
-                        aspectRatio = AspectRatio.SQUARE,
-                    ),
+                musicLibrary = HomeRowViewOptions.musicDefault,
                 playlist =
                     HomeRowViewOptions(
                         aspectRatio = AspectRatio.SQUARE,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowSettings.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowSettings.kt
@@ -58,12 +58,11 @@ fun HomeRowSettings(
     config: HomeRowConfig,
     preferenceOptions: List<PreferenceGroup<HomeRowViewOptions>>,
     viewOptions: HomeRowViewOptions,
-    onViewOptionsChange: (HomeRowViewOptions) -> Unit,
+    onViewOptionsChange: (HomeRowViewOptions?) -> Unit,
     onConfigChange: (HomeRowConfig) -> Unit,
     onConfigAction: (HomeRowConfigAction) -> Unit,
     onApplyApplyAll: () -> Unit,
     modifier: Modifier = Modifier,
-    defaultViewOptions: HomeRowViewOptions = HomeRowViewOptions(),
 ) {
     val firstFocus = remember { FocusRequester() }
     LaunchedEffect(Unit) { firstFocus.tryRequestFocus() }
@@ -91,7 +90,9 @@ fun HomeRowSettings(
                         onClickPreference = { pref ->
                             when (pref) {
                                 Options.ViewOptionsReset -> {
-                                    onViewOptionsChange.invoke(defaultViewOptions)
+                                    // Reset means "no choice", not "the default value", so the
+                                    // row keeps following the default if it later changes
+                                    onViewOptionsChange.invoke(null)
                                 }
 
                                 Options.ViewOptionsApplyAll -> {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsPage.kt
@@ -30,7 +30,6 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.surfaceColorAtElevation
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.model.HomeRowConfig
-import com.github.damontecres.wholphin.data.model.HomeRowViewOptions
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.BasicDialog
@@ -213,23 +212,15 @@ fun HomeSettingsPage(
                                             else -> Options.OPTIONS
                                         }
                                     }
-                                val defaultViewOptions =
-                                    remember(row.config) {
-                                        when (row.config) {
-                                            is HomeRowConfig.Genres -> HomeRowViewOptions.genreDefault
-                                            else -> HomeRowViewOptions()
-                                        }
-                                    }
                                 HomeRowSettings(
                                     title = row.title.getString(),
                                     preferenceOptions = preferenceOptions,
-                                    viewOptions = row.config.viewOptions,
-                                    defaultViewOptions = defaultViewOptions,
+                                    viewOptions = row.viewOptions,
                                     onViewOptionsChange = {
                                         viewModel.updateViewOptions(dest.rowId, it)
                                     },
                                     onApplyApplyAll = {
-                                        viewModel.updateViewOptionsForAll(row.config.viewOptions)
+                                        viewModel.updateViewOptionsForAll(row.viewOptions)
                                     },
                                     modifier = destModifier,
                                     config = row.config,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
@@ -33,8 +33,9 @@ import com.github.damontecres.wholphin.services.UnsupportedHomeSettingsVersionEx
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.services.getRecentlyAddedTitle
 import com.github.damontecres.wholphin.services.hilt.IoCoroutineScope
+import com.github.damontecres.wholphin.services.resolveViewOptions
 import com.github.damontecres.wholphin.services.tvAccess
-import com.github.damontecres.wholphin.ui.AspectRatio
+import com.github.damontecres.wholphin.services.withViewOptions
 import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.ui.showToast
@@ -274,24 +275,6 @@ class HomeSettingsViewModel
             rowType: LibraryRowType,
         ): Job =
             viewModelScope.launchIO {
-                val viewOptions =
-                    when (library.collectionType) {
-                        CollectionType.MUSIC -> {
-                            HomeRowViewOptions(aspectRatio = AspectRatio.SQUARE)
-                        }
-
-                        CollectionType.HOMEVIDEOS,
-                        CollectionType.MUSICVIDEOS,
-                        -> {
-                            HomeRowViewOptions(
-                                aspectRatio = AspectRatio.WIDE,
-                            )
-                        }
-
-                        else -> {
-                            HomeRowViewOptions()
-                        }
-                    }
                 val id = idCounter++
                 val newRow =
                     when (rowType) {
@@ -303,10 +286,12 @@ class HomeSettingsViewModel
                                         it,
                                     )
                                 }
+                            val config = RecentlyAdded(library.itemId)
                             HomeRowConfigDisplay(
                                 id = id,
                                 title = title,
-                                config = RecentlyAdded(library.itemId, viewOptions),
+                                config = config,
+                                viewOptions = config.resolveViewOptions(listOf(library)),
                             )
                         }
 
@@ -318,10 +303,12 @@ class HomeSettingsViewModel
                                         it,
                                     )
                                 }
+                            val config = RecentlyReleased(library.itemId)
                             HomeRowConfigDisplay(
                                 id = id,
                                 title = title,
-                                config = RecentlyReleased(library.itemId, viewOptions),
+                                config = config,
+                                viewOptions = config.resolveViewOptions(listOf(library)),
                             )
                         }
 
@@ -353,10 +340,12 @@ class HomeSettingsViewModel
                                         it,
                                     )
                                 }
+                            val config = Suggestions(library.itemId)
                             HomeRowConfigDisplay(
                                 id = id,
                                 title = title,
-                                config = Suggestions(library.itemId, viewOptions),
+                                config = config,
+                                viewOptions = config.resolveViewOptions(listOf(library)),
                             )
                         }
 
@@ -365,10 +354,7 @@ class HomeSettingsViewModel
                             HomeRowConfigDisplay(
                                 id = id,
                                 title = title,
-                                config =
-                                    TvChannels(
-                                        viewOptions = HomeRowViewOptions.liveTvDefault,
-                                    ),
+                                config = TvChannels(),
                             )
                         }
 
@@ -383,10 +369,12 @@ class HomeSettingsViewModel
 
                         LibraryRowType.RECENTLY_RECORDED -> {
                             val title = getRecentlyAddedTitle(library.name)
+                            val config = RecentlyAdded(library.itemId)
                             HomeRowConfigDisplay(
                                 id = id,
                                 title = title,
-                                config = RecentlyAdded(library.itemId),
+                                config = config,
+                                viewOptions = config.resolveViewOptions(listOf(library)),
                             )
                         }
 
@@ -455,16 +443,14 @@ class HomeSettingsViewModel
 
         fun updateViewOptions(
             rowId: Int,
-            viewOptions: HomeRowViewOptions,
+            viewOptions: HomeRowViewOptions?,
         ) {
             viewModelScope.launchIO {
                 var fetchData = false
                 updateState {
                     val index = it.rows.indexOfFirst { it.id == rowId }
-                    val config = it.rows[index].config
-                    val newRowConfig = config.updateViewOptions(viewOptions)
-                    val newRow = it.rows[index].copy(config = newRowConfig)
-                    if (config.viewOptions.useSeries != viewOptions.useSeries) {
+                    val newRow = it.rows[index].withViewOptions(viewOptions, it.libraries)
+                    if (it.rows[index].viewOptions.useSeries != newRow.viewOptions.useSeries) {
                         fetchData = true
                     }
                     it.copy(
@@ -477,7 +463,7 @@ class HomeSettingsViewModel
                                 val row = it.rowData[index]
                                 val newRow =
                                     if (row is HomeRowLoadingState.Success) {
-                                        row.copy(viewOptions = viewOptions)
+                                        row.copy(viewOptions = newRow.viewOptions)
                                     } else {
                                         row
                                     }
@@ -636,16 +622,16 @@ class HomeSettingsViewModel
                 updateState {
                     val newRows =
                         it.rows.toMutableList().map { row ->
-                            val vo = row.config.viewOptions
+                            val vo = row.viewOptions
                             val newVo = vo.copy(heightDp = vo.heightDp + (4 * relative))
-                            row.copy(config = row.config.updateViewOptions(newVo))
+                            row.withViewOptions(newVo, it.libraries)
                         }
                     it.copy(
                         rows = newRows,
                         rowData =
                             it.rowData.toMutableList().mapIndexed { index, row ->
                                 if (row is HomeRowLoadingState.Success) {
-                                    row.copy(viewOptions = newRows[index].config.viewOptions)
+                                    row.copy(viewOptions = newRows[index].viewOptions)
                                 } else {
                                     row
                                 }
@@ -724,11 +710,11 @@ class HomeSettingsViewModel
                                 }
 
                                 is Genres -> {
-                                    it.config.updateViewOptions(it.config.viewOptions.copy(heightDp = preset.genreSize))
+                                    it.config.updateViewOptions(it.viewOptions.copy(heightDp = preset.genreSize))
                                 }
 
                                 is HomeRowConfig.Studios -> {
-                                    it.config.updateViewOptions(it.config.viewOptions.copy(heightDp = preset.genreSize))
+                                    it.config.updateViewOptions(it.viewOptions.copy(heightDp = preset.genreSize))
                                 }
 
                                 is HomeRowConfig.GetItems -> {
@@ -765,7 +751,10 @@ class HomeSettingsViewModel
                                     it.config.updateViewOptions(preset.liveTv)
                                 }
                             }
-                        it.copy(config = newConfig)
+                        it.copy(
+                            config = newConfig,
+                            viewOptions = newConfig.resolveViewOptions(state.libraries),
+                        )
                     }
 
                 _state.update {
@@ -775,7 +764,7 @@ class HomeSettingsViewModel
                         rowData =
                             it.rowData.toMutableList().mapIndexed { index, row ->
                                 if (row is HomeRowLoadingState.Success) {
-                                    row.copy(viewOptions = newRows[index].config.viewOptions)
+                                    row.copy(viewOptions = newRows[index].viewOptions)
                                 } else {
                                     row
                                 }
@@ -811,6 +800,7 @@ class HomeSettingsViewModel
                                                 id = it.rows[index].id,
                                                 title = ResStringProvider(R.string.combine_continue_next),
                                                 config = ContinueWatchingCombined(row.config.viewOptions),
+                                                viewOptions = row.viewOptions,
                                             ),
                                         )
                                         removeAll(rowsToRemove)
@@ -836,6 +826,7 @@ class HomeSettingsViewModel
                                                 id = it.rows[index].id,
                                                 title = ResStringProvider(R.string.continue_watching),
                                                 config = ContinueWatching(row.config.viewOptions),
+                                                viewOptions = row.viewOptions,
                                             ),
                                         )
                                         add(
@@ -844,6 +835,7 @@ class HomeSettingsViewModel
                                                 id = idCounter++,
                                                 title = ResStringProvider(R.string.next_up),
                                                 config = NextUp(row.config.viewOptions),
+                                                viewOptions = row.viewOptions,
                                             ),
                                         )
                                     },

--- a/app/src/test/java/com/github/damontecres/wholphin/data/model/HomeRowViewOptionsTest.kt
+++ b/app/src/test/java/com/github/damontecres/wholphin/data/model/HomeRowViewOptionsTest.kt
@@ -1,0 +1,101 @@
+package com.github.damontecres.wholphin.data.model
+
+import com.github.damontecres.wholphin.ui.AspectRatio
+import com.github.damontecres.wholphin.ui.Cards
+import kotlinx.serialization.json.Json
+import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.CollectionType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.UUID
+
+/**
+ * A row stores only what the user chose, so everything else is decided here, on every load.
+ */
+class HomeRowViewOptionsTest {
+    private val parentId = UUID.randomUUID()
+
+    /** Matches the encoding used to persist settings, which is what makes an absent key mean null */
+    private val json =
+        Json {
+            isLenient = true
+            ignoreUnknownKeys = true
+        }
+
+    @Test
+    fun `a music row is square album art, not a stretched poster`() {
+        val row = HomeRowConfig.RecentlyAdded(parentId)
+        assertEquals(
+            HomeRowViewOptions(
+                heightDp = Cards.HEIGHT_EPISODE,
+                aspectRatio = AspectRatio.SQUARE,
+            ),
+            row.resolveViewOptions(CollectionType.MUSIC),
+        )
+    }
+
+    @Test
+    fun `the same row in a movie library keeps the poster shape`() {
+        val row = HomeRowConfig.RecentlyAdded(parentId)
+        assertEquals(HomeRowViewOptions(), row.resolveViewOptions(CollectionType.MOVIES))
+    }
+
+    @Test
+    fun `a row pointed at a music collection is square too`() {
+        val row = HomeRowConfig.ByParent(parentId)
+        assertEquals(HomeRowViewOptions.musicDefault, row.resolveViewOptions(CollectionType.MUSIC))
+    }
+
+    @Test
+    fun `video libraries are wide`() {
+        val row = HomeRowConfig.RecentlyAdded(parentId)
+        assertEquals(AspectRatio.WIDE, row.resolveViewOptions(CollectionType.HOMEVIDEOS).aspectRatio)
+        assertEquals(AspectRatio.WIDE, row.resolveViewOptions(CollectionType.MUSICVIDEOS).aspectRatio)
+    }
+
+    @Test
+    fun `a choice the user made wins over the default`() {
+        val chosen = HomeRowViewOptions(heightDp = 200, aspectRatio = AspectRatio.TALL)
+        val row = HomeRowConfig.RecentlyAdded(parentId, chosen)
+        assertEquals(chosen, row.resolveViewOptions(CollectionType.MUSIC))
+    }
+
+    @Test
+    fun `rows whose shape does not come from a library ignore the collection type`() {
+        assertEquals(
+            HomeRowViewOptions.genreDefault,
+            HomeRowConfig.Genres(parentId).resolveViewOptions(CollectionType.MUSIC),
+        )
+        assertEquals(
+            HomeRowViewOptions.liveTvDefault,
+            HomeRowConfig.TvChannels().resolveViewOptions(CollectionType.MUSIC),
+        )
+        assertEquals(
+            HomeRowViewOptions.episodeDefault,
+            HomeRowConfig.Favorite(BaseItemKind.EPISODE).resolveViewOptions(CollectionType.MUSIC),
+        )
+        assertEquals(
+            HomeRowViewOptions(),
+            HomeRowConfig.Favorite(BaseItemKind.MOVIE).resolveViewOptions(CollectionType.MUSIC),
+        )
+    }
+
+    @Test
+    fun `a row nobody sized stores nothing, so it picks up whatever the default is now`() {
+        val stored = json.encodeToString<HomeRowConfig>(HomeRowConfig.RecentlyAdded(parentId))
+        assertFalse("should not persist an unchosen value", stored.contains("viewOptions"))
+
+        val decoded = json.decodeFromString<HomeRowConfig>(stored)
+        assertNull(decoded.viewOptions)
+        assertEquals(HomeRowViewOptions.musicDefault, decoded.resolveViewOptions(CollectionType.MUSIC))
+    }
+
+    @Test
+    fun `a row the user sized is stored and comes back unchanged`() {
+        val chosen = HomeRowViewOptions(heightDp = 200, aspectRatio = AspectRatio.SQUARE)
+        val stored = json.encodeToString<HomeRowConfig>(HomeRowConfig.RecentlyAdded(parentId, chosen))
+        assertEquals(chosen, json.decodeFromString<HomeRowConfig>(stored).viewOptions)
+    }
+}


### PR DESCRIPTION
## Description
Home rows for music libraries used the tall poster card shape, which stretches square album art. That happened because every row always stored a concrete viewOptions value (the poster default), so the app could not tell “nobody chose a size” from “deliberately set to poster.”

Make HomeRowConfig.viewOptions nullable (null = follow the default) and resolve the default from the parent library’s collection type. Untouched music rows now use square album cards, and they will pick up future default changes.

Also:

Per-row Reset clears the choice (null) instead of writing the default value
The Wholphin Default preset’s music rows use musicDefault (128dp square); other presets are unchanged
Small refactor: resolve a home row’s parent item once when building the row display (no behavior change)
Adds HomeRowViewOptionsTest for the default-resolution and persistence behavior.

### Related issues
https://github.com/damontecres/Wholphin/issues/1838

### Testing
- Update from a v1.0.6 install with default values for all Home screen rows to this version. All TV and Movies libraries continue showing their defaults, music rows show the new default
- Update from a v1.0.6 install with custom values for Home screen TV/Movie and music rows to this version. The custom values are kept in the new version
- Revert from fix/music-how-row-square-cards with default values to v1.0.6. The Music libraries go back from squared to stretch images. Defaults don't write to config, they are computed from whatever the current default is

## Screenshots
<img width="1920" height="1080" alt="Screenshot_20260814_224126" src="https://github.com/user-attachments/assets/c59d777f-11d8-45ec-94f6-3f714c1e141d" />
Music row shows the same size and ratio as inside a Music library

## AI or LLM usage
Cursor and Claude Code