### PR TITLE
Refresh library list on page resume

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderView.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderView.kt
@@ -567,6 +567,9 @@ class CollectionFolderViewModel
                         themeSongPlayer.playThemeFor(it.id)
                     }
                 }
+                val pager =
+                    ((state.value.items as? DataLoadingState.Success)?.data as? ApiRequestPager<*>)
+                pager?.refresh()
             }
         }
 


### PR DESCRIPTION
<!-- By submitting this pull request, you acknowledge that you have read the [contributing guide](https://github.com/damontecres/Wholphin/blob/main/CONTRIBUTING.md, including the AI/LLM policy, and [developer's guide](https://github.com/damontecres/Wholphin/blob/main/DEVELOPMENT.md) -->

## Description
Added refresh on page resume so it will refresh the library list if there's some status or media change.

### Related issues
Currently if I go back to the library by back button or from the sidebar it will not refresh the library

### Testing
On emulator and TCL TV

## Screenshots

https://github.com/user-attachments/assets/e03eb099-1920-4675-a33b-1393817ba5f1

https://github.com/user-attachments/assets/12a9ed2b-1d0d-4310-b452-45b8efe2d4f1

## AI or LLM usage
Code discovery using AI, but the code I did it myself