### PR TITLE
Fixes slideshow images not being full screen

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/slideshow/SlideshowPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/slideshow/SlideshowPage.kt
@@ -408,8 +408,11 @@ fun SlideshowPage(
                                     ImageRequest
                                         .Builder(LocalContext.current)
                                         .data(imageState.url)
-                                        .size(Size.ORIGINAL)
-                                        .transitionFactory(CrossFadeFactory(750.milliseconds))
+                                        .apply {
+                                            // Fixes images noting being full size when resolutions change
+                                            // See: https://github.com/damontecres/Wholphin/pull/1089
+                                            if (isZoomed) size(Size.ORIGINAL)
+                                        }.transitionFactory(CrossFadeFactory(750.milliseconds))
                                         .useExistingImageAsPlaceholder(true)
                                         .build(),
                                 contentDescription = null,


### PR DESCRIPTION
## Description
I accidentally removed the original fix/workaround from #1089 during a merge in #1052, so this PR restores the fix.

### Related issues
Fixes #1736
Related to the original fix #1089

### Testing
Emulator with portrait and landscape images

## Screenshots
N/A

## AI or LLM usage
None