### PR TITLE
Add more searchable types & choose what to search

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
@@ -243,7 +243,7 @@ data class HomeRowViewOptions(
 
         val liveTvDefault =
             HomeRowViewOptions(
-                heightDp = 96,
+                heightDp = Cards.HEIGHT_LIVE_TV,
                 aspectRatio = AspectRatio.WIDE,
                 contentScale = PrefContentScale.FIT,
             )

--- a/app/src/main/java/com/github/damontecres/wholphin/services/LiveTvService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/LiveTvService.kt
@@ -1,0 +1,94 @@
+package com.github.damontecres.wholphin.services
+
+import com.github.damontecres.wholphin.data.model.BaseItem
+import com.github.damontecres.wholphin.ui.toServerString
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.liveTvApi
+import org.jellyfin.sdk.model.api.TimerInfoDto
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Functions for recording live tv programs
+ */
+@Singleton
+class LiveTvService
+    @Inject
+    constructor(
+        private val api: ApiClient,
+    ) {
+        /**
+         * Fetch a tv program by ID
+         */
+        suspend fun fetchProgramForDialog(programId: UUID): BaseItem {
+            val result =
+                api.liveTvApi
+                    .getProgram(programId.toServerString())
+                    .content
+                    .let { BaseItem(it) }
+            return result
+        }
+
+        /**
+         * Cancel a recording by [timerId]
+         *
+         * @param series whether the timerId is a series recording or not
+         * @param timerId the recording ID
+         */
+        suspend fun cancelRecording(
+            series: Boolean,
+            timerId: String?,
+        ): Boolean =
+            if (timerId != null) {
+                if (series) {
+                    api.liveTvApi.cancelSeriesTimer(timerId)
+                } else {
+                    api.liveTvApi.cancelTimer(timerId)
+                }
+                true
+            } else {
+                false
+            }
+
+        /**
+         * Record tv program
+         *
+         * @param programId the tv program ID
+         * @param series whether to set up series recording or just a single recording
+         */
+        suspend fun record(
+            programId: UUID,
+            series: Boolean,
+        ) {
+            val d by api.liveTvApi.getDefaultTimer(programId.toServerString())
+            if (series) {
+                api.liveTvApi.createSeriesTimer(d)
+            } else {
+                val payload =
+                    TimerInfoDto(
+                        id = d.id,
+                        type = d.type,
+                        serverId = d.serverId,
+                        externalId = d.externalId,
+                        channelId = d.channelId,
+                        externalChannelId = d.externalChannelId,
+                        channelName = d.channelName,
+                        programId = d.programId,
+                        externalProgramId = d.externalProgramId,
+                        name = d.name,
+                        overview = d.overview,
+                        startDate = d.startDate,
+                        endDate = d.endDate,
+                        serviceName = d.serviceName,
+                        priority = d.priority,
+                        prePaddingSeconds = d.prePaddingSeconds,
+                        postPaddingSeconds = d.postPaddingSeconds,
+                        isPrePaddingRequired = d.isPrePaddingRequired,
+                        isPostPaddingRequired = d.isPostPaddingRequired,
+                        keepUntil = d.keepUntil,
+                    )
+                api.liveTvApi.createTimer(payload)
+            }
+        }
+    }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/Formatting.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/Formatting.kt
@@ -220,6 +220,10 @@ fun listToDotString(
         }
     }
 
+@get:StringRes
+val BaseItemKind.titleStringRes: Int
+    get() = formatTypeName(this)
+
 @StringRes
 fun formatTypeName(type: BaseItemKind): Int =
     when (type) {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/Formatting.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/Formatting.kt
@@ -243,7 +243,7 @@ fun formatTypeName(type: BaseItemKind): Int =
         BaseItemKind.MUSIC_GENRE -> R.string.genres
         BaseItemKind.MUSIC_VIDEO -> R.string.music_videos
         BaseItemKind.PHOTO -> R.string.photos
-        BaseItemKind.PHOTO_ALBUM -> R.string.photos
+        BaseItemKind.PHOTO_ALBUM -> R.string.photo_albums
         BaseItemKind.PROGRAM -> R.string.programs
         BaseItemKind.RECORDING -> R.string.recordings
         BaseItemKind.SEASON -> R.string.tv_seasons

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/UiConstants.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/UiConstants.kt
@@ -90,6 +90,7 @@ object Cards {
     const val HEIGHT_2X3_DP = 172
     val height2x3 = HEIGHT_2X3_DP.dp
     const val HEIGHT_EPISODE = 128
+    const val HEIGHT_LIVE_TV = 96
     val heightEpisode = HEIGHT_EPISODE.dp
     val playedPercentHeight = 6.dp
     val serverUserCircle = height2x3 * .75f

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/SeasonCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/SeasonCard.kt
@@ -51,37 +51,7 @@ fun SeasonCard(
     showImageOverlay: Boolean = false,
     aspectRatio: Float = item?.aspectRatio ?: AspectRatios.TALL,
 ) {
-    val imageUrlService = LocalImageUrlService.current
-    val density = LocalDensity.current
-    val imageUrl =
-        remember(item, imageHeight, imageWidth, density) {
-            if (item != null) {
-                val fillHeight =
-                    if (imageHeight.isSpecified) {
-                        with(density) {
-                            imageHeight.roundToPx()
-                        }
-                    } else {
-                        null
-                    }
-                val fillWidth =
-                    if (imageWidth.isSpecified) {
-                        with(density) {
-                            imageWidth.roundToPx()
-                        }
-                    } else {
-                        null
-                    }
-                imageUrlService.getItemImageUrl(
-                    item,
-                    ImageType.PRIMARY,
-                    fillWidth = fillWidth,
-                    fillHeight = fillHeight,
-                )
-            } else {
-                null
-            }
-        }
+    val imageUrl = rememberImageUrl(item, imageHeight, imageWidth)
     SeasonCard(
         title = item?.title,
         subtitle = item?.subtitle,
@@ -101,6 +71,44 @@ fun SeasonCard(
         showImageOverlay = showImageOverlay,
         aspectRatio = aspectRatio,
     )
+}
+
+@Composable
+fun rememberImageUrl(
+    item: BaseItem?,
+    imageHeight: Dp,
+    imageWidth: Dp = Dp.Unspecified,
+): String? {
+    val density = LocalDensity.current
+    val imageUrlService = LocalImageUrlService.current
+    return remember(item, imageHeight, imageWidth, density) {
+        if (item != null) {
+            val fillHeight =
+                if (imageHeight.isSpecified) {
+                    with(density) {
+                        imageHeight.roundToPx()
+                    }
+                } else {
+                    null
+                }
+            val fillWidth =
+                if (imageWidth.isSpecified) {
+                    with(density) {
+                        imageWidth.roundToPx()
+                    }
+                } else {
+                    null
+                }
+            imageUrlService.getItemImageUrl(
+                item,
+                ImageType.PRIMARY,
+                fillWidth = fillWidth,
+                fillHeight = fillHeight,
+            )
+        } else {
+            null
+        }
+    }
 }
 
 private val spaceBetweenFocused = 4.dp

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderGrid.kt
@@ -206,7 +206,7 @@ val CollectionType.baseItemKinds: List<BaseItemKind>
             }
 
             CollectionType.TVSHOWS -> {
-                listOf(BaseItemKind.SERIES)
+                listOf(BaseItemKind.SERIES, BaseItemKind.SEASON, BaseItemKind.EPISODE)
             }
 
             CollectionType.HOMEVIDEOS -> {
@@ -221,12 +221,20 @@ val CollectionType.baseItemKinds: List<BaseItemKind>
                 )
             }
 
+            CollectionType.MUSICVIDEOS -> {
+                listOf(BaseItemKind.MUSIC_VIDEO)
+            }
+
             CollectionType.BOXSETS -> {
                 listOf(BaseItemKind.BOX_SET)
             }
 
             CollectionType.PLAYLISTS -> {
                 listOf(BaseItemKind.PLAYLIST)
+            }
+
+            CollectionType.PHOTOS -> {
+                listOf(BaseItemKind.PHOTO, BaseItemKind.PHOTO_ALBUM)
             }
 
             else -> {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/DvrSchedule.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/DvrSchedule.kt
@@ -1,6 +1,7 @@
 package com.github.damontecres.wholphin.ui.detail.livetv
 
 import android.text.format.DateUtils
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -178,6 +179,7 @@ fun DvrSchedule(
                         .focusRequester(focusRequester),
             )
             showDialog?.let { item ->
+                val context = LocalContext.current
                 ProgramDialog(
                     state = DataLoadingState.Success(item),
                     canRecord = true,
@@ -185,13 +187,18 @@ fun DvrSchedule(
                         showDialog = null
                     },
                     onWatch = { program ->
-                        program.data.channelId?.let {
+                        val channelId = program.data.channelId
+                        if (channelId != null) {
                             viewModel.navigationManager.navigateTo(
                                 Destination.Playback(
-                                    itemId = it,
+                                    itemId = channelId,
                                     positionMs = 0L,
                                 ),
                             )
+                        } else {
+                            Toast
+                                .makeText(context, "Program has no channel ID", Toast.LENGTH_LONG)
+                                .show()
                         }
                     },
                     onRecord = { _, _ ->

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/LiveTvViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/LiveTvViewModel.kt
@@ -15,6 +15,7 @@ import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.ImageUrlService
+import com.github.damontecres.wholphin.services.LiveTvService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.ui.AppColors
 import com.github.damontecres.wholphin.ui.data.RowColumn
@@ -25,7 +26,7 @@ import com.github.damontecres.wholphin.ui.isNotNullOrBlank
 import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.ui.roundMinutes
-import com.github.damontecres.wholphin.ui.toServerString
+import com.github.damontecres.wholphin.ui.showToast
 import com.github.damontecres.wholphin.util.DataLoadingState
 import com.github.damontecres.wholphin.util.ExceptionHandler
 import com.github.damontecres.wholphin.util.LoadingState
@@ -51,7 +52,6 @@ import org.jellyfin.sdk.model.api.ImageType
 import org.jellyfin.sdk.model.api.ItemFields
 import org.jellyfin.sdk.model.api.ItemSortBy
 import org.jellyfin.sdk.model.api.SortOrder
-import org.jellyfin.sdk.model.api.TimerInfoDto
 import org.jellyfin.sdk.model.api.request.GetLiveTvChannelsRequest
 import org.jellyfin.sdk.model.extensions.ticks
 import timber.log.Timber
@@ -81,6 +81,7 @@ class LiveTvViewModel
         private val serverRepository: ServerRepository,
         private val imageUrlService: ImageUrlService,
         private val favoriteWatchManager: FavoriteWatchManager,
+        private val liveTvService: LiveTvService,
     ) : ViewModel() {
         private lateinit var channelsIdToIndex: Map<UUID, Int>
         private val mutex = Mutex()
@@ -430,12 +431,10 @@ class LiveTvViewModel
             _programDialogState.update { it.copy(loading = DataLoadingState.Loading) }
             viewModelScope.launchDefault {
                 try {
-                    val result =
-                        api.liveTvApi
-                            .getProgram(programId.toServerString())
-                            .content
-                            .let { BaseItem(it) }
+                    val result = liveTvService.fetchProgramForDialog(programId)
                     _programDialogState.update { it.copy(loading = DataLoadingState.Success(result)) }
+                } catch (ex: CancellationException) {
+                    throw ex
                 } catch (ex: Exception) {
                     Timber.e(ex, "Error fetching program $programId")
                     _programDialogState.update { it.copy(loading = DataLoadingState.Error(ex)) }
@@ -447,16 +446,19 @@ class LiveTvViewModel
             series: Boolean,
             timerId: String?,
         ) {
-            if (timerId != null) {
-                viewModelScope.launchIO(ExceptionHandler(autoToast = true)) {
-                    if (series) {
-                        api.liveTvApi.cancelSeriesTimer(timerId)
-                    } else {
-                        api.liveTvApi.cancelTimer(timerId)
+            viewModelScope.launchIO(ExceptionHandler(autoToast = true)) {
+                try {
+                    val result = liveTvService.cancelRecording(series, timerId)
+                    if (result) {
+                        state.value.let {
+                            refreshPrograms(it.channels, it.programs.range)
+                        }
                     }
-                    state.value.let {
-                        refreshPrograms(it.channels, it.programs.range)
-                    }
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Error canceling timer %s, series=%s", timerId, series)
+                    showToast(context, "Error: ${ex.localizedMessage}")
                 }
             }
         }
@@ -466,37 +468,16 @@ class LiveTvViewModel
             series: Boolean,
         ) {
             viewModelScope.launchIO {
-                val d by api.liveTvApi.getDefaultTimer(programId.toServerString())
-                if (series) {
-                    api.liveTvApi.createSeriesTimer(d)
-                } else {
-                    val payload =
-                        TimerInfoDto(
-                            id = d.id,
-                            type = d.type,
-                            serverId = d.serverId,
-                            externalId = d.externalId,
-                            channelId = d.channelId,
-                            externalChannelId = d.externalChannelId,
-                            channelName = d.channelName,
-                            programId = d.programId,
-                            externalProgramId = d.externalProgramId,
-                            name = d.name,
-                            overview = d.overview,
-                            startDate = d.startDate,
-                            endDate = d.endDate,
-                            serviceName = d.serviceName,
-                            priority = d.priority,
-                            prePaddingSeconds = d.prePaddingSeconds,
-                            postPaddingSeconds = d.postPaddingSeconds,
-                            isPrePaddingRequired = d.isPrePaddingRequired,
-                            isPostPaddingRequired = d.isPostPaddingRequired,
-                            keepUntil = d.keepUntil,
-                        )
-                    api.liveTvApi.createTimer(payload)
-                }
-                state.value.let {
-                    refreshPrograms(it.channels, it.programs.range)
+                try {
+                    liveTvService.record(programId, series)
+                    state.value.let {
+                        refreshPrograms(it.channels, it.programs.range)
+                    }
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Error recording %s, series=%s", programId, series)
+                    showToast(context, "Error: ${ex.localizedMessage}")
                 }
             }
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/TvGuideGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/livetv/TvGuideGrid.kt
@@ -211,13 +211,18 @@ fun TvGuideGrid(
                     onDismissRequest = onDismissRequest,
                     onWatch = {
                         onDismissRequest.invoke()
-                        it.data.channelId?.let {
+                        val channelId = it.data.channelId
+                        if (channelId != null) {
                             viewModel.navigationManager.navigateTo(
                                 Destination.Playback(
-                                    itemId = it,
+                                    itemId = channelId,
                                     positionMs = 0L,
                                 ),
                             )
+                        } else {
+                            Toast
+                                .makeText(context, "Program has no channel ID", Toast.LENGTH_LONG)
+                                .show()
                         }
                     },
                     onRecord = { program, series ->

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverSearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/discover/DiscoverSearchPage.kt
@@ -50,10 +50,10 @@ import com.github.damontecres.wholphin.ui.components.SearchEditTextBox
 import com.github.damontecres.wholphin.ui.components.VoiceInputManager
 import com.github.damontecres.wholphin.ui.components.VoiceSearchButton
 import com.github.damontecres.wholphin.ui.launchIO
-import com.github.damontecres.wholphin.ui.main.SearchCombinedResults
-import com.github.damontecres.wholphin.ui.main.SearchResult
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.rememberInt
+import com.github.damontecres.wholphin.ui.search.SearchCombinedResults
+import com.github.damontecres.wholphin.ui.search.SearchResult
 import com.github.damontecres.wholphin.ui.tryRequestFocus
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsPage.kt
@@ -36,12 +36,12 @@ import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.BasicDialog
 import com.github.damontecres.wholphin.ui.components.ConfirmDialog
 import com.github.damontecres.wholphin.ui.data.RowColumn
-import com.github.damontecres.wholphin.ui.detail.search.SearchForDialog
 import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.ui.main.HomePageContent
 import com.github.damontecres.wholphin.ui.main.settings.HomeSettingsDestination.ChooseRowType
 import com.github.damontecres.wholphin.ui.main.settings.HomeSettingsDestination.RowSettings
 import com.github.damontecres.wholphin.ui.rememberPosition
+import com.github.damontecres.wholphin.ui.search.SearchForDialog
 import com.github.damontecres.wholphin.util.ExceptionHandler
 import com.github.damontecres.wholphin.util.HomeRowLoadingState
 import kotlinx.coroutines.Job

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/DestinationContent.kt
@@ -42,13 +42,13 @@ import com.github.damontecres.wholphin.ui.detail.series.SeriesOverview
 import com.github.damontecres.wholphin.ui.discover.DiscoverPage
 import com.github.damontecres.wholphin.ui.discover.DiscoverRequestGrid
 import com.github.damontecres.wholphin.ui.main.HomePage
-import com.github.damontecres.wholphin.ui.main.SearchPage
 import com.github.damontecres.wholphin.ui.main.settings.HomeSettingsPage
 import com.github.damontecres.wholphin.ui.playback.PlayExternalPage
 import com.github.damontecres.wholphin.ui.playback.PlaybackPage
 import com.github.damontecres.wholphin.ui.preferences.PreferencesPage
 import com.github.damontecres.wholphin.ui.preferences.subtitle.SubtitleStylePage
 import com.github.damontecres.wholphin.ui.preferences.user.UserProfilePreferencesPage
+import com.github.damontecres.wholphin.ui.search.SearchPage
 import com.github.damontecres.wholphin.ui.setup.InstallUpdatePage
 import com.github.damontecres.wholphin.ui.slideshow.SlideshowPage
 import org.jellyfin.sdk.model.api.BaseItemKind

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchForDialog.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchForDialog.kt
@@ -1,4 +1,4 @@
-package com.github.damontecres.wholphin.ui.detail.search
+package com.github.damontecres.wholphin.ui.search
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.focusGroup
@@ -51,7 +51,6 @@ import com.github.damontecres.wholphin.ui.components.BasicDialog
 import com.github.damontecres.wholphin.ui.components.ErrorMessage
 import com.github.damontecres.wholphin.ui.components.SearchEditTextBox
 import com.github.damontecres.wholphin.ui.components.VoiceSearchButton
-import com.github.damontecres.wholphin.ui.main.SearchResult
 import kotlinx.coroutines.delay
 import org.jellyfin.sdk.model.api.BaseItemKind
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchForViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchForViewModel.kt
@@ -1,4 +1,4 @@
-package com.github.damontecres.wholphin.ui.detail.search
+package com.github.damontecres.wholphin.ui.search
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -7,7 +7,6 @@ import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.ui.SlimItemFields
 import com.github.damontecres.wholphin.ui.components.VoiceInputManager
 import com.github.damontecres.wholphin.ui.launchIO
-import com.github.damontecres.wholphin.ui.main.SearchResult
 import com.github.damontecres.wholphin.ui.toBaseItems
 import com.github.damontecres.wholphin.util.ApiRequestPager
 import com.github.damontecres.wholphin.util.GetItemsRequestHandler

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
@@ -69,17 +69,12 @@ import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.DiscoverItem
 import com.github.damontecres.wholphin.preferences.UserPreferences
-import com.github.damontecres.wholphin.ui.AspectRatios
 import com.github.damontecres.wholphin.ui.Cards
-import com.github.damontecres.wholphin.ui.LocalImageUrlService
-import com.github.damontecres.wholphin.ui.cards.BannerCardWithTitle
 import com.github.damontecres.wholphin.ui.cards.DiscoverItemCard
 import com.github.damontecres.wholphin.ui.cards.GridCard
 import com.github.damontecres.wholphin.ui.cards.ItemRow
 import com.github.damontecres.wholphin.ui.cards.ItemRowTitle
-import com.github.damontecres.wholphin.ui.cards.PersonCard
 import com.github.damontecres.wholphin.ui.cards.SeasonCard
-import com.github.damontecres.wholphin.ui.cards.personRowCardWidth
 import com.github.damontecres.wholphin.ui.components.ExpandableFaButton
 import com.github.damontecres.wholphin.ui.components.SearchEditTextBox
 import com.github.damontecres.wholphin.ui.components.TabDetails
@@ -100,7 +95,6 @@ import com.github.damontecres.wholphin.util.WholphinDispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.ImageType
 import timber.log.Timber
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -435,92 +429,6 @@ fun SearchPage(
                     ) {
                         itemsIndexed(searchableTypes) { index, type ->
                             val rowIndex = RESULTS_START + index
-                            val cardContent: @Composable (
-                                index: Int,
-                                item: BaseItem?,
-                                modifier: Modifier,
-                                onClick: () -> Unit,
-                                onLongClick: () -> Unit,
-                            ) -> Unit =
-                                when (type) {
-                                    BaseItemKind.EPISODE -> {
-                                        { index, item, mod, onClick, onLongClick ->
-                                            BannerCardWithTitle(
-                                                title = item?.title,
-                                                subtitle = item?.subtitle,
-                                                item = item,
-                                                onClick = {
-                                                    setPosition(RowColumn(rowIndex, index))
-                                                    onClick.invoke()
-                                                },
-                                                onLongClick = onLongClick,
-                                                modifier = mod.padding(horizontal = 8.dp),
-                                                cardHeight = Cards.heightEpisode,
-                                            )
-                                        }
-                                    }
-
-                                    BaseItemKind.MUSIC_ALBUM,
-                                    BaseItemKind.MUSIC_ARTIST,
-                                    BaseItemKind.AUDIO,
-                                    -> {
-                                        { index, item, mod, onClick, onLongClick ->
-                                            SeasonCard(
-                                                item = item,
-                                                onClick = {
-                                                    setPosition(RowColumn(rowIndex, index))
-                                                    onClick.invoke()
-                                                },
-                                                onLongClick = onLongClick,
-                                                imageHeight = Cards.heightEpisode,
-                                                aspectRatio = AspectRatios.SQUARE,
-                                                showImageOverlay = true,
-                                                modifier = mod,
-                                            )
-                                        }
-                                    }
-
-                                    BaseItemKind.PERSON -> {
-                                        { index, item, mod, onClick, onLongClick ->
-                                            val imageUrlService = LocalImageUrlService.current
-                                            val imageUrl =
-                                                remember(item) {
-                                                    imageUrlService.getItemImageUrl(
-                                                        item,
-                                                        ImageType.PRIMARY,
-                                                    )
-                                                }
-                                            PersonCard(
-                                                name = item?.name ?: "",
-                                                role = null,
-                                                imageUrl = imageUrl,
-                                                favorite = item?.favorite ?: false,
-                                                onClick = {
-                                                    setPosition(RowColumn(rowIndex, index))
-                                                    onClick.invoke()
-                                                },
-                                                onLongClick = onLongClick,
-                                                modifier = mod.width(personRowCardWidth),
-                                            )
-                                        }
-                                    }
-
-                                    else -> {
-                                        { index, item, mod, onClick, onLongClick ->
-                                            SeasonCard(
-                                                item = item,
-                                                onClick = {
-                                                    setPosition(RowColumn(rowIndex, index))
-                                                    onClick.invoke()
-                                                },
-                                                onLongClick = onLongClick,
-                                                imageHeight = Cards.height2x3,
-                                                showImageOverlay = true,
-                                                modifier = mod,
-                                            )
-                                        }
-                                    }
-                                }
                             val result = state.results.getOrDefault(type, SearchResult.Searching)
                             SearchRowResult(
                                 title = type.titleStringRes,
@@ -534,7 +442,18 @@ fun SearchPage(
                                 },
                                 onClickPosition = { setPosition(it) },
                                 modifier = Modifier.fillMaxWidth(),
-                                cardContent = cardContent,
+                                cardContent = { index, item, mod, onClick, onLongClick ->
+                                    SearchPageCard(
+                                        item = item,
+                                        type = type,
+                                        onClick = {
+                                            setPosition(RowColumn(rowIndex, index))
+                                            onClick.invoke()
+                                        },
+                                        onLongClick = onLongClick,
+                                        modifier = mod,
+                                    )
+                                },
                             )
                         }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
@@ -69,12 +69,15 @@ import com.github.damontecres.wholphin.data.model.DiscoverItem
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.AspectRatios
 import com.github.damontecres.wholphin.ui.Cards
+import com.github.damontecres.wholphin.ui.LocalImageUrlService
 import com.github.damontecres.wholphin.ui.cards.BannerCardWithTitle
 import com.github.damontecres.wholphin.ui.cards.DiscoverItemCard
 import com.github.damontecres.wholphin.ui.cards.GridCard
 import com.github.damontecres.wholphin.ui.cards.ItemRow
 import com.github.damontecres.wholphin.ui.cards.ItemRowTitle
+import com.github.damontecres.wholphin.ui.cards.PersonCard
 import com.github.damontecres.wholphin.ui.cards.SeasonCard
+import com.github.damontecres.wholphin.ui.cards.personRowCardWidth
 import com.github.damontecres.wholphin.ui.components.ExpandableFaButton
 import com.github.damontecres.wholphin.ui.components.SearchEditTextBox
 import com.github.damontecres.wholphin.ui.components.TabDetails
@@ -94,6 +97,7 @@ import com.github.damontecres.wholphin.util.WholphinDispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.ImageType
 import timber.log.Timber
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -222,15 +226,7 @@ fun SearchPage(
                     if (combinedMode) {
                         listOf(state.combinedResults)
                     } else {
-                        listOf(
-                            state.movies,
-                            state.series,
-                            state.episodes,
-                            state.collections,
-                            state.albums,
-                            state.artists,
-                            state.songs,
-                        )
+                        searchableTypes.map { state.results[it] }
                     }
                 } else {
                     listOf(state.seerrResults)
@@ -469,6 +465,31 @@ fun SearchPage(
                                                 aspectRatio = AspectRatios.SQUARE,
                                                 showImageOverlay = true,
                                                 modifier = mod,
+                                            )
+                                        }
+                                    }
+
+                                    BaseItemKind.PERSON -> {
+                                        { index, item, mod, onClick, onLongClick ->
+                                            val imageUrlService = LocalImageUrlService.current
+                                            val imageUrl =
+                                                remember(item) {
+                                                    imageUrlService.getItemImageUrl(
+                                                        item,
+                                                        ImageType.PRIMARY,
+                                                    )
+                                                }
+                                            PersonCard(
+                                                name = item?.name ?: "",
+                                                role = null,
+                                                imageUrl = imageUrl,
+                                                favorite = item?.favorite ?: false,
+                                                onClick = {
+                                                    setPosition(RowColumn(rowIndex, index))
+                                                    onClick.invoke()
+                                                },
+                                                onLongClick = onLongClick,
+                                                modifier = mod.width(personRowCardWidth),
                                             )
                                         }
                                     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
@@ -99,16 +99,9 @@ import kotlin.time.Duration.Companion.milliseconds
 
 internal const val SEARCH_ROW = 0
 internal const val TAB_ROW = SEARCH_ROW + 1
-internal const val MOVIE_ROW = TAB_ROW + 1
-internal const val SERIES_ROW = MOVIE_ROW + 1
-internal const val EPISODE_ROW = SERIES_ROW + 1
-internal const val COLLECTION_ROW = EPISODE_ROW + 1
-internal const val ALBUM_ROW = COLLECTION_ROW + 1
-internal const val ARTIST_ROW = ALBUM_ROW + 1
-internal const val SONG_ROW = ARTIST_ROW + 1
-internal const val SEERR_ROW = SONG_ROW + 1
-
-internal const val COMBINED_ROW = TAB_ROW + 1
+internal const val SEERR_ROW = TAB_ROW + 1
+internal const val COMBINED_ROW = SEERR_ROW
+internal const val RESULTS_START = SEERR_ROW + 1
 
 @Composable
 fun SearchPage(
@@ -131,7 +124,8 @@ fun SearchPage(
 
 //    val query = rememberTextFieldState()
     var query by rememberSaveable { mutableStateOf(initialQuery) }
-    val focusRequesters = remember { List(SEERR_ROW + 1) { FocusRequester() } }
+    val focusRequesters =
+        remember { List(RESULTS_START + searchableTypes.size) { FocusRequester() } }
 
     val seerrActive by viewModel.seerrActive.collectAsState(initial = false)
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
@@ -252,13 +246,13 @@ fun SearchPage(
                             if (combinedMode) {
                                 COMBINED_ROW
                             } else {
-                                MOVIE_ROW + firstSuccess
+                                firstSuccess
                             }
                         } else {
                             SEERR_ROW
                         }
 //                    setPosition(RowColumn(targetRow, 0))
-                    onMain { focusRequesters[targetRow].tryRequestFocus() }
+                    onMain { focusRequesters.getOrNull(targetRow)?.tryRequestFocus() }
                 }
             }
         }
@@ -432,7 +426,8 @@ fun SearchPage(
                         verticalArrangement = Arrangement.spacedBy(0.dp),
                         modifier = Modifier.focusGroup(),
                     ) {
-                        itemsIndexed(searchableTypes) { rowIndex, type ->
+                        itemsIndexed(searchableTypes) { index, type ->
+                            val rowIndex = RESULTS_START + index
                             val cardContent: @Composable (
                                 index: Int,
                                 item: BaseItem?,
@@ -448,7 +443,7 @@ fun SearchPage(
                                                 subtitle = item?.subtitle,
                                                 item = item,
                                                 onClick = {
-                                                    setPosition(RowColumn(EPISODE_ROW, index))
+                                                    setPosition(RowColumn(rowIndex, index))
                                                     onClick.invoke()
                                                 },
                                                 onLongClick = onLongClick,
@@ -466,7 +461,7 @@ fun SearchPage(
                                             SeasonCard(
                                                 item = item,
                                                 onClick = {
-                                                    setPosition(RowColumn(ALBUM_ROW, index))
+                                                    setPosition(RowColumn(rowIndex, index))
                                                     onClick.invoke()
                                                 },
                                                 onLongClick = onLongClick,
@@ -483,7 +478,7 @@ fun SearchPage(
                                             SeasonCard(
                                                 item = item,
                                                 onClick = {
-                                                    setPosition(RowColumn(ALBUM_ROW, index))
+                                                    setPosition(RowColumn(rowIndex, index))
                                                     onClick.invoke()
                                                 },
                                                 onLongClick = onLongClick,
@@ -498,12 +493,12 @@ fun SearchPage(
                             SearchRowResult(
                                 title = type.titleStringRes,
                                 result = result,
-                                rowIndex = MOVIE_ROW,
+                                rowIndex = rowIndex,
                                 position = position,
-                                focusRequester = focusRequesters[MOVIE_ROW],
+                                focusRequester = focusRequesters[rowIndex],
                                 onClickItem = onClickItem,
                                 onLongClickItem = { index, item ->
-                                    onLongClickItem(MOVIE_ROW, index, item)
+                                    onLongClickItem(rowIndex, index, item)
                                 },
                                 onClickPosition = { setPosition(it) },
                                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -57,12 +56,10 @@ import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.DiscoverItem
 import com.github.damontecres.wholphin.preferences.UserPreferences
-import com.github.damontecres.wholphin.ui.Cards
 import com.github.damontecres.wholphin.ui.cards.DiscoverItemCard
 import com.github.damontecres.wholphin.ui.cards.GridCard
 import com.github.damontecres.wholphin.ui.cards.ItemRow
 import com.github.damontecres.wholphin.ui.cards.ItemRowTitle
-import com.github.damontecres.wholphin.ui.cards.SeasonCard
 import com.github.damontecres.wholphin.ui.components.ExpandableFaButton
 import com.github.damontecres.wholphin.ui.components.SearchEditTextBox
 import com.github.damontecres.wholphin.ui.components.TabDetails
@@ -117,7 +114,7 @@ fun SearchPage(
         remember(state.includedSearchableTypes.size) { List(RESULTS_START + state.includedSearchableTypes.size) { FocusRequester() } }
 
     val seerrActive by viewModel.seerrActive.collectAsState(initial = false)
-    var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+    var selectedTab by rememberSaveable(seerrActive, state.discoverEnabled) { mutableIntStateOf(0) }
     var showViewOptions by rememberSaveable { mutableStateOf(false) }
     var showFilterTypeDialog by rememberSaveable { mutableStateOf(false) }
     var searchClicked by rememberSaveable(query) { mutableStateOf(false) }
@@ -194,7 +191,8 @@ fun SearchPage(
     val positionCallback = { columns: Int, index: Int ->
         showHeader = index < columns
     }
-    val showTabs = seerrActive && query.isNotBlank() && showHeader && combinedMode
+    val showTabs =
+        seerrActive && state.discoverEnabled && query.isNotBlank() && showHeader && combinedMode
     val isLibraryTab = selectedTab == 0
 
     LaunchedEffect(seerrActive, query) {
@@ -248,11 +246,13 @@ fun SearchPage(
     }
 
     val tabs =
-        remember {
-            listOf(
-                TabDetails(R.string.library),
-                TabDetails(R.string.discover),
-            )
+        remember(seerrActive, state.discoverEnabled) {
+            buildList {
+                add(TabDetails(R.string.library))
+                if (seerrActive && state.discoverEnabled) {
+                    add(TabDetails(R.string.discover))
+                }
+            }
         }
 
     Column(
@@ -445,18 +445,23 @@ fun SearchPage(
                             )
                         }
 
-                        searchResultRow(
-                            title = R.string.discover,
-                            result = state.seerrResults,
-                            rowIndex = SEERR_ROW,
-                            position = position,
-                            focusRequester = focusRequesters[SEERR_ROW],
-                            onClickItem = onClickItem,
-                            onLongClickItem = { _, _ -> },
-                            onClickDiscover = onClickDiscover,
-                            onClickPosition = { setPosition(it) },
-                            modifier = Modifier.fillMaxWidth(),
-                        )
+                        if (seerrActive && state.discoverEnabled) {
+                            item {
+                                SearchRowResult(
+                                    title = R.string.discover,
+                                    result = state.seerrResults,
+                                    rowIndex = SEERR_ROW,
+                                    position = position,
+                                    focusRequester = focusRequesters[SEERR_ROW],
+                                    onClickItem = onClickItem,
+                                    onLongClickItem = { _, _ -> },
+                                    onClickDiscover = onClickDiscover,
+                                    onClickPosition = { setPosition(it) },
+                                    cardContent = { _, _, _, _, _ -> },
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -480,7 +485,10 @@ fun SearchPage(
             onDismissRequest = { showFilterTypeDialog = false },
             searchableTypes = state.possibleSearchableTypes,
             excludedSearchableTypes = state.excludedSearchableTypes,
+            discoverAvailable = seerrActive,
+            discoverEnabled = state.discoverEnabled,
             onClick = viewModel::onClickExcludeSearchableType,
+            onClickDiscover = viewModel::onClickExcludeDiscover,
         )
     }
 
@@ -652,54 +660,6 @@ private fun <T : CardGridItem> SearchGrid(
             positionCallback = positionCallback,
             modifier = Modifier.fillMaxSize(),
             cardContent = cardContent,
-        )
-    }
-}
-
-fun LazyListScope.searchResultRow(
-    @StringRes title: Int,
-    result: SearchResult,
-    rowIndex: Int,
-    position: RowColumn,
-    focusRequester: FocusRequester,
-    onClickItem: (Int, BaseItem) -> Unit,
-    onLongClickItem: (Int, BaseItem) -> Unit,
-    onClickPosition: (RowColumn) -> Unit,
-    modifier: Modifier = Modifier,
-    onClickDiscover: ((Int, DiscoverItem) -> Unit)? = null,
-    cardContent: @Composable (
-        index: Int,
-        item: BaseItem?,
-        modifier: Modifier,
-        onClick: () -> Unit,
-        onLongClick: () -> Unit,
-    ) -> Unit = @Composable { index, item, mod, onClick, onLongClick ->
-        SeasonCard(
-            item = item,
-            onClick = {
-                onClickPosition.invoke(RowColumn(rowIndex, index))
-                onClick.invoke()
-            },
-            onLongClick = onLongClick,
-            imageHeight = Cards.height2x3,
-            showImageOverlay = true,
-            modifier = mod,
-        )
-    },
-) {
-    item {
-        SearchRowResult(
-            title = R.string.discover,
-            result = result,
-            rowIndex = SEERR_ROW,
-            position = position,
-            focusRequester = focusRequester,
-            onClickItem = onClickItem,
-            onLongClickItem = { _, _ -> },
-            onClickDiscover = onClickDiscover,
-            onClickPosition = onClickPosition,
-            cardContent = cardContent,
-            modifier = modifier,
         )
     }
 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
@@ -1,6 +1,7 @@
 package com.github.damontecres.wholphin.ui.search
 
 import android.view.Gravity
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedVisibility
@@ -48,6 +49,7 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalView
@@ -88,6 +90,7 @@ import com.github.damontecres.wholphin.ui.data.RowColumn
 import com.github.damontecres.wholphin.ui.detail.CardGrid
 import com.github.damontecres.wholphin.ui.detail.CardGridItem
 import com.github.damontecres.wholphin.ui.detail.GridItemDetails
+import com.github.damontecres.wholphin.ui.detail.livetv.ProgramDialog
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.onMain
 import com.github.damontecres.wholphin.ui.preferences.SwitchColors
@@ -117,6 +120,7 @@ fun SearchPage(
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
     val state by viewModel.state.collectAsState()
+    val programDialogState by viewModel.programDialogState.collectAsState()
 
     // Start with current preferences, but collect updates when view options change
     val prefs =
@@ -136,6 +140,7 @@ fun SearchPage(
     var showViewOptions by rememberSaveable { mutableStateOf(false) }
     var searchClicked by rememberSaveable(query) { mutableStateOf(false) }
     var immediateSearchQuery by rememberSaveable { mutableStateOf<String?>(null) }
+    var showProgramDialog by remember { mutableStateOf(false) }
 
     val position by viewModel.position.collectAsState()
 
@@ -174,7 +179,13 @@ fun SearchPage(
         focusRequesters.getOrNull(position.row)?.tryRequestFocus()
     }
     val onClickItem = { _: Int, item: BaseItem ->
-        viewModel.navigationManager.navigateTo(item.destination())
+        Timber.v("Clicked %s, type=%s", item.id, item.type)
+        if (item.type == BaseItemKind.TV_PROGRAM || item.type == BaseItemKind.PROGRAM || item.type == BaseItemKind.LIVE_TV_PROGRAM) {
+            viewModel.fetchProgramForDialog(item.id)
+            showProgramDialog = true
+        } else {
+            viewModel.navigationManager.navigateTo(item.destination())
+        }
     }
     val onLongClickItem = { rowIndex: Int, index: Int, item: BaseItem ->
         setPosition(RowColumn(rowIndex, index))
@@ -555,6 +566,44 @@ fun SearchPage(
             onDismissRequest = { showViewOptions = false },
         )
     }
+
+    if (showProgramDialog) {
+        val context = LocalContext.current
+        val onDismissRequest = { showProgramDialog = false }
+        ProgramDialog(
+            state = programDialogState.loading,
+            canRecord = true,
+            onDismissRequest = onDismissRequest,
+            onWatch = {
+                onDismissRequest.invoke()
+                val channelId = it.data.channelId
+                if (channelId != null) {
+                    viewModel.navigationManager.navigateTo(
+                        Destination.Playback(
+                            itemId = channelId,
+                            positionMs = 0L,
+                        ),
+                    )
+                } else {
+                    Toast.makeText(context, "Program has no channel ID", Toast.LENGTH_LONG).show()
+                }
+            },
+            onRecord = { program, series ->
+                viewModel.record(
+                    programId = program.id,
+                    series = series,
+                )
+                onDismissRequest.invoke()
+            },
+            onCancelRecord = { program, series ->
+                viewModel.cancelRecording(
+                    series = series,
+                    timerId = if (series) program.data.seriesTimerId else program.data.timerId,
+                )
+                onDismissRequest.invoke()
+            },
+        )
+    }
 }
 
 @Composable
@@ -807,65 +856,19 @@ fun LazyListScope.searchResultRow(
     },
 ) {
     item {
-        when (val r = result) {
-            is SearchResult.Error -> {
-                SearchResultPlaceholder(
-                    title = stringResource(title),
-                    message = r.ex.localizedMessage ?: "Error occurred during search",
-                    messageColor = MaterialTheme.colorScheme.error,
-                    modifier = Modifier,
-                )
-            }
-
-            SearchResult.NoQuery -> {
-                // no-op
-            }
-
-            SearchResult.Searching -> {
-                SearchResultPlaceholder(
-                    title = stringResource(title),
-                    message = stringResource(R.string.searching),
-                    modifier = modifier,
-                )
-            }
-
-            is SearchResult.Success -> {
-                if (r.items.isNotEmpty()) {
-                    ItemRow(
-                        title = stringResource(title),
-                        items = r.items,
-                        onClickItem = onClickItem,
-                        onLongClickItem = onLongClickItem,
-                        modifier = modifier.focusRequester(focusRequester),
-                        cardContent = cardContent,
-                    )
-                }
-            }
-
-            is SearchResult.SuccessSeerr -> {
-                if (r.items.isNotEmpty()) {
-                    ItemRow(
-                        title = stringResource(title),
-                        items = r.items,
-                        onClickItem = { index, item ->
-                            onClickPosition.invoke(RowColumn(rowIndex, index))
-                            onClickDiscover?.invoke(index, item)
-                        },
-                        onLongClickItem = { _, _ -> },
-                        modifier = modifier.focusRequester(focusRequester),
-                        cardContent = { index: Int, item: DiscoverItem?, mod: Modifier, onClick: () -> Unit, onLongClick: () -> Unit ->
-                            DiscoverItemCard(
-                                item = item,
-                                onClick = onClick,
-                                onLongClick = onLongClick,
-                                showOverlay = true,
-                                modifier = mod,
-                            )
-                        },
-                    )
-                }
-            }
-        }
+        SearchRowResult(
+            title = R.string.discover,
+            result = result,
+            rowIndex = SEERR_ROW,
+            position = position,
+            focusRequester = focusRequester,
+            onClickItem = onClickItem,
+            onLongClickItem = { _, _ -> },
+            onClickDiscover = onClickDiscover,
+            onClickPosition = onClickPosition,
+            cardContent = cardContent,
+            modifier = modifier,
+        )
     }
 }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
@@ -1,6 +1,5 @@
 package com.github.damontecres.wholphin.ui.search
 
-import android.view.Gravity
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
@@ -11,7 +10,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -21,11 +19,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -52,19 +48,12 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.DialogWindowProvider
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
-import androidx.tv.material3.ListItem
 import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.Switch
 import androidx.tv.material3.Text
-import androidx.tv.material3.surfaceColorAtElevation
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.DiscoverItem
@@ -88,7 +77,6 @@ import com.github.damontecres.wholphin.ui.detail.GridItemDetails
 import com.github.damontecres.wholphin.ui.detail.livetv.ProgramDialog
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.onMain
-import com.github.damontecres.wholphin.ui.preferences.SwitchColors
 import com.github.damontecres.wholphin.ui.titleStringRes
 import com.github.damontecres.wholphin.ui.tryRequestFocus
 import com.github.damontecres.wholphin.util.WholphinDispatchers
@@ -127,11 +115,12 @@ fun SearchPage(
 //    val query = rememberTextFieldState()
     var query by rememberSaveable { mutableStateOf(initialQuery) }
     val focusRequesters =
-        remember(state.searchableTypes.size) { List(RESULTS_START + state.searchableTypes.size) { FocusRequester() } }
+        remember(state.includedSearchableTypes.size) { List(RESULTS_START + state.includedSearchableTypes.size) { FocusRequester() } }
 
     val seerrActive by viewModel.seerrActive.collectAsState(initial = false)
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
     var showViewOptions by rememberSaveable { mutableStateOf(false) }
+    var showFilterTypeDialog by rememberSaveable { mutableStateOf(false) }
     var searchClicked by rememberSaveable(query) { mutableStateOf(false) }
     var immediateSearchQuery by rememberSaveable { mutableStateOf<String?>(null) }
     var showProgramDialog by remember { mutableStateOf(false) }
@@ -231,7 +220,7 @@ fun SearchPage(
                     if (combinedMode) {
                         listOf(state.combinedResults)
                     } else {
-                        state.searchableTypes.map { state.results[it] }
+                        state.includedSearchableTypes.map { state.results[it] }
                     }
                 } else {
                     listOf(state.seerrResults)
@@ -427,7 +416,7 @@ fun SearchPage(
                         verticalArrangement = Arrangement.spacedBy(0.dp),
                         modifier = Modifier.focusGroup(),
                     ) {
-                        itemsIndexed(state.searchableTypes) { index, type ->
+                        itemsIndexed(state.includedSearchableTypes) { index, type ->
                             val rowIndex = RESULTS_START + index
                             val result = state.results.getOrDefault(type, SearchResult.Searching)
                             SearchRowResult(
@@ -482,7 +471,17 @@ fun SearchPage(
             onCombinedResultsChange = viewModel::setCombinedResults,
             voiceSearchButtonVisible = voiceSearchButtonVisible,
             onVoiceSearchButtonVisibleChange = viewModel::setVoiceSearchButtonVisible,
+            onClickFilterTypes = { showFilterTypeDialog = true },
             onDismissRequest = { showViewOptions = false },
+        )
+    }
+
+    if (showFilterTypeDialog) {
+        SearchTypeOptionsDialog(
+            onDismissRequest = { showFilterTypeDialog = false },
+            searchableTypes = state.possibleSearchableTypes,
+            excludedSearchableTypes = state.excludedSearchableTypes,
+            onClick = viewModel::onClickExcludeSearchableType,
         )
     }
 
@@ -522,91 +521,6 @@ fun SearchPage(
                 onDismissRequest.invoke()
             },
         )
-    }
-}
-
-@Composable
-fun SearchViewOptionsDialog(
-    combinedResults: Boolean,
-    onCombinedResultsChange: (Boolean) -> Unit,
-    voiceSearchButtonVisible: Boolean,
-    onVoiceSearchButtonVisibleChange: (Boolean) -> Unit,
-    onDismissRequest: () -> Unit,
-) {
-    Dialog(
-        onDismissRequest = onDismissRequest,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-    ) {
-        val dialogWindowProvider = LocalView.current.parent as? DialogWindowProvider
-        dialogWindowProvider?.window?.setGravity(Gravity.CENTER)
-
-        Box(
-            modifier =
-                Modifier
-                    .width(400.dp)
-                    .background(
-                        MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp),
-                        RoundedCornerShape(28.dp),
-                    ).padding(24.dp),
-        ) {
-            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                Text(
-                    text = stringResource(R.string.view_options),
-                    style = MaterialTheme.typography.headlineSmall,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-
-                ListItem(
-                    selected = false,
-                    headlineContent = {
-                        Text(stringResource(R.string.combined_search_results))
-                    },
-                    supportingContent = {
-                        Text(
-                            if (combinedResults) {
-                                stringResource(R.string.combined_search_results_on)
-                            } else {
-                                stringResource(R.string.combined_search_results_off)
-                            },
-                        )
-                    },
-                    trailingContent = {
-                        Switch(
-                            checked = combinedResults,
-                            onCheckedChange = onCombinedResultsChange,
-                            colors = SwitchColors(),
-                        )
-                    },
-                    onClick = { onCombinedResultsChange(!combinedResults) },
-                    modifier = Modifier.fillMaxWidth(),
-                )
-
-                ListItem(
-                    selected = false,
-                    headlineContent = {
-                        Text(stringResource(R.string.show_voice_search_button))
-                    },
-                    supportingContent = {
-                        Text(
-                            if (voiceSearchButtonVisible) {
-                                stringResource(R.string.visible_ui)
-                            } else {
-                                stringResource(R.string.hidden_ui)
-                            },
-                        )
-                    },
-                    trailingContent = {
-                        Switch(
-                            checked = voiceSearchButtonVisible,
-                            onCheckedChange = onVoiceSearchButtonVisibleChange,
-                            colors = SwitchColors(),
-                        )
-                    },
-                    onClick = { onVoiceSearchButtonVisibleChange(!voiceSearchButtonVisible) },
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-        }
     }
 }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -87,10 +88,12 @@ import com.github.damontecres.wholphin.ui.detail.GridItemDetails
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.onMain
 import com.github.damontecres.wholphin.ui.preferences.SwitchColors
+import com.github.damontecres.wholphin.ui.titleStringRes
 import com.github.damontecres.wholphin.ui.tryRequestFocus
 import com.github.damontecres.wholphin.util.WholphinDispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import org.jellyfin.sdk.model.api.BaseItemKind
 import timber.log.Timber
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -429,153 +432,85 @@ fun SearchPage(
                         verticalArrangement = Arrangement.spacedBy(0.dp),
                         modifier = Modifier.focusGroup(),
                     ) {
-                        searchResultRow(
-                            title = R.string.movies_title,
-                            result = state.movies,
-                            rowIndex = MOVIE_ROW,
-                            position = position,
-                            focusRequester = focusRequesters[MOVIE_ROW],
-                            onClickItem = onClickItem,
-                            onLongClickItem = { index, item ->
-                                onLongClickItem(MOVIE_ROW, index, item)
-                            },
-                            onClickPosition = { setPosition(it) },
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        searchResultRow(
-                            title = R.string.tv_shows_title,
-                            result = state.series,
-                            rowIndex = SERIES_ROW,
-                            position = position,
-                            focusRequester = focusRequesters[SERIES_ROW],
-                            onClickItem = onClickItem,
-                            onLongClickItem = { index, item ->
-                                onLongClickItem(SERIES_ROW, index, item)
-                            },
-                            onClickPosition = { setPosition(it) },
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        searchResultRow(
-                            title = R.string.episodes,
-                            result = state.episodes,
-                            rowIndex = EPISODE_ROW,
-                            position = position,
-                            focusRequester = focusRequesters[EPISODE_ROW],
-                            onClickItem = onClickItem,
-                            onLongClickItem = { index, item ->
-                                onLongClickItem(EPISODE_ROW, index, item)
-                            },
-                            onClickPosition = { setPosition(it) },
-                            modifier = Modifier.fillMaxWidth(),
-                            cardContent = @Composable { index, item, mod, onClick, onLongClick ->
-                                BannerCardWithTitle(
-                                    title = item?.title,
-                                    subtitle = item?.subtitle,
-                                    item = item,
-                                    onClick = {
-                                        setPosition(RowColumn(EPISODE_ROW, index))
-                                        onClick.invoke()
-                                    },
-                                    onLongClick = onLongClick,
-                                    modifier = mod.padding(horizontal = 8.dp),
-                                    cardHeight = Cards.heightEpisode,
-                                )
-                            },
-                        )
-                        searchResultRow(
-                            title = R.string.collections,
-                            result = state.collections,
-                            rowIndex = COLLECTION_ROW,
-                            position = position,
-                            focusRequester = focusRequesters[COLLECTION_ROW],
-                            onClickItem = onClickItem,
-                            onLongClickItem = { index, item ->
-                                onLongClickItem(COLLECTION_ROW, index, item)
-                            },
-                            onClickPosition = { setPosition(it) },
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                        searchResultRow(
-                            title = R.string.albums,
-                            result = state.albums,
-                            rowIndex = ALBUM_ROW,
-                            position = position,
-                            focusRequester = focusRequesters[ALBUM_ROW],
-                            onClickItem = onClickItem,
-                            onLongClickItem = { index, item ->
-                                onLongClickItem(ALBUM_ROW, index, item)
-                            },
-                            onClickPosition = { setPosition(it) },
-                            modifier = Modifier.fillMaxWidth(),
-                            cardContent = { index, item, mod, onClick, onLongClick ->
-                                SeasonCard(
-                                    item = item,
-                                    onClick = {
-                                        setPosition(RowColumn(ALBUM_ROW, index))
-                                        onClick.invoke()
-                                    },
-                                    onLongClick = onLongClick,
-                                    imageHeight = Cards.heightEpisode,
-                                    aspectRatio = AspectRatios.SQUARE,
-                                    showImageOverlay = true,
-                                    modifier = mod,
-                                )
-                            },
-                        )
-                        searchResultRow(
-                            title = R.string.artists,
-                            result = state.artists,
-                            rowIndex = ARTIST_ROW,
-                            position = position,
-                            focusRequester = focusRequesters[ARTIST_ROW],
-                            onClickItem = onClickItem,
-                            onLongClickItem = { index, item ->
-                                onLongClickItem(ARTIST_ROW, index, item)
-                            },
-                            onClickPosition = { setPosition(it) },
-                            modifier = Modifier.fillMaxWidth(),
-                            cardContent = { index, item, mod, onClick, onLongClick ->
-                                SeasonCard(
-                                    item = item,
-                                    onClick = {
-                                        setPosition(RowColumn(ARTIST_ROW, index))
-                                        onClick.invoke()
-                                    },
-                                    onLongClick = onLongClick,
-                                    imageHeight = Cards.heightEpisode,
-                                    aspectRatio = AspectRatios.SQUARE,
-                                    showImageOverlay = true,
-                                    modifier = mod,
-                                )
-                            },
-                        )
-                        searchResultRow(
-                            title = R.string.songs,
-                            result = state.songs,
-                            rowIndex = SONG_ROW,
-                            position = position,
-                            focusRequester = focusRequesters[SONG_ROW],
-                            onClickItem = onClickItem,
-                            onLongClickItem = { index, item ->
-                                onLongClickItem(SONG_ROW, index, item)
-                            },
-                            onClickPosition = { setPosition(it) },
-                            modifier = Modifier.fillMaxWidth(),
-                            cardContent = { index, item, mod, onClick, onLongClick ->
-                                SeasonCard(
-                                    item = item,
-                                    onClick = {
-                                        setPosition(RowColumn(SONG_ROW, index))
-                                        onClick.invoke()
-                                    },
-                                    onLongClick = onLongClick,
-                                    imageHeight = Cards.heightEpisode,
-                                    aspectRatio = AspectRatios.SQUARE,
-                                    showImageOverlay = true,
-                                    modifier = mod,
-                                )
-                            },
-                        )
+                        itemsIndexed(searchableTypes) { rowIndex, type ->
+                            val cardContent: @Composable (
+                                index: Int,
+                                item: BaseItem?,
+                                modifier: Modifier,
+                                onClick: () -> Unit,
+                                onLongClick: () -> Unit,
+                            ) -> Unit =
+                                when (type) {
+                                    BaseItemKind.EPISODE -> {
+                                        { index, item, mod, onClick, onLongClick ->
+                                            BannerCardWithTitle(
+                                                title = item?.title,
+                                                subtitle = item?.subtitle,
+                                                item = item,
+                                                onClick = {
+                                                    setPosition(RowColumn(EPISODE_ROW, index))
+                                                    onClick.invoke()
+                                                },
+                                                onLongClick = onLongClick,
+                                                modifier = mod.padding(horizontal = 8.dp),
+                                                cardHeight = Cards.heightEpisode,
+                                            )
+                                        }
+                                    }
+
+                                    BaseItemKind.MUSIC_ALBUM,
+                                    BaseItemKind.MUSIC_ARTIST,
+                                    BaseItemKind.AUDIO,
+                                    -> {
+                                        { index, item, mod, onClick, onLongClick ->
+                                            SeasonCard(
+                                                item = item,
+                                                onClick = {
+                                                    setPosition(RowColumn(ALBUM_ROW, index))
+                                                    onClick.invoke()
+                                                },
+                                                onLongClick = onLongClick,
+                                                imageHeight = Cards.heightEpisode,
+                                                aspectRatio = AspectRatios.SQUARE,
+                                                showImageOverlay = true,
+                                                modifier = mod,
+                                            )
+                                        }
+                                    }
+
+                                    else -> {
+                                        { index, item, mod, onClick, onLongClick ->
+                                            SeasonCard(
+                                                item = item,
+                                                onClick = {
+                                                    setPosition(RowColumn(ALBUM_ROW, index))
+                                                    onClick.invoke()
+                                                },
+                                                onLongClick = onLongClick,
+                                                imageHeight = Cards.height2x3,
+                                                showImageOverlay = true,
+                                                modifier = mod,
+                                            )
+                                        }
+                                    }
+                                }
+                            val result = state.results.getOrDefault(type, SearchResult.Searching)
+                            SearchRowResult(
+                                title = type.titleStringRes,
+                                result = result,
+                                rowIndex = MOVIE_ROW,
+                                position = position,
+                                focusRequester = focusRequesters[MOVIE_ROW],
+                                onClickItem = onClickItem,
+                                onLongClickItem = { index, item ->
+                                    onLongClickItem(MOVIE_ROW, index, item)
+                                },
+                                onClickPosition = { setPosition(it) },
+                                modifier = Modifier.fillMaxWidth(),
+                                cardContent = cardContent,
+                            )
+                        }
+
                         searchResultRow(
                             title = R.string.discover,
                             result = state.seerrResults,
@@ -913,6 +848,87 @@ fun LazyListScope.searchResultRow(
                         },
                     )
                 }
+            }
+        }
+    }
+}
+
+@Composable
+fun SearchRowResult(
+    @StringRes title: Int,
+    result: SearchResult,
+    rowIndex: Int,
+    position: RowColumn,
+    focusRequester: FocusRequester,
+    onClickItem: (Int, BaseItem) -> Unit,
+    onLongClickItem: (Int, BaseItem) -> Unit,
+    onClickPosition: (RowColumn) -> Unit,
+    modifier: Modifier = Modifier,
+    onClickDiscover: ((Int, DiscoverItem) -> Unit)? = null,
+    cardContent: @Composable (
+        index: Int,
+        item: BaseItem?,
+        modifier: Modifier,
+        onClick: () -> Unit,
+        onLongClick: () -> Unit,
+    ) -> Unit,
+) {
+    when (val r = result) {
+        is SearchResult.Error -> {
+            SearchResultPlaceholder(
+                title = stringResource(title),
+                message = r.ex.localizedMessage ?: "Error occurred during search",
+                messageColor = MaterialTheme.colorScheme.error,
+                modifier = Modifier,
+            )
+        }
+
+        SearchResult.NoQuery -> {
+            // no-op
+        }
+
+        SearchResult.Searching -> {
+            SearchResultPlaceholder(
+                title = stringResource(title),
+                message = stringResource(R.string.searching),
+                modifier = modifier,
+            )
+        }
+
+        is SearchResult.Success -> {
+            if (r.items.isNotEmpty()) {
+                ItemRow(
+                    title = stringResource(title),
+                    items = r.items,
+                    onClickItem = onClickItem,
+                    onLongClickItem = onLongClickItem,
+                    modifier = modifier.focusRequester(focusRequester),
+                    cardContent = cardContent,
+                )
+            }
+        }
+
+        is SearchResult.SuccessSeerr -> {
+            if (r.items.isNotEmpty()) {
+                ItemRow(
+                    title = stringResource(title),
+                    items = r.items,
+                    onClickItem = { index, item ->
+                        onClickPosition.invoke(RowColumn(rowIndex, index))
+                        onClickDiscover?.invoke(index, item)
+                    },
+                    onLongClickItem = { _, _ -> },
+                    modifier = modifier.focusRequester(focusRequester),
+                    cardContent = { index: Int, item: DiscoverItem?, mod: Modifier, onClick: () -> Unit, onLongClick: () -> Unit ->
+                        DiscoverItemCard(
+                            item = item,
+                            onClick = onClick,
+                            onLongClick = onLongClick,
+                            showOverlay = true,
+                            modifier = mod,
+                        )
+                    },
+                )
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
@@ -127,7 +127,7 @@ fun SearchPage(
 //    val query = rememberTextFieldState()
     var query by rememberSaveable { mutableStateOf(initialQuery) }
     val focusRequesters =
-        remember { List(RESULTS_START + searchableTypes.size) { FocusRequester() } }
+        remember(state.searchableTypes.size) { List(RESULTS_START + state.searchableTypes.size) { FocusRequester() } }
 
     val seerrActive by viewModel.seerrActive.collectAsState(initial = false)
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
@@ -231,7 +231,7 @@ fun SearchPage(
                     if (combinedMode) {
                         listOf(state.combinedResults)
                     } else {
-                        searchableTypes.map { state.results[it] }
+                        state.searchableTypes.map { state.results[it] }
                     }
                 } else {
                     listOf(state.seerrResults)
@@ -427,7 +427,7 @@ fun SearchPage(
                         verticalArrangement = Arrangement.spacedBy(0.dp),
                         modifier = Modifier.focusGroup(),
                     ) {
-                        itemsIndexed(searchableTypes) { index, type ->
+                        itemsIndexed(state.searchableTypes) { index, type ->
                             val rowIndex = RESULTS_START + index
                             val result = state.results.getOrDefault(type, SearchResult.Searching)
                             SearchRowResult(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -370,9 +369,9 @@ fun SearchPage(
         Box(
             modifier = Modifier.fillMaxSize(),
         ) {
-            SideEffect {
-                Timber.v("isLibraryTab=%s, combinedMode=%s", isLibraryTab, combinedMode)
-            }
+//            SideEffect {
+//                Timber.v("isLibraryTab=%s, combinedMode=%s", isLibraryTab, combinedMode)
+//            }
             when {
                 isLibraryTab && combinedMode -> {
                     SearchCombinedResults(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPage.kt
@@ -1,6 +1,5 @@
-package com.github.damontecres.wholphin.ui.main
+package com.github.damontecres.wholphin.ui.search
 
-import android.content.Context
 import android.view.Gravity
 import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
@@ -56,436 +55,57 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
-import androidx.datastore.core.DataStore
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
-import androidx.lifecycle.viewModelScope
 import androidx.tv.material3.ListItem
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Switch
 import androidx.tv.material3.Text
 import androidx.tv.material3.surfaceColorAtElevation
 import com.github.damontecres.wholphin.R
-import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.DiscoverItem
-import com.github.damontecres.wholphin.data.model.SeerrItemType
-import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.UserPreferences
-import com.github.damontecres.wholphin.preferences.updateSearchPreferences
-import com.github.damontecres.wholphin.services.FavoriteWatchManager
-import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
-import com.github.damontecres.wholphin.services.NavigationManager
-import com.github.damontecres.wholphin.services.SeerrService
-import com.github.damontecres.wholphin.services.UserPreferencesService
-import com.github.damontecres.wholphin.services.deleteItem
 import com.github.damontecres.wholphin.ui.AspectRatios
 import com.github.damontecres.wholphin.ui.Cards
-import com.github.damontecres.wholphin.ui.SlimItemFields
 import com.github.damontecres.wholphin.ui.cards.BannerCardWithTitle
 import com.github.damontecres.wholphin.ui.cards.DiscoverItemCard
 import com.github.damontecres.wholphin.ui.cards.GridCard
 import com.github.damontecres.wholphin.ui.cards.ItemRow
 import com.github.damontecres.wholphin.ui.cards.ItemRowTitle
 import com.github.damontecres.wholphin.ui.cards.SeasonCard
-import com.github.damontecres.wholphin.ui.components.ContextMenuProvider
 import com.github.damontecres.wholphin.ui.components.ExpandableFaButton
 import com.github.damontecres.wholphin.ui.components.SearchEditTextBox
 import com.github.damontecres.wholphin.ui.components.TabDetails
 import com.github.damontecres.wholphin.ui.components.TabRow
-import com.github.damontecres.wholphin.ui.components.VoiceInputManager
 import com.github.damontecres.wholphin.ui.components.VoiceSearchButton
 import com.github.damontecres.wholphin.ui.components.rememberContextMenu
 import com.github.damontecres.wholphin.ui.data.RowColumn
 import com.github.damontecres.wholphin.ui.detail.CardGrid
 import com.github.damontecres.wholphin.ui.detail.CardGridItem
 import com.github.damontecres.wholphin.ui.detail.GridItemDetails
-import com.github.damontecres.wholphin.ui.isNotNullOrBlank
-import com.github.damontecres.wholphin.ui.launchDefault
-import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.onMain
 import com.github.damontecres.wholphin.ui.preferences.SwitchColors
-import com.github.damontecres.wholphin.ui.showToast
 import com.github.damontecres.wholphin.ui.tryRequestFocus
-import com.github.damontecres.wholphin.util.ExceptionHandler
-import com.github.damontecres.wholphin.util.SearchRelevance
 import com.github.damontecres.wholphin.util.WholphinDispatchers
-import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.api.client.extensions.itemsApi
-import org.jellyfin.sdk.api.client.extensions.userLibraryApi
-import org.jellyfin.sdk.model.api.BaseItemKind
-import org.jellyfin.sdk.model.api.request.GetItemsRequest
 import timber.log.Timber
-import java.util.UUID
-import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 
-@HiltViewModel
-class SearchViewModel
-    @Inject
-    constructor(
-        @param:ApplicationContext private val context: Context,
-        val api: ApiClient,
-        val navigationManager: NavigationManager,
-        private val appPreferences: DataStore<AppPreferences>,
-        private val seerrService: SeerrService,
-        val voiceInputManager: VoiceInputManager,
-        val userPreferencesService: UserPreferencesService,
-        private val serverRepository: ServerRepository,
-        private val favoriteWatchManager: FavoriteWatchManager,
-        private val mediaManagementService: MediaManagementService,
-        private val mediaReportService: MediaReportService,
-    ) : ViewModel(),
-        ContextMenuProvider {
-        val seerrActive = seerrService.active
+internal const val SEARCH_ROW = 0
+internal const val TAB_ROW = SEARCH_ROW + 1
+internal const val MOVIE_ROW = TAB_ROW + 1
+internal const val SERIES_ROW = MOVIE_ROW + 1
+internal const val EPISODE_ROW = SERIES_ROW + 1
+internal const val COLLECTION_ROW = EPISODE_ROW + 1
+internal const val ALBUM_ROW = COLLECTION_ROW + 1
+internal const val ARTIST_ROW = ALBUM_ROW + 1
+internal const val SONG_ROW = ARTIST_ROW + 1
+internal const val SEERR_ROW = SONG_ROW + 1
 
-        private val _state = MutableStateFlow(SearchState())
-        val state: StateFlow<SearchState> = _state
-        val position = MutableStateFlow(RowColumn(0, 0))
-
-        private var currentQuery: String? = null
-        private var combinedMode = false
-
-        fun search(
-            query: String?,
-            combined: Boolean = false,
-        ) {
-            if (currentQuery == query && combinedMode == combined) {
-                return
-            }
-            currentQuery = query
-            combinedMode = combined
-            if (query.isNotNullOrBlank()) {
-                _state.update { SearchState.searchingState }
-                if (combined) {
-                    searchCombined(query)
-                } else {
-                    searchInternal(
-                        query,
-                        BaseItemKind.MOVIE,
-                    ) { result, state -> state.copy(movies = result) }
-                    searchInternal(
-                        query,
-                        BaseItemKind.SERIES,
-                    ) { result, state -> state.copy(series = result) }
-                    searchInternal(query, BaseItemKind.EPISODE) { result, state ->
-                        state.copy(
-                            episodes = result,
-                        )
-                    }
-                    searchInternal(query, BaseItemKind.BOX_SET) { result, state ->
-                        state.copy(
-                            collections = result,
-                        )
-                    }
-                    searchInternal(query, BaseItemKind.MUSIC_ALBUM) { result, state ->
-                        state.copy(
-                            albums = result,
-                        )
-                    }
-                    searchInternal(query, BaseItemKind.MUSIC_ARTIST) { result, state ->
-                        state.copy(
-                            artists = result,
-                        )
-                    }
-                    searchInternal(
-                        query,
-                        BaseItemKind.AUDIO,
-                    ) { result, state -> state.copy(songs = result) }
-                }
-                searchSeerr(query)
-            } else {
-                _state.update { SearchState() }
-            }
-        }
-
-        private fun searchInternal(
-            query: String,
-            type: BaseItemKind,
-            update: (SearchResult, SearchState) -> SearchState,
-        ) {
-            viewModelScope.launchIO {
-                try {
-                    val request =
-                        GetItemsRequest(
-                            searchTerm = query,
-                            recursive = true,
-                            includeItemTypes = listOf(type),
-                            fields = SlimItemFields,
-                            limit = 50,
-                        )
-                    val result = api.itemsApi.getItems(request).content
-                    val items =
-                        result.items.map {
-                            BaseItem(it, false)
-                        }
-                    val sorted =
-                        items.sortedWith(
-                            compareBy<BaseItem> { SearchRelevance.score(it, query) }
-                                .thenBy { it.sortName },
-                        )
-                    _state.update { update.invoke(SearchResult.Success(sorted), it) }
-                } catch (ex: CancellationException) {
-                    throw ex
-                } catch (ex: Exception) {
-                    Timber.e(ex, "Exception searching for $type")
-                    _state.update { update.invoke(SearchResult.Error(ex), it) }
-                }
-            }
-        }
-
-        private fun searchCombined(query: String) {
-            viewModelScope.launch(ExceptionHandler() + WholphinDispatchers.IO) {
-                try {
-                    val request =
-                        GetItemsRequest(
-                            searchTerm = query,
-                            recursive = true,
-                            includeItemTypes =
-                                listOf(
-                                    BaseItemKind.MOVIE,
-                                    BaseItemKind.SERIES,
-                                    BaseItemKind.BOX_SET,
-                                ),
-                            fields = SlimItemFields,
-                            limit = 50,
-                        )
-
-                    val result = api.itemsApi.getItems(request).content
-                    val items =
-                        result.items.map {
-                            BaseItem(it, false)
-                        }
-                    val sorted =
-                        items.sortedWith(
-                            compareBy<BaseItem> { SearchRelevance.score(it, query) }
-                                .thenBy { it.name ?: "" },
-                        )
-                    _state.update { it.copy(combinedResults = SearchResult.Success(sorted)) }
-                } catch (ex: Exception) {
-                    Timber.e(ex, "Exception in combined search")
-                    _state.update { it.copy(combinedResults = SearchResult.Error(ex)) }
-                }
-            }
-        }
-
-        fun setCombinedResults(enabled: Boolean) {
-            viewModelScope.launchIO {
-                appPreferences.updateData {
-                    it.updateSearchPreferences {
-                        combinedSearchResults = enabled
-                    }
-                }
-            }
-        }
-
-        fun setVoiceSearchButtonVisible(visible: Boolean) {
-            viewModelScope.launchIO {
-                appPreferences.updateData {
-                    it.updateSearchPreferences {
-                        showVoiceSearchButton = visible
-                    }
-                }
-            }
-        }
-
-        private fun searchSeerr(query: String) {
-            viewModelScope.launchIO {
-                if (seerrService.active.first()) {
-                    _state.update { it.copy(seerrResults = SearchResult.Searching) }
-                    val results =
-                        seerrService
-                            .search(query)
-                            .map { seerrService.createDiscoverItem(it) }
-                            .filter { it.type == SeerrItemType.MOVIE || it.type == SeerrItemType.TV }
-                    _state.update { it.copy(seerrResults = SearchResult.SuccessSeerr(results)) }
-                }
-            }
-        }
-
-        init {
-            addCloseable(voiceInputManager)
-        }
-
-        override fun navigateTo(destination: Destination) {
-            navigationManager.navigateTo(destination)
-        }
-
-        override fun canDelete(
-            item: BaseItem,
-            appPreferences: AppPreferences,
-        ): Boolean = mediaManagementService.canDelete(item, appPreferences)
-
-        override fun deleteItem(
-            index: Int,
-            item: BaseItem,
-        ) {
-            deleteItem(context, mediaManagementService, item) {
-                viewModelScope.launchDefault {
-                    refreshItem(item.id)
-                }
-            }
-        }
-
-        private suspend fun refreshItem(itemId: UUID) {
-            try {
-                val position = position.value
-                val searchResult =
-                    if (combinedMode) {
-                        state.value.combinedResults
-                    } else {
-                        when (position.row) {
-                            MOVIE_ROW -> state.value.movies
-                            SERIES_ROW -> state.value.series
-                            EPISODE_ROW -> state.value.episodes
-                            COLLECTION_ROW -> state.value.collections
-                            ALBUM_ROW -> state.value.albums
-                            ARTIST_ROW -> state.value.artists
-                            SONG_ROW -> state.value.songs
-                            SEERR_ROW -> null
-                            else -> null
-                        }
-                    } ?: return
-                val items = (searchResult as? SearchResult.Success)?.items ?: return
-
-                Timber.v("Item refresh: position=%s", position)
-                val item = items.getOrNull(position.column)
-                // Exact item deleted (eg a movie) or deleted item was within the series
-                if (item != null && item.id == itemId) {
-                    val newItem =
-                        api.userLibraryApi
-                            .getItem(item.id)
-                            .content
-                            .let { BaseItem(it) }
-                    val newList =
-                        SearchResult.Success(
-                            items.toMutableList().apply {
-                                set(position.column, newItem)
-                            },
-                        )
-                    _state.update {
-                        if (combinedMode) {
-                            it.copy(
-                                combinedResults = newList,
-                            )
-                        } else {
-                            when (position.row) {
-                                MOVIE_ROW -> it.copy(movies = newList)
-                                SERIES_ROW -> it.copy(series = newList)
-                                EPISODE_ROW -> it.copy(episodes = newList)
-                                COLLECTION_ROW -> it.copy(collections = newList)
-                                ALBUM_ROW -> it.copy(albums = newList)
-                                ARTIST_ROW -> it.copy(artists = newList)
-                                SONG_ROW -> it.copy(songs = newList)
-                                SEERR_ROW -> it
-                                else -> it
-                            }
-                        }
-                    }
-                }
-            } catch (ex: Exception) {
-                Timber.e(ex, "Error refreshing item %s", itemId)
-                showToast(context, "Error refreshing")
-            }
-        }
-
-        override fun setWatched(
-            position: Int,
-            itemId: UUID,
-            played: Boolean,
-        ) {
-            viewModelScope.launch(ExceptionHandler() + WholphinDispatchers.IO) {
-                favoriteWatchManager.setWatched(itemId, played)
-                refreshItem(itemId)
-            }
-        }
-
-        override fun setFavorite(
-            position: Int,
-            itemId: UUID,
-            favorite: Boolean,
-        ) {
-            viewModelScope.launch(ExceptionHandler() + WholphinDispatchers.IO) {
-                favoriteWatchManager.setFavorite(itemId, favorite)
-                refreshItem(itemId)
-            }
-        }
-
-        override fun isAdministrator(): Boolean = serverRepository.currentUserDto?.policy?.isAdministrator == true
-
-        override fun sendReportFor(itemId: UUID) = mediaReportService.sendReportFor(itemId)
-    }
-
-sealed interface SearchResult {
-    data object NoQuery : SearchResult
-
-    data object Searching : SearchResult
-
-    data class Error(
-        val ex: Exception,
-    ) : SearchResult
-
-    data class Success(
-        val items: List<BaseItem?>,
-    ) : SearchResult
-
-    data class SuccessSeerr(
-        val items: List<DiscoverItem>,
-    ) : SearchResult
-}
-
-data class SearchState(
-    val movies: SearchResult = SearchResult.NoQuery,
-    val series: SearchResult = SearchResult.NoQuery,
-    val episodes: SearchResult = SearchResult.NoQuery,
-    val collections: SearchResult = SearchResult.NoQuery,
-    val albums: SearchResult = SearchResult.NoQuery,
-    val artists: SearchResult = SearchResult.NoQuery,
-    val songs: SearchResult = SearchResult.NoQuery,
-    val seerrResults: SearchResult = SearchResult.NoQuery,
-    val combinedResults: SearchResult = SearchResult.NoQuery,
-) {
-    companion object {
-        val searchingState =
-            SearchState(
-                movies = SearchResult.Searching,
-                series = SearchResult.Searching,
-                episodes = SearchResult.Searching,
-                collections = SearchResult.Searching,
-                albums = SearchResult.Searching,
-                artists = SearchResult.Searching,
-                songs = SearchResult.Searching,
-                seerrResults = SearchResult.Searching,
-                combinedResults = SearchResult.Searching,
-            )
-    }
-}
-
-private const val SEARCH_ROW = 0
-private const val TAB_ROW = SEARCH_ROW + 1
-private const val MOVIE_ROW = TAB_ROW + 1
-private const val SERIES_ROW = MOVIE_ROW + 1
-private const val EPISODE_ROW = SERIES_ROW + 1
-private const val COLLECTION_ROW = EPISODE_ROW + 1
-private const val ALBUM_ROW = COLLECTION_ROW + 1
-private const val ARTIST_ROW = ALBUM_ROW + 1
-private const val SONG_ROW = ARTIST_ROW + 1
-private const val SEERR_ROW = SONG_ROW + 1
-
-private const val COMBINED_ROW = TAB_ROW + 1
+internal const val COMBINED_ROW = TAB_ROW + 1
 
 @Composable
 fun SearchPage(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPageCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchPageCard.kt
@@ -1,0 +1,149 @@
+package com.github.damontecres.wholphin.ui.search
+
+import android.text.format.DateUtils
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.github.damontecres.wholphin.data.model.BaseItem
+import com.github.damontecres.wholphin.ui.AspectRatios
+import com.github.damontecres.wholphin.ui.Cards
+import com.github.damontecres.wholphin.ui.LocalImageUrlService
+import com.github.damontecres.wholphin.ui.cards.BannerCardWithTitle
+import com.github.damontecres.wholphin.ui.cards.PersonCard
+import com.github.damontecres.wholphin.ui.cards.SeasonCard
+import com.github.damontecres.wholphin.ui.cards.personRowCardWidth
+import com.github.damontecres.wholphin.ui.cards.rememberImageUrl
+import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.ImageType
+import java.time.OffsetDateTime
+
+@Composable
+fun SearchPageCard(
+    item: BaseItem?,
+    type: BaseItemKind,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    when (type) {
+        BaseItemKind.EPISODE -> {
+            BannerCardWithTitle(
+                title = item?.title,
+                subtitle = item?.subtitle,
+                item = item,
+                onClick = onClick,
+                onLongClick = onLongClick,
+                modifier = modifier.padding(horizontal = 8.dp),
+                cardHeight = Cards.heightEpisode,
+            )
+        }
+
+        BaseItemKind.MUSIC_ALBUM,
+        BaseItemKind.MUSIC_ARTIST,
+        BaseItemKind.AUDIO,
+        -> {
+            SeasonCard(
+                item = item,
+                onClick = onClick,
+                onLongClick = onLongClick,
+                imageHeight = Cards.heightEpisode,
+                aspectRatio = AspectRatios.SQUARE,
+                showImageOverlay = true,
+                modifier = modifier,
+            )
+        }
+
+        BaseItemKind.PERSON -> {
+            val imageUrlService = LocalImageUrlService.current
+            val imageUrl =
+                remember(item) {
+                    imageUrlService.getItemImageUrl(
+                        item,
+                        ImageType.PRIMARY,
+                    )
+                }
+            PersonCard(
+                name = item?.name ?: "",
+                role = null,
+                imageUrl = imageUrl,
+                favorite = item?.favorite ?: false,
+                onClick = onClick,
+                onLongClick = onLongClick,
+                modifier = modifier.width(personRowCardWidth),
+            )
+        }
+
+        BaseItemKind.TV_CHANNEL -> {
+            SeasonCard(
+                item = item,
+                onClick = onClick,
+                onLongClick = onLongClick,
+                imageHeight = Cards.HEIGHT_LIVE_TV.dp,
+                showImageOverlay = true,
+                aspectRatio = AspectRatios.WIDE,
+                modifier = modifier,
+            )
+        }
+
+        BaseItemKind.PROGRAM,
+        BaseItemKind.TV_PROGRAM,
+        BaseItemKind.LIVE_TV_PROGRAM,
+        -> {
+            val subtitle =
+                remember(item) {
+                    val startDate = item?.data?.startDate
+                    val endDate = item?.data?.endDate
+                    if (startDate != null && endDate != null) {
+                        DateUtils.formatDateRange(
+                            context,
+                            startDate
+                                .toInstant(OffsetDateTime.now().offset)
+                                .epochSecond * 1000,
+                            endDate
+                                .toInstant(OffsetDateTime.now().offset)
+                                .epochSecond * 1000,
+                            DateUtils.FORMAT_SHOW_TIME or DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_SHOW_WEEKDAY,
+                        )
+                    } else {
+                        null
+                    }
+                }
+
+            SeasonCard(
+                title = item?.title,
+                subtitle = subtitle,
+                name = item?.name,
+                imageUrl = rememberImageUrl(item, Cards.HEIGHT_LIVE_TV.dp, Dp.Unspecified),
+                isFavorite = item?.data?.userData?.isFavorite ?: false,
+                isPlayed = item?.data?.userData?.played ?: false,
+                unplayedItemCount = item?.data?.userData?.unplayedItemCount ?: 0,
+                playedPercentage = item?.data?.userData?.playedPercentage ?: 0.0,
+                numberOfVersions = item?.data?.mediaSourceCount ?: 0,
+                onClick = onClick,
+                onLongClick = onLongClick,
+                modifier = modifier,
+                imageHeight = Cards.HEIGHT_LIVE_TV.dp,
+                imageWidth = Dp.Unspecified,
+                showImageOverlay = true,
+                aspectRatio = AspectRatios.WIDE,
+            )
+        }
+
+        else -> {
+            SeasonCard(
+                item = item,
+                onClick = onClick,
+                onLongClick = onLongClick,
+                imageHeight = Cards.height2x3,
+                showImageOverlay = true,
+                modifier = modifier,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchTypeOptionsDialog.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchTypeOptionsDialog.kt
@@ -23,7 +23,10 @@ fun SearchTypeOptionsDialog(
     onDismissRequest: () -> Unit,
     searchableTypes: List<BaseItemKind>,
     excludedSearchableTypes: List<BaseItemKind>,
+    discoverAvailable: Boolean,
+    discoverEnabled: Boolean,
     onClick: (BaseItemKind) -> Unit,
+    onClickDiscover: () -> Unit,
 ) {
     BasicDialog(
         onDismissRequest = onDismissRequest,
@@ -32,7 +35,10 @@ fun SearchTypeOptionsDialog(
         SearchTypeOptionsDialogContent(
             searchableTypes = searchableTypes,
             excludedSearchableTypes = excludedSearchableTypes,
+            discoverAvailable = discoverAvailable,
+            discoverEnabled = discoverEnabled,
             onClick = onClick,
+            onClickDiscover = onClickDiscover,
             modifier = Modifier.padding(16.dp),
         )
     }
@@ -42,7 +48,10 @@ fun SearchTypeOptionsDialog(
 fun SearchTypeOptionsDialogContent(
     searchableTypes: List<BaseItemKind>,
     excludedSearchableTypes: List<BaseItemKind>,
+    discoverAvailable: Boolean,
+    discoverEnabled: Boolean,
     onClick: (BaseItemKind) -> Unit,
+    onClickDiscover: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -66,6 +75,25 @@ fun SearchTypeOptionsDialogContent(
                         )
                     },
                 )
+            }
+            if (discoverAvailable) {
+                item {
+                    ListItem(
+                        enabled = true,
+                        selected = false,
+                        onClick = onClickDiscover,
+                        headlineContent = {
+                            Text(stringResource(R.string.discover))
+                        },
+                        trailingContent = {
+                            Switch(
+                                checked = discoverEnabled,
+                                onCheckedChange = {},
+                                colors = SwitchColors(),
+                            )
+                        },
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchTypeOptionsDialog.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchTypeOptionsDialog.kt
@@ -1,0 +1,72 @@
+package com.github.damontecres.wholphin.ui.search
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.ListItem
+import androidx.tv.material3.Switch
+import androidx.tv.material3.Text
+import com.github.damontecres.wholphin.R
+import com.github.damontecres.wholphin.ui.components.BasicDialog
+import com.github.damontecres.wholphin.ui.main.settings.TitleText
+import com.github.damontecres.wholphin.ui.preferences.SwitchColors
+import com.github.damontecres.wholphin.ui.titleStringRes
+import org.jellyfin.sdk.model.api.BaseItemKind
+
+@Composable
+fun SearchTypeOptionsDialog(
+    onDismissRequest: () -> Unit,
+    searchableTypes: List<BaseItemKind>,
+    excludedSearchableTypes: List<BaseItemKind>,
+    onClick: (BaseItemKind) -> Unit,
+) {
+    BasicDialog(
+        onDismissRequest = onDismissRequest,
+        elevation = 3.dp,
+    ) {
+        SearchTypeOptionsDialogContent(
+            searchableTypes = searchableTypes,
+            excludedSearchableTypes = excludedSearchableTypes,
+            onClick = onClick,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Composable
+fun SearchTypeOptionsDialogContent(
+    searchableTypes: List<BaseItemKind>,
+    excludedSearchableTypes: List<BaseItemKind>,
+    onClick: (BaseItemKind) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier) {
+        TitleText(stringResource(R.string.include_types))
+
+        LazyColumn {
+            items(searchableTypes) { searchableType ->
+                val checked = searchableType !in excludedSearchableTypes
+                ListItem(
+                    enabled = true,
+                    selected = false,
+                    onClick = { onClick.invoke(searchableType) },
+                    headlineContent = {
+                        Text(stringResource(searchableType.titleStringRes))
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = checked,
+                            onCheckedChange = {},
+                            colors = SwitchColors(),
+                        )
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -30,6 +30,7 @@ import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.showToast
+import com.github.damontecres.wholphin.ui.toBaseItems
 import com.github.damontecres.wholphin.util.DataLoadingState
 import com.github.damontecres.wholphin.util.ExceptionHandler
 import com.github.damontecres.wholphin.util.SearchRelevance
@@ -43,7 +44,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.artistsApi
 import org.jellyfin.sdk.api.client.extensions.itemsApi
+import org.jellyfin.sdk.api.client.extensions.personsApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
 import org.jellyfin.sdk.model.api.BaseItemKind
 import org.jellyfin.sdk.model.api.request.GetItemsRequest
@@ -131,12 +134,29 @@ class SearchViewModel
                                         recursive = true,
                                         includeItemTypes = listOf(type),
                                         fields = ProgramItemFields,
-                                        limit = 50,
+                                        limit = SEARCH_LIMIT,
                                         enableTotalRecordCount = false,
                                     )
-                                api.itemsApi.getItems(request).content.items.map {
-                                    BaseItem(it, false)
-                                }
+                                api.itemsApi.getItems(request).toBaseItems(api, false)
+                            }
+
+                            BaseItemKind.MUSIC_ARTIST -> {
+                                api.artistsApi
+                                    .getArtists(
+                                        searchTerm = query,
+                                        fields = SlimItemFields,
+                                        limit = SEARCH_LIMIT,
+                                        enableTotalRecordCount = false,
+                                    ).toBaseItems(api, false)
+                            }
+
+                            BaseItemKind.PERSON -> {
+                                api.personsApi
+                                    .getPersons(
+                                        searchTerm = query,
+                                        fields = SlimItemFields,
+                                        limit = SEARCH_LIMIT,
+                                    ).toBaseItems(api, false)
                             }
 
                             else -> {
@@ -146,12 +166,10 @@ class SearchViewModel
                                         recursive = true,
                                         includeItemTypes = listOf(type),
                                         fields = SlimItemFields,
-                                        limit = 50,
+                                        limit = SEARCH_LIMIT,
                                         enableTotalRecordCount = false,
                                     )
-                                api.itemsApi.getItems(request).content.items.map {
-                                    BaseItem(it, false)
-                                }
+                                api.itemsApi.getItems(request).toBaseItems(api, false)
                             }
                         }
                     val sorted =
@@ -440,3 +458,5 @@ val searchableTypes =
         BaseItemKind.PLAYLIST,
         BaseItemKind.VIDEO,
     )
+
+private const val SEARCH_LIMIT = 50

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -19,6 +19,7 @@ import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.SeerrService
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.services.deleteItem
+import com.github.damontecres.wholphin.ui.ProgramItemFields
 import com.github.damontecres.wholphin.ui.SlimItemFields
 import com.github.damontecres.wholphin.ui.components.ContextMenuProvider
 import com.github.damontecres.wholphin.ui.components.VoiceInputManager
@@ -121,18 +122,37 @@ class SearchViewModel
         ) {
             viewModelScope.launchIO {
                 try {
-                    val request =
-                        GetItemsRequest(
-                            searchTerm = query,
-                            recursive = true,
-                            includeItemTypes = listOf(type),
-                            fields = SlimItemFields,
-                            limit = 50,
-                        )
-                    val result = api.itemsApi.getItems(request).content
-                    val items =
-                        result.items.map {
-                            BaseItem(it, false)
+                    val items: List<BaseItem> =
+                        when (type) {
+                            BaseItemKind.LIVE_TV_PROGRAM -> {
+                                val request =
+                                    GetItemsRequest(
+                                        searchTerm = query,
+                                        recursive = true,
+                                        includeItemTypes = listOf(type),
+                                        fields = ProgramItemFields,
+                                        limit = 50,
+                                        enableTotalRecordCount = false,
+                                    )
+                                api.itemsApi.getItems(request).content.items.map {
+                                    BaseItem(it, false)
+                                }
+                            }
+
+                            else -> {
+                                val request =
+                                    GetItemsRequest(
+                                        searchTerm = query,
+                                        recursive = true,
+                                        includeItemTypes = listOf(type),
+                                        fields = SlimItemFields,
+                                        limit = 50,
+                                        enableTotalRecordCount = false,
+                                    )
+                                api.itemsApi.getItems(request).content.items.map {
+                                    BaseItem(it, false)
+                                }
+                            }
                         }
                     val sorted =
                         items.sortedWith(
@@ -412,7 +432,7 @@ val searchableTypes =
         BaseItemKind.BOX_SET,
         BaseItemKind.PERSON,
         BaseItemKind.TV_CHANNEL,
-        BaseItemKind.TV_PROGRAM,
+        BaseItemKind.LIVE_TV_PROGRAM,
         BaseItemKind.MUSIC_ALBUM,
         BaseItemKind.MUSIC_ARTIST,
         BaseItemKind.AUDIO,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -473,6 +473,8 @@ private val allSearchableTypes =
         BaseItemKind.MUSIC_VIDEO,
         BaseItemKind.PLAYLIST,
         BaseItemKind.VIDEO,
+        BaseItemKind.PHOTO,
+        BaseItemKind.PHOTO_ALBUM,
     )
 
 private const val SEARCH_LIMIT = 50

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -1,6 +1,7 @@
 package com.github.damontecres.wholphin.ui.search
 
 import android.content.Context
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.datastore.core.DataStore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -72,6 +73,17 @@ class SearchViewModel
         private var currentQuery: String? = null
         private var combinedMode = false
 
+        init {
+            init()
+        }
+
+        private fun init() {
+            _state.update { SearchState() }
+            searchableTypes.forEach {
+                state.value.results[it] = SearchResult.NoQuery
+            }
+        }
+
         fun search(
             query: String?,
             combined: Boolean = false,
@@ -86,42 +98,13 @@ class SearchViewModel
                 if (combined) {
                     searchCombined(query)
                 } else {
-                    searchInternal(
-                        query,
-                        BaseItemKind.MOVIE,
-                    ) { result, state -> state.copy(movies = result) }
-                    searchInternal(
-                        query,
-                        BaseItemKind.SERIES,
-                    ) { result, state -> state.copy(series = result) }
-                    searchInternal(query, BaseItemKind.EPISODE) { result, state ->
-                        state.copy(
-                            episodes = result,
-                        )
+                    searchableTypes.forEach { type ->
+                        searchInternal2(query, type)
                     }
-                    searchInternal(query, BaseItemKind.BOX_SET) { result, state ->
-                        state.copy(
-                            collections = result,
-                        )
-                    }
-                    searchInternal(query, BaseItemKind.MUSIC_ALBUM) { result, state ->
-                        state.copy(
-                            albums = result,
-                        )
-                    }
-                    searchInternal(query, BaseItemKind.MUSIC_ARTIST) { result, state ->
-                        state.copy(
-                            artists = result,
-                        )
-                    }
-                    searchInternal(
-                        query,
-                        BaseItemKind.AUDIO,
-                    ) { result, state -> state.copy(songs = result) }
                 }
                 searchSeerr(query)
             } else {
-                _state.update { SearchState() }
+                init()
             }
         }
 
@@ -156,6 +139,41 @@ class SearchViewModel
                 } catch (ex: Exception) {
                     Timber.e(ex, "Exception searching for $type")
                     _state.update { update.invoke(SearchResult.Error(ex), it) }
+                }
+            }
+        }
+
+        private fun searchInternal2(
+            query: String,
+            type: BaseItemKind,
+        ) {
+            viewModelScope.launchIO {
+                try {
+                    val request =
+                        GetItemsRequest(
+                            searchTerm = query,
+                            recursive = true,
+                            includeItemTypes = listOf(type),
+                            fields = SlimItemFields,
+                            limit = 50,
+                        )
+                    val result = api.itemsApi.getItems(request).content
+                    val items =
+                        result.items.map {
+                            BaseItem(it, false)
+                        }
+                    val sorted =
+                        items.sortedWith(
+                            compareBy<BaseItem> { SearchRelevance.score(it, query) }
+                                .thenBy { it.sortName },
+                        )
+                    Timber.v("Search finished for %s, %s results", type, sorted.size)
+                    _state.value.results[type] = SearchResult.Success(sorted)
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Exception searching for $type")
+                    _state.value.results[type] = SearchResult.Error(ex)
                 }
             }
         }
@@ -370,6 +388,7 @@ data class SearchState(
     val songs: SearchResult = SearchResult.NoQuery,
     val seerrResults: SearchResult = SearchResult.NoQuery,
     val combinedResults: SearchResult = SearchResult.NoQuery,
+    val results: SnapshotStateMap<BaseItemKind, SearchResult> = SnapshotStateMap(),
 ) {
     companion object {
         val searchingState =
@@ -386,3 +405,20 @@ data class SearchState(
             )
     }
 }
+
+val searchableTypes =
+    listOf(
+        BaseItemKind.MOVIE,
+        BaseItemKind.SERIES,
+        BaseItemKind.EPISODE,
+        BaseItemKind.BOX_SET,
+        BaseItemKind.PERSON,
+        BaseItemKind.TV_CHANNEL,
+        BaseItemKind.TV_PROGRAM,
+        BaseItemKind.MUSIC_ALBUM,
+        BaseItemKind.MUSIC_ARTIST,
+        BaseItemKind.AUDIO,
+        BaseItemKind.MUSIC_VIDEO,
+        BaseItemKind.PLAYLIST,
+        BaseItemKind.VIDEO,
+    )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -16,6 +16,7 @@ import com.github.damontecres.wholphin.services.KeyValueService
 import com.github.damontecres.wholphin.services.LiveTvService
 import com.github.damontecres.wholphin.services.MediaManagementService
 import com.github.damontecres.wholphin.services.MediaReportService
+import com.github.damontecres.wholphin.services.NavDrawerService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.SeerrService
 import com.github.damontecres.wholphin.services.UserPreferencesService
@@ -25,6 +26,7 @@ import com.github.damontecres.wholphin.ui.ProgramItemFields
 import com.github.damontecres.wholphin.ui.SlimItemFields
 import com.github.damontecres.wholphin.ui.components.ContextMenuProvider
 import com.github.damontecres.wholphin.ui.components.VoiceInputManager
+import com.github.damontecres.wholphin.ui.components.baseItemKinds
 import com.github.damontecres.wholphin.ui.data.RowColumn
 import com.github.damontecres.wholphin.ui.detail.livetv.ProgramDialogState
 import com.github.damontecres.wholphin.ui.isNotNullOrBlank
@@ -74,6 +76,7 @@ class SearchViewModel
         private val mediaReportService: MediaReportService,
         private val liveTvService: LiveTvService,
         private val keyValueService: KeyValueService,
+        private val navDrawerService: NavDrawerService,
     ) : ViewModel(),
         ContextMenuProvider {
         val seerrActive = seerrService.active
@@ -120,12 +123,26 @@ class SearchViewModel
             }
         }
 
-        private fun determineSearchableTypes(excludedSearchableTypes: List<BaseItemKind>): List<BaseItemKind> {
+        private suspend fun determineSearchableTypes(excludedSearchableTypes: List<BaseItemKind>): List<BaseItemKind> {
             val tvAccess = serverRepository.currentUserDto?.tvAccess == true
+            val libraryTypes =
+                serverRepository.currentUser
+                    ?.id
+                    ?.let { userId ->
+                        navDrawerService
+                            .getAllUserLibraries(userId, tvAccess)
+                            .flatMap { it.collectionType.baseItemKinds }
+                            .toSet()
+                    }.orEmpty()
             val searchableTypes =
                 allSearchableTypes.filter {
                     val excluded = excludedSearchableTypes.contains(it)
+                    // Only include if there's a relevant, accessible library
+                    val hasLibrary = libraryTypes.contains(it)
                     when (it) {
+                        // No library type for person
+                        BaseItemKind.PERSON -> !excluded
+
                         // Remove live tv search if user doesn't have access
                         BaseItemKind.TV_CHANNEL,
                         BaseItemKind.LIVE_TV_PROGRAM,
@@ -133,7 +150,7 @@ class SearchViewModel
                         BaseItemKind.PROGRAM,
                         -> tvAccess && !excluded
 
-                        else -> !excluded
+                        else -> hasLibrary && !excluded
                     }
                 }
             return searchableTypes

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -12,6 +12,7 @@ import com.github.damontecres.wholphin.data.model.SeerrItemType
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.updateSearchPreferences
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
+import com.github.damontecres.wholphin.services.LiveTvService
 import com.github.damontecres.wholphin.services.MediaManagementService
 import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavigationManager
@@ -22,11 +23,13 @@ import com.github.damontecres.wholphin.ui.SlimItemFields
 import com.github.damontecres.wholphin.ui.components.ContextMenuProvider
 import com.github.damontecres.wholphin.ui.components.VoiceInputManager
 import com.github.damontecres.wholphin.ui.data.RowColumn
+import com.github.damontecres.wholphin.ui.detail.livetv.ProgramDialogState
 import com.github.damontecres.wholphin.ui.isNotNullOrBlank
 import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.showToast
+import com.github.damontecres.wholphin.util.DataLoadingState
 import com.github.damontecres.wholphin.util.ExceptionHandler
 import com.github.damontecres.wholphin.util.SearchRelevance
 import com.github.damontecres.wholphin.util.WholphinDispatchers
@@ -62,6 +65,7 @@ class SearchViewModel
         private val favoriteWatchManager: FavoriteWatchManager,
         private val mediaManagementService: MediaManagementService,
         private val mediaReportService: MediaReportService,
+        private val liveTvService: LiveTvService,
     ) : ViewModel(),
         ContextMenuProvider {
         val seerrActive = seerrService.active
@@ -72,6 +76,9 @@ class SearchViewModel
 
         private var currentQuery: String? = null
         private var combinedMode = false
+
+        private val _programDialogState = MutableStateFlow(ProgramDialogState())
+        val programDialogState: StateFlow<ProgramDialogState> = _programDialogState
 
         init {
             init()
@@ -307,6 +314,55 @@ class SearchViewModel
         override fun isAdministrator(): Boolean = serverRepository.currentUserDto?.policy?.isAdministrator == true
 
         override fun sendReportFor(itemId: UUID) = mediaReportService.sendReportFor(itemId)
+
+        fun fetchProgramForDialog(programId: UUID) {
+            _programDialogState.update { it.copy(loading = DataLoadingState.Loading) }
+            viewModelScope.launchDefault {
+                try {
+                    val result = liveTvService.fetchProgramForDialog(programId)
+                    _programDialogState.update { it.copy(loading = DataLoadingState.Success(result)) }
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Error fetching program $programId")
+                    _programDialogState.update { it.copy(loading = DataLoadingState.Error(ex)) }
+                }
+            }
+        }
+
+        fun cancelRecording(
+            series: Boolean,
+            timerId: String?,
+        ) {
+            viewModelScope.launchIO(ExceptionHandler(autoToast = true)) {
+                try {
+                    val result = liveTvService.cancelRecording(series, timerId)
+                    // TODO update program card?
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Error canceling timer %s, series=%s", timerId, series)
+                    showToast(context, "Error: ${ex.localizedMessage}")
+                }
+            }
+        }
+
+        fun record(
+            programId: UUID,
+            series: Boolean,
+        ) {
+            viewModelScope.launchIO {
+                try {
+                    liveTvService.record(programId, series)
+                    // TODO update program card?
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Error recording %s, series=%s", programId, series)
+                    showToast(context, "Error: ${ex.localizedMessage}")
+                }
+            }
+        }
     }
 
 sealed interface SearchResult {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -278,16 +278,8 @@ class SearchViewModel
                     if (combinedMode) {
                         state.value.combinedResults
                     } else {
-                        when (position.row) {
-                            MOVIE_ROW -> state.value.movies
-                            SERIES_ROW -> state.value.series
-                            EPISODE_ROW -> state.value.episodes
-                            COLLECTION_ROW -> state.value.collections
-                            ALBUM_ROW -> state.value.albums
-                            ARTIST_ROW -> state.value.artists
-                            SONG_ROW -> state.value.songs
-                            SEERR_ROW -> null
-                            else -> null
+                        searchableTypes.getOrNull(position.row)?.let {
+                            state.value.results[it]
                         }
                     } ?: return
                 val items = (searchResult as? SearchResult.Success)?.items ?: return
@@ -307,23 +299,15 @@ class SearchViewModel
                                 set(position.column, newItem)
                             },
                         )
-                    _state.update {
-                        if (combinedMode) {
+                    if (combinedMode) {
+                        _state.update {
                             it.copy(
                                 combinedResults = newList,
                             )
-                        } else {
-                            when (position.row) {
-                                MOVIE_ROW -> it.copy(movies = newList)
-                                SERIES_ROW -> it.copy(series = newList)
-                                EPISODE_ROW -> it.copy(episodes = newList)
-                                COLLECTION_ROW -> it.copy(collections = newList)
-                                ALBUM_ROW -> it.copy(albums = newList)
-                                ARTIST_ROW -> it.copy(artists = newList)
-                                SONG_ROW -> it.copy(songs = newList)
-                                SEERR_ROW -> it
-                                else -> it
-                            }
+                        }
+                    } else {
+                        searchableTypes.getOrNull(position.row)?.let { type ->
+                            state.value.results[type] = newList
                         }
                     }
                 }
@@ -386,11 +370,12 @@ data class SearchState(
     val albums: SearchResult = SearchResult.NoQuery,
     val artists: SearchResult = SearchResult.NoQuery,
     val songs: SearchResult = SearchResult.NoQuery,
+    val results: SnapshotStateMap<BaseItemKind, SearchResult> = SnapshotStateMap(),
     val seerrResults: SearchResult = SearchResult.NoQuery,
     val combinedResults: SearchResult = SearchResult.NoQuery,
-    val results: SnapshotStateMap<BaseItemKind, SearchResult> = SnapshotStateMap(),
 ) {
     companion object {
+        // TODO
         val searchingState =
             SearchState(
                 movies = SearchResult.Searching,
@@ -400,6 +385,12 @@ data class SearchState(
                 albums = SearchResult.Searching,
                 artists = SearchResult.Searching,
                 songs = SearchResult.Searching,
+                results =
+                    SnapshotStateMap<BaseItemKind, SearchResult>().apply {
+                        searchableTypes.forEach {
+                            this[it] = SearchResult.Searching
+                        }
+                    },
                 seerrResults = SearchResult.Searching,
                 combinedResults = SearchResult.Searching,
             )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -91,21 +91,38 @@ class SearchViewModel
         private val _programDialogState = MutableStateFlow(ProgramDialogState())
         val programDialogState: StateFlow<ProgramDialogState> = _programDialogState
 
+        private var userLibraryTypes: Set<BaseItemKind> = emptySet()
+
         init {
             init()
         }
 
         private fun init() {
-            _state.update { SearchState() }
             viewModelScope.launchDefault {
+                val tvAccess = serverRepository.currentUserDto?.tvAccess == true
+                userLibraryTypes =
+                    serverRepository.currentUser
+                        ?.id
+                        ?.let { userId ->
+                            navDrawerService
+                                .getAllUserLibraries(userId, tvAccess)
+                                .flatMap { it.collectionType.baseItemKinds }
+                                .toSet()
+                        }.orEmpty()
+
                 val excludedSearchableTypes =
                     serverRepository.currentUser?.id?.let { userId ->
-                        keyValueService
-                            .get<List<BaseItemKind>>(
-                                userId,
-                                EXCLUDED_SEARCHABLE_TYPES_KEY,
-                                emptyList(),
-                            ).firstOrNull()
+                        try {
+                            keyValueService
+                                .get<List<BaseItemKind>>(
+                                    userId,
+                                    EXCLUDED_SEARCHABLE_TYPES_KEY,
+                                    emptyList(),
+                                ).firstOrNull()
+                        } catch (ex: Exception) {
+                            Timber.e(ex, "Error occurred fetching excluded search types")
+                            emptyList()
+                        }
                     } ?: emptyList()
                 val searchableTypes = determineSearchableTypes(excludedSearchableTypes)
                 val possibleSearchableTypes = determineSearchableTypes(emptyList())
@@ -123,22 +140,13 @@ class SearchViewModel
             }
         }
 
-        private suspend fun determineSearchableTypes(excludedSearchableTypes: List<BaseItemKind>): List<BaseItemKind> {
+        private fun determineSearchableTypes(excludedSearchableTypes: List<BaseItemKind>): List<BaseItemKind> {
             val tvAccess = serverRepository.currentUserDto?.tvAccess == true
-            val libraryTypes =
-                serverRepository.currentUser
-                    ?.id
-                    ?.let { userId ->
-                        navDrawerService
-                            .getAllUserLibraries(userId, tvAccess)
-                            .flatMap { it.collectionType.baseItemKinds }
-                            .toSet()
-                    }.orEmpty()
             val searchableTypes =
                 allSearchableTypes.filter {
                     val excluded = excludedSearchableTypes.contains(it)
                     // Only include if there's a relevant, accessible library
-                    val hasLibrary = libraryTypes.contains(it)
+                    val hasLibrary = userLibraryTypes.contains(it)
                     when (it) {
                         // No library type for person
                         BaseItemKind.PERSON -> !excluded
@@ -172,12 +180,10 @@ class SearchViewModel
                         results =
                             SnapshotStateMap<BaseItemKind, SearchResult>().apply {
                                 it.includedSearchableTypes.forEach {
-                                    put(
-                                        it,
-                                        SearchResult.Searching,
-                                    )
+                                    put(it, SearchResult.Searching)
                                 }
                             },
+                        combinedResults = SearchResult.Searching,
                     )
                 }
                 if (combined) {
@@ -189,7 +195,17 @@ class SearchViewModel
                 }
                 searchSeerr(query)
             } else {
-                init()
+                _state.update {
+                    it.copy(
+                        results =
+                            SnapshotStateMap<BaseItemKind, SearchResult>().apply {
+                                it.includedSearchableTypes.forEach {
+                                    put(it, SearchResult.NoQuery)
+                                }
+                            },
+                        combinedResults = SearchResult.NoQuery,
+                    )
+                }
             }
         }
 
@@ -265,18 +281,14 @@ class SearchViewModel
         private fun searchCombined(query: String) {
             viewModelScope.launch(ExceptionHandler() + WholphinDispatchers.IO) {
                 try {
+                    Timber.v("Starting searchCombined")
                     val request =
                         GetItemsRequest(
                             searchTerm = query,
                             recursive = true,
-                            includeItemTypes =
-                                listOf(
-                                    BaseItemKind.MOVIE,
-                                    BaseItemKind.SERIES,
-                                    BaseItemKind.BOX_SET,
-                                ),
+                            includeItemTypes = state.value.includedSearchableTypes,
                             fields = SlimItemFields,
-                            limit = 50,
+                            limit = SEARCH_LIMIT,
                         )
 
                     val result = api.itemsApi.getItems(request).content
@@ -289,6 +301,7 @@ class SearchViewModel
                             compareBy<BaseItem> { SearchRelevance.score(it, query) }
                                 .thenBy { it.name ?: "" },
                         )
+                    Timber.v("searchCombined complete %s results", sorted.size)
                     _state.update { it.copy(combinedResults = SearchResult.Success(sorted)) }
                 } catch (ex: Exception) {
                     Timber.e(ex, "Exception in combined search")
@@ -467,6 +480,7 @@ class SearchViewModel
                 try {
                     liveTvService.record(programId, series)
                     // TODO update program card?
+                    refreshItem(programId)
                 } catch (ex: CancellationException) {
                     throw ex
                 } catch (ex: Exception) {
@@ -478,31 +492,40 @@ class SearchViewModel
 
         fun onClickExcludeSearchableType(type: BaseItemKind) {
             viewModelScope.launchIO {
-                val state = state.value
-                val updateSearch: Boolean
-                val newExcludes =
-                    state.excludedSearchableTypes.toMutableList().apply {
-                        if (type in this) {
-                            updateSearch = true
-                            remove(type)
-                        } else {
-                            updateSearch = false
-                            add(type)
+                try {
+                    val state = state.value
+                    val updateSearch: Boolean
+                    val newExcludes =
+                        state.excludedSearchableTypes.toMutableList().apply {
+                            if (type in this) {
+                                updateSearch = true
+                                remove(type)
+                            } else {
+                                // If combined, need to update, otherwise just hide the newly excluded results
+                                updateSearch = combinedMode
+                                add(type)
+                            }
                         }
+                    Timber.v("newExcludes=%s", newExcludes)
+                    serverRepository.currentUser?.id?.let { userId ->
+                        keyValueService.save(userId, EXCLUDED_SEARCHABLE_TYPES_KEY, newExcludes)
                     }
-                Timber.v("newExcludes=%s", newExcludes)
-                serverRepository.currentUser?.id?.let { userId ->
-                    keyValueService.save(userId, EXCLUDED_SEARCHABLE_TYPES_KEY, newExcludes)
-                }
-                val searchableTypes = determineSearchableTypes(newExcludes)
-                _state.update {
-                    it.copy(
-                        includedSearchableTypes = searchableTypes,
-                        excludedSearchableTypes = newExcludes,
-                    )
-                }
-                if (updateSearch && currentQuery.isNotNullOrBlank()) {
-                    search(currentQuery, combinedMode, true)
+                    val searchableTypes = determineSearchableTypes(newExcludes)
+                    _state.update {
+                        it.copy(
+                            includedSearchableTypes = searchableTypes,
+                            excludedSearchableTypes = newExcludes,
+                        )
+                    }
+                    if (updateSearch && currentQuery.isNotNullOrBlank()) {
+                        Timber.d("Need to update search")
+                        search(currentQuery, combinedMode, true)
+                    }
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Exception toggling %s", type)
+                    showToast(context, "An error occurred: ${ex.localizedMessage}")
                 }
             }
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -19,6 +19,7 @@ import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.SeerrService
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.services.deleteItem
+import com.github.damontecres.wholphin.services.tvAccess
 import com.github.damontecres.wholphin.ui.ProgramItemFields
 import com.github.damontecres.wholphin.ui.SlimItemFields
 import com.github.damontecres.wholphin.ui.components.ContextMenuProvider
@@ -90,8 +91,30 @@ class SearchViewModel
 
         private fun init() {
             _state.update { SearchState() }
-            searchableTypes.forEach {
-                state.value.results[it] = SearchResult.NoQuery
+            viewModelScope.launchDefault {
+                val tvAccess = serverRepository.currentUserDto?.tvAccess == true
+                val searchableTypes =
+                    allSearchableTypes.filter {
+                        when (it) {
+                            // Remove live tv search if user doesn't have access
+                            BaseItemKind.TV_CHANNEL,
+                            BaseItemKind.LIVE_TV_PROGRAM,
+                            BaseItemKind.TV_PROGRAM,
+                            BaseItemKind.PROGRAM,
+                            -> tvAccess
+
+                            else -> true
+                        }
+                    }
+                _state.update {
+                    it.copy(
+                        searchableTypes = searchableTypes,
+                        results =
+                            SnapshotStateMap<BaseItemKind, SearchResult>().apply {
+                                searchableTypes.forEach { put(it, SearchResult.NoQuery) }
+                            },
+                    )
+                }
             }
         }
 
@@ -105,11 +128,18 @@ class SearchViewModel
             currentQuery = query
             combinedMode = combined
             if (query.isNotNullOrBlank()) {
-                _state.update { SearchState.searchingState }
+                _state.update {
+                    it.copy(
+                        results =
+                            SnapshotStateMap<BaseItemKind, SearchResult>().apply {
+                                it.searchableTypes.forEach { put(it, SearchResult.NoQuery) }
+                            },
+                    )
+                }
                 if (combined) {
                     searchCombined(query)
                 } else {
-                    searchableTypes.forEach { type ->
+                    state.value.searchableTypes.forEach { type ->
                         searchType(query, type)
                     }
                 }
@@ -288,7 +318,7 @@ class SearchViewModel
                     if (combinedMode) {
                         state.value.combinedResults
                     } else {
-                        searchableTypes.getOrNull(position.row)?.let {
+                        state.value.searchableTypes.getOrNull(position.row)?.let {
                             state.value.results[it]
                         }
                     } ?: return
@@ -316,7 +346,7 @@ class SearchViewModel
                             )
                         }
                     } else {
-                        searchableTypes.getOrNull(position.row)?.let { type ->
+                        state.value.searchableTypes.getOrNull(position.row)?.let { type ->
                             state.value.results[type] = newList
                         }
                     }
@@ -425,24 +455,10 @@ data class SearchState(
     val results: SnapshotStateMap<BaseItemKind, SearchResult> = SnapshotStateMap(),
     val seerrResults: SearchResult = SearchResult.NoQuery,
     val combinedResults: SearchResult = SearchResult.NoQuery,
-) {
-    companion object {
-        // TODO
-        val searchingState =
-            SearchState(
-                results =
-                    SnapshotStateMap<BaseItemKind, SearchResult>().apply {
-                        searchableTypes.forEach {
-                            this[it] = SearchResult.Searching
-                        }
-                    },
-                seerrResults = SearchResult.Searching,
-                combinedResults = SearchResult.Searching,
-            )
-    }
-}
+    val searchableTypes: List<BaseItemKind> = emptyList(),
+)
 
-val searchableTypes =
+private val allSearchableTypes =
     listOf(
         BaseItemKind.MOVIE,
         BaseItemKind.SERIES,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -66,7 +66,7 @@ class SearchViewModel
         @param:ApplicationContext private val context: Context,
         val api: ApiClient,
         val navigationManager: NavigationManager,
-        private val appPreferences: DataStore<AppPreferences>,
+        val appPreferences: DataStore<AppPreferences>,
         private val seerrService: SeerrService,
         val voiceInputManager: VoiceInputManager,
         val userPreferencesService: UserPreferencesService,
@@ -124,10 +124,25 @@ class SearchViewModel
                             emptyList()
                         }
                     } ?: emptyList()
+                val discoverEnabled =
+                    serverRepository.currentUser?.id?.let { userId ->
+                        try {
+                            keyValueService
+                                .get(
+                                    userId,
+                                    INCLUDE_DISCOVER_KEY,
+                                    true,
+                                ).firstOrNull()
+                        } catch (ex: Exception) {
+                            Timber.e(ex, "Error occurred fetching excluded search types")
+                            true
+                        }
+                    } ?: true
                 val searchableTypes = determineSearchableTypes(excludedSearchableTypes)
                 val possibleSearchableTypes = determineSearchableTypes(emptyList())
                 _state.update {
                     it.copy(
+                        discoverEnabled = discoverEnabled,
                         includedSearchableTypes = searchableTypes,
                         possibleSearchableTypes = possibleSearchableTypes,
                         excludedSearchableTypes = excludedSearchableTypes,
@@ -332,7 +347,7 @@ class SearchViewModel
 
         private fun searchSeerr(query: String) {
             viewModelScope.launchIO {
-                if (seerrService.active.first()) {
+                if (seerrActive.first() && state.value.discoverEnabled) {
                     _state.update { it.copy(seerrResults = SearchResult.Searching) }
                     val results =
                         seerrService
@@ -530,8 +545,36 @@ class SearchViewModel
             }
         }
 
+        fun onClickExcludeDiscover() {
+            viewModelScope.launchIO {
+                try {
+                    val newIncludeDiscover = state.value.discoverEnabled.not()
+                    Timber.v("newIncludeDiscover=%s", newIncludeDiscover)
+                    serverRepository.currentUser?.id?.let { userId ->
+                        keyValueService.save(userId, INCLUDE_DISCOVER_KEY, newIncludeDiscover)
+                    }
+                    _state.update {
+                        it.copy(
+                            discoverEnabled = newIncludeDiscover,
+                        )
+                    }
+                    if (newIncludeDiscover) {
+                        currentQuery?.takeIf { it.isNotNullOrBlank() }?.let { query ->
+                            searchSeerr(query)
+                        }
+                    }
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Exception discover")
+                    showToast(context, "An error occurred: ${ex.localizedMessage}")
+                }
+            }
+        }
+
         companion object {
             private const val EXCLUDED_SEARCHABLE_TYPES_KEY = "excludedSearchableTypes"
+            private const val INCLUDE_DISCOVER_KEY = "searchIncludeDiscover"
         }
     }
 
@@ -560,6 +603,7 @@ data class SearchState(
     val possibleSearchableTypes: List<BaseItemKind> = emptyList(),
     val includedSearchableTypes: List<BaseItemKind> = emptyList(),
     val excludedSearchableTypes: List<BaseItemKind> = emptyList(),
+    val discoverEnabled: Boolean = true,
 )
 
 private val allSearchableTypes =

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -99,7 +99,7 @@ class SearchViewModel
                     searchCombined(query)
                 } else {
                     searchableTypes.forEach { type ->
-                        searchInternal2(query, type)
+                        searchType(query, type)
                     }
                 }
                 searchSeerr(query)
@@ -108,42 +108,7 @@ class SearchViewModel
             }
         }
 
-        private fun searchInternal(
-            query: String,
-            type: BaseItemKind,
-            update: (SearchResult, SearchState) -> SearchState,
-        ) {
-            viewModelScope.launchIO {
-                try {
-                    val request =
-                        GetItemsRequest(
-                            searchTerm = query,
-                            recursive = true,
-                            includeItemTypes = listOf(type),
-                            fields = SlimItemFields,
-                            limit = 50,
-                        )
-                    val result = api.itemsApi.getItems(request).content
-                    val items =
-                        result.items.map {
-                            BaseItem(it, false)
-                        }
-                    val sorted =
-                        items.sortedWith(
-                            compareBy<BaseItem> { SearchRelevance.score(it, query) }
-                                .thenBy { it.sortName },
-                        )
-                    _state.update { update.invoke(SearchResult.Success(sorted), it) }
-                } catch (ex: CancellationException) {
-                    throw ex
-                } catch (ex: Exception) {
-                    Timber.e(ex, "Exception searching for $type")
-                    _state.update { update.invoke(SearchResult.Error(ex), it) }
-                }
-            }
-        }
-
-        private fun searchInternal2(
+        private fun searchType(
             query: String,
             type: BaseItemKind,
         ) {
@@ -363,13 +328,6 @@ sealed interface SearchResult {
 }
 
 data class SearchState(
-    val movies: SearchResult = SearchResult.NoQuery,
-    val series: SearchResult = SearchResult.NoQuery,
-    val episodes: SearchResult = SearchResult.NoQuery,
-    val collections: SearchResult = SearchResult.NoQuery,
-    val albums: SearchResult = SearchResult.NoQuery,
-    val artists: SearchResult = SearchResult.NoQuery,
-    val songs: SearchResult = SearchResult.NoQuery,
     val results: SnapshotStateMap<BaseItemKind, SearchResult> = SnapshotStateMap(),
     val seerrResults: SearchResult = SearchResult.NoQuery,
     val combinedResults: SearchResult = SearchResult.NoQuery,
@@ -378,13 +336,6 @@ data class SearchState(
         // TODO
         val searchingState =
             SearchState(
-                movies = SearchResult.Searching,
-                series = SearchResult.Searching,
-                episodes = SearchResult.Searching,
-                collections = SearchResult.Searching,
-                albums = SearchResult.Searching,
-                artists = SearchResult.Searching,
-                songs = SearchResult.Searching,
                 results =
                     SnapshotStateMap<BaseItemKind, SearchResult>().apply {
                         searchableTypes.forEach {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -1,0 +1,388 @@
+package com.github.damontecres.wholphin.ui.search
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.damontecres.wholphin.data.ServerRepository
+import com.github.damontecres.wholphin.data.model.BaseItem
+import com.github.damontecres.wholphin.data.model.DiscoverItem
+import com.github.damontecres.wholphin.data.model.SeerrItemType
+import com.github.damontecres.wholphin.preferences.AppPreferences
+import com.github.damontecres.wholphin.preferences.updateSearchPreferences
+import com.github.damontecres.wholphin.services.FavoriteWatchManager
+import com.github.damontecres.wholphin.services.MediaManagementService
+import com.github.damontecres.wholphin.services.MediaReportService
+import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.SeerrService
+import com.github.damontecres.wholphin.services.UserPreferencesService
+import com.github.damontecres.wholphin.services.deleteItem
+import com.github.damontecres.wholphin.ui.SlimItemFields
+import com.github.damontecres.wholphin.ui.components.ContextMenuProvider
+import com.github.damontecres.wholphin.ui.components.VoiceInputManager
+import com.github.damontecres.wholphin.ui.data.RowColumn
+import com.github.damontecres.wholphin.ui.isNotNullOrBlank
+import com.github.damontecres.wholphin.ui.launchDefault
+import com.github.damontecres.wholphin.ui.launchIO
+import com.github.damontecres.wholphin.ui.nav.Destination
+import com.github.damontecres.wholphin.ui.showToast
+import com.github.damontecres.wholphin.util.ExceptionHandler
+import com.github.damontecres.wholphin.util.SearchRelevance
+import com.github.damontecres.wholphin.util.WholphinDispatchers
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.jellyfin.sdk.api.client.ApiClient
+import org.jellyfin.sdk.api.client.extensions.itemsApi
+import org.jellyfin.sdk.api.client.extensions.userLibraryApi
+import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.request.GetItemsRequest
+import timber.log.Timber
+import java.util.UUID
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchViewModel
+    @Inject
+    constructor(
+        @param:ApplicationContext private val context: Context,
+        val api: ApiClient,
+        val navigationManager: NavigationManager,
+        private val appPreferences: DataStore<AppPreferences>,
+        private val seerrService: SeerrService,
+        val voiceInputManager: VoiceInputManager,
+        val userPreferencesService: UserPreferencesService,
+        private val serverRepository: ServerRepository,
+        private val favoriteWatchManager: FavoriteWatchManager,
+        private val mediaManagementService: MediaManagementService,
+        private val mediaReportService: MediaReportService,
+    ) : ViewModel(),
+        ContextMenuProvider {
+        val seerrActive = seerrService.active
+
+        private val _state = MutableStateFlow(SearchState())
+        val state: StateFlow<SearchState> = _state
+        val position = MutableStateFlow(RowColumn(0, 0))
+
+        private var currentQuery: String? = null
+        private var combinedMode = false
+
+        fun search(
+            query: String?,
+            combined: Boolean = false,
+        ) {
+            if (currentQuery == query && combinedMode == combined) {
+                return
+            }
+            currentQuery = query
+            combinedMode = combined
+            if (query.isNotNullOrBlank()) {
+                _state.update { SearchState.searchingState }
+                if (combined) {
+                    searchCombined(query)
+                } else {
+                    searchInternal(
+                        query,
+                        BaseItemKind.MOVIE,
+                    ) { result, state -> state.copy(movies = result) }
+                    searchInternal(
+                        query,
+                        BaseItemKind.SERIES,
+                    ) { result, state -> state.copy(series = result) }
+                    searchInternal(query, BaseItemKind.EPISODE) { result, state ->
+                        state.copy(
+                            episodes = result,
+                        )
+                    }
+                    searchInternal(query, BaseItemKind.BOX_SET) { result, state ->
+                        state.copy(
+                            collections = result,
+                        )
+                    }
+                    searchInternal(query, BaseItemKind.MUSIC_ALBUM) { result, state ->
+                        state.copy(
+                            albums = result,
+                        )
+                    }
+                    searchInternal(query, BaseItemKind.MUSIC_ARTIST) { result, state ->
+                        state.copy(
+                            artists = result,
+                        )
+                    }
+                    searchInternal(
+                        query,
+                        BaseItemKind.AUDIO,
+                    ) { result, state -> state.copy(songs = result) }
+                }
+                searchSeerr(query)
+            } else {
+                _state.update { SearchState() }
+            }
+        }
+
+        private fun searchInternal(
+            query: String,
+            type: BaseItemKind,
+            update: (SearchResult, SearchState) -> SearchState,
+        ) {
+            viewModelScope.launchIO {
+                try {
+                    val request =
+                        GetItemsRequest(
+                            searchTerm = query,
+                            recursive = true,
+                            includeItemTypes = listOf(type),
+                            fields = SlimItemFields,
+                            limit = 50,
+                        )
+                    val result = api.itemsApi.getItems(request).content
+                    val items =
+                        result.items.map {
+                            BaseItem(it, false)
+                        }
+                    val sorted =
+                        items.sortedWith(
+                            compareBy<BaseItem> { SearchRelevance.score(it, query) }
+                                .thenBy { it.sortName },
+                        )
+                    _state.update { update.invoke(SearchResult.Success(sorted), it) }
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Exception searching for $type")
+                    _state.update { update.invoke(SearchResult.Error(ex), it) }
+                }
+            }
+        }
+
+        private fun searchCombined(query: String) {
+            viewModelScope.launch(ExceptionHandler() + WholphinDispatchers.IO) {
+                try {
+                    val request =
+                        GetItemsRequest(
+                            searchTerm = query,
+                            recursive = true,
+                            includeItemTypes =
+                                listOf(
+                                    BaseItemKind.MOVIE,
+                                    BaseItemKind.SERIES,
+                                    BaseItemKind.BOX_SET,
+                                ),
+                            fields = SlimItemFields,
+                            limit = 50,
+                        )
+
+                    val result = api.itemsApi.getItems(request).content
+                    val items =
+                        result.items.map {
+                            BaseItem(it, false)
+                        }
+                    val sorted =
+                        items.sortedWith(
+                            compareBy<BaseItem> { SearchRelevance.score(it, query) }
+                                .thenBy { it.name ?: "" },
+                        )
+                    _state.update { it.copy(combinedResults = SearchResult.Success(sorted)) }
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Exception in combined search")
+                    _state.update { it.copy(combinedResults = SearchResult.Error(ex)) }
+                }
+            }
+        }
+
+        fun setCombinedResults(enabled: Boolean) {
+            viewModelScope.launchIO {
+                appPreferences.updateData {
+                    it.updateSearchPreferences {
+                        combinedSearchResults = enabled
+                    }
+                }
+            }
+        }
+
+        fun setVoiceSearchButtonVisible(visible: Boolean) {
+            viewModelScope.launchIO {
+                appPreferences.updateData {
+                    it.updateSearchPreferences {
+                        showVoiceSearchButton = visible
+                    }
+                }
+            }
+        }
+
+        private fun searchSeerr(query: String) {
+            viewModelScope.launchIO {
+                if (seerrService.active.first()) {
+                    _state.update { it.copy(seerrResults = SearchResult.Searching) }
+                    val results =
+                        seerrService
+                            .search(query)
+                            .map { seerrService.createDiscoverItem(it) }
+                            .filter { it.type == SeerrItemType.MOVIE || it.type == SeerrItemType.TV }
+                    _state.update { it.copy(seerrResults = SearchResult.SuccessSeerr(results)) }
+                }
+            }
+        }
+
+        init {
+            addCloseable(voiceInputManager)
+        }
+
+        override fun navigateTo(destination: Destination) {
+            navigationManager.navigateTo(destination)
+        }
+
+        override fun canDelete(
+            item: BaseItem,
+            appPreferences: AppPreferences,
+        ): Boolean = mediaManagementService.canDelete(item, appPreferences)
+
+        override fun deleteItem(
+            index: Int,
+            item: BaseItem,
+        ) {
+            deleteItem(context, mediaManagementService, item) {
+                viewModelScope.launchDefault {
+                    refreshItem(item.id)
+                }
+            }
+        }
+
+        private suspend fun refreshItem(itemId: UUID) {
+            try {
+                val position = position.value
+                val searchResult =
+                    if (combinedMode) {
+                        state.value.combinedResults
+                    } else {
+                        when (position.row) {
+                            MOVIE_ROW -> state.value.movies
+                            SERIES_ROW -> state.value.series
+                            EPISODE_ROW -> state.value.episodes
+                            COLLECTION_ROW -> state.value.collections
+                            ALBUM_ROW -> state.value.albums
+                            ARTIST_ROW -> state.value.artists
+                            SONG_ROW -> state.value.songs
+                            SEERR_ROW -> null
+                            else -> null
+                        }
+                    } ?: return
+                val items = (searchResult as? SearchResult.Success)?.items ?: return
+
+                Timber.v("Item refresh: position=%s", position)
+                val item = items.getOrNull(position.column)
+                // Exact item deleted (eg a movie) or deleted item was within the series
+                if (item != null && item.id == itemId) {
+                    val newItem =
+                        api.userLibraryApi
+                            .getItem(item.id)
+                            .content
+                            .let { BaseItem(it) }
+                    val newList =
+                        SearchResult.Success(
+                            items.toMutableList().apply {
+                                set(position.column, newItem)
+                            },
+                        )
+                    _state.update {
+                        if (combinedMode) {
+                            it.copy(
+                                combinedResults = newList,
+                            )
+                        } else {
+                            when (position.row) {
+                                MOVIE_ROW -> it.copy(movies = newList)
+                                SERIES_ROW -> it.copy(series = newList)
+                                EPISODE_ROW -> it.copy(episodes = newList)
+                                COLLECTION_ROW -> it.copy(collections = newList)
+                                ALBUM_ROW -> it.copy(albums = newList)
+                                ARTIST_ROW -> it.copy(artists = newList)
+                                SONG_ROW -> it.copy(songs = newList)
+                                SEERR_ROW -> it
+                                else -> it
+                            }
+                        }
+                    }
+                }
+            } catch (ex: Exception) {
+                Timber.e(ex, "Error refreshing item %s", itemId)
+                showToast(context, "Error refreshing")
+            }
+        }
+
+        override fun setWatched(
+            position: Int,
+            itemId: UUID,
+            played: Boolean,
+        ) {
+            viewModelScope.launch(ExceptionHandler() + WholphinDispatchers.IO) {
+                favoriteWatchManager.setWatched(itemId, played)
+                refreshItem(itemId)
+            }
+        }
+
+        override fun setFavorite(
+            position: Int,
+            itemId: UUID,
+            favorite: Boolean,
+        ) {
+            viewModelScope.launch(ExceptionHandler() + WholphinDispatchers.IO) {
+                favoriteWatchManager.setFavorite(itemId, favorite)
+                refreshItem(itemId)
+            }
+        }
+
+        override fun isAdministrator(): Boolean = serverRepository.currentUserDto?.policy?.isAdministrator == true
+
+        override fun sendReportFor(itemId: UUID) = mediaReportService.sendReportFor(itemId)
+    }
+
+sealed interface SearchResult {
+    data object NoQuery : SearchResult
+
+    data object Searching : SearchResult
+
+    data class Error(
+        val ex: Exception,
+    ) : SearchResult
+
+    data class Success(
+        val items: List<BaseItem?>,
+    ) : SearchResult
+
+    data class SuccessSeerr(
+        val items: List<DiscoverItem>,
+    ) : SearchResult
+}
+
+data class SearchState(
+    val movies: SearchResult = SearchResult.NoQuery,
+    val series: SearchResult = SearchResult.NoQuery,
+    val episodes: SearchResult = SearchResult.NoQuery,
+    val collections: SearchResult = SearchResult.NoQuery,
+    val albums: SearchResult = SearchResult.NoQuery,
+    val artists: SearchResult = SearchResult.NoQuery,
+    val songs: SearchResult = SearchResult.NoQuery,
+    val seerrResults: SearchResult = SearchResult.NoQuery,
+    val combinedResults: SearchResult = SearchResult.NoQuery,
+) {
+    companion object {
+        val searchingState =
+            SearchState(
+                movies = SearchResult.Searching,
+                series = SearchResult.Searching,
+                episodes = SearchResult.Searching,
+                collections = SearchResult.Searching,
+                albums = SearchResult.Searching,
+                artists = SearchResult.Searching,
+                songs = SearchResult.Searching,
+                seerrResults = SearchResult.Searching,
+                combinedResults = SearchResult.Searching,
+            )
+    }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -12,6 +12,7 @@ import com.github.damontecres.wholphin.data.model.SeerrItemType
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.updateSearchPreferences
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
+import com.github.damontecres.wholphin.services.KeyValueService
 import com.github.damontecres.wholphin.services.LiveTvService
 import com.github.damontecres.wholphin.services.MediaManagementService
 import com.github.damontecres.wholphin.services.MediaReportService
@@ -42,6 +43,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.jellyfin.sdk.api.client.ApiClient
@@ -71,6 +73,7 @@ class SearchViewModel
         private val mediaManagementService: MediaManagementService,
         private val mediaReportService: MediaReportService,
         private val liveTvService: LiveTvService,
+        private val keyValueService: KeyValueService,
     ) : ViewModel(),
         ContextMenuProvider {
         val seerrActive = seerrService.active
@@ -92,23 +95,22 @@ class SearchViewModel
         private fun init() {
             _state.update { SearchState() }
             viewModelScope.launchDefault {
-                val tvAccess = serverRepository.currentUserDto?.tvAccess == true
-                val searchableTypes =
-                    allSearchableTypes.filter {
-                        when (it) {
-                            // Remove live tv search if user doesn't have access
-                            BaseItemKind.TV_CHANNEL,
-                            BaseItemKind.LIVE_TV_PROGRAM,
-                            BaseItemKind.TV_PROGRAM,
-                            BaseItemKind.PROGRAM,
-                            -> tvAccess
-
-                            else -> true
-                        }
-                    }
+                val excludedSearchableTypes =
+                    serverRepository.currentUser?.id?.let { userId ->
+                        keyValueService
+                            .get<List<BaseItemKind>>(
+                                userId,
+                                EXCLUDED_SEARCHABLE_TYPES_KEY,
+                                emptyList(),
+                            ).firstOrNull()
+                    } ?: emptyList()
+                val searchableTypes = determineSearchableTypes(excludedSearchableTypes)
+                val possibleSearchableTypes = determineSearchableTypes(emptyList())
                 _state.update {
                     it.copy(
-                        searchableTypes = searchableTypes,
+                        includedSearchableTypes = searchableTypes,
+                        possibleSearchableTypes = possibleSearchableTypes,
+                        excludedSearchableTypes = excludedSearchableTypes,
                         results =
                             SnapshotStateMap<BaseItemKind, SearchResult>().apply {
                                 searchableTypes.forEach { put(it, SearchResult.NoQuery) }
@@ -118,11 +120,31 @@ class SearchViewModel
             }
         }
 
+        private fun determineSearchableTypes(excludedSearchableTypes: List<BaseItemKind>): List<BaseItemKind> {
+            val tvAccess = serverRepository.currentUserDto?.tvAccess == true
+            val searchableTypes =
+                allSearchableTypes.filter {
+                    val excluded = excludedSearchableTypes.contains(it)
+                    when (it) {
+                        // Remove live tv search if user doesn't have access
+                        BaseItemKind.TV_CHANNEL,
+                        BaseItemKind.LIVE_TV_PROGRAM,
+                        BaseItemKind.TV_PROGRAM,
+                        BaseItemKind.PROGRAM,
+                        -> tvAccess && !excluded
+
+                        else -> !excluded
+                    }
+                }
+            return searchableTypes
+        }
+
         fun search(
             query: String?,
             combined: Boolean = false,
+            force: Boolean = false,
         ) {
-            if (currentQuery == query && combinedMode == combined) {
+            if (currentQuery == query && combinedMode == combined && !force) {
                 return
             }
             currentQuery = query
@@ -132,14 +154,19 @@ class SearchViewModel
                     it.copy(
                         results =
                             SnapshotStateMap<BaseItemKind, SearchResult>().apply {
-                                it.searchableTypes.forEach { put(it, SearchResult.NoQuery) }
+                                it.includedSearchableTypes.forEach {
+                                    put(
+                                        it,
+                                        SearchResult.Searching,
+                                    )
+                                }
                             },
                     )
                 }
                 if (combined) {
                     searchCombined(query)
                 } else {
-                    state.value.searchableTypes.forEach { type ->
+                    state.value.includedSearchableTypes.forEach { type ->
                         searchType(query, type)
                     }
                 }
@@ -318,7 +345,7 @@ class SearchViewModel
                     if (combinedMode) {
                         state.value.combinedResults
                     } else {
-                        state.value.searchableTypes.getOrNull(position.row)?.let {
+                        state.value.includedSearchableTypes.getOrNull(position.row)?.let {
                             state.value.results[it]
                         }
                     } ?: return
@@ -346,7 +373,7 @@ class SearchViewModel
                             )
                         }
                     } else {
-                        state.value.searchableTypes.getOrNull(position.row)?.let { type ->
+                        state.value.includedSearchableTypes.getOrNull(position.row)?.let { type ->
                             state.value.results[type] = newList
                         }
                     }
@@ -431,6 +458,41 @@ class SearchViewModel
                 }
             }
         }
+
+        fun onClickExcludeSearchableType(type: BaseItemKind) {
+            viewModelScope.launchIO {
+                val state = state.value
+                val updateSearch: Boolean
+                val newExcludes =
+                    state.excludedSearchableTypes.toMutableList().apply {
+                        if (type in this) {
+                            updateSearch = true
+                            remove(type)
+                        } else {
+                            updateSearch = false
+                            add(type)
+                        }
+                    }
+                Timber.v("newExcludes=%s", newExcludes)
+                serverRepository.currentUser?.id?.let { userId ->
+                    keyValueService.save(userId, EXCLUDED_SEARCHABLE_TYPES_KEY, newExcludes)
+                }
+                val searchableTypes = determineSearchableTypes(newExcludes)
+                _state.update {
+                    it.copy(
+                        includedSearchableTypes = searchableTypes,
+                        excludedSearchableTypes = newExcludes,
+                    )
+                }
+                if (updateSearch && currentQuery.isNotNullOrBlank()) {
+                    search(currentQuery, combinedMode, true)
+                }
+            }
+        }
+
+        companion object {
+            private const val EXCLUDED_SEARCHABLE_TYPES_KEY = "excludedSearchableTypes"
+        }
     }
 
 sealed interface SearchResult {
@@ -455,7 +517,9 @@ data class SearchState(
     val results: SnapshotStateMap<BaseItemKind, SearchResult> = SnapshotStateMap(),
     val seerrResults: SearchResult = SearchResult.NoQuery,
     val combinedResults: SearchResult = SearchResult.NoQuery,
-    val searchableTypes: List<BaseItemKind> = emptyList(),
+    val possibleSearchableTypes: List<BaseItemKind> = emptyList(),
+    val includedSearchableTypes: List<BaseItemKind> = emptyList(),
+    val excludedSearchableTypes: List<BaseItemKind> = emptyList(),
 )
 
 private val allSearchableTypes =

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewOptionsDialog.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewOptionsDialog.kt
@@ -1,0 +1,121 @@
+package com.github.damontecres.wholphin.ui.search
+
+import android.view.Gravity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.DialogWindowProvider
+import androidx.tv.material3.ListItem
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Switch
+import androidx.tv.material3.Text
+import androidx.tv.material3.surfaceColorAtElevation
+import com.github.damontecres.wholphin.R
+import com.github.damontecres.wholphin.ui.preferences.SwitchColors
+
+@Composable
+fun SearchViewOptionsDialog(
+    combinedResults: Boolean,
+    onCombinedResultsChange: (Boolean) -> Unit,
+    voiceSearchButtonVisible: Boolean,
+    onVoiceSearchButtonVisibleChange: (Boolean) -> Unit,
+    onClickFilterTypes: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        val dialogWindowProvider = LocalView.current.parent as? DialogWindowProvider
+        dialogWindowProvider?.window?.setGravity(Gravity.CENTER)
+
+        Box(
+            modifier =
+                Modifier
+                    .width(400.dp)
+                    .background(
+                        MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp),
+                        RoundedCornerShape(28.dp),
+                    ).padding(24.dp),
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Text(
+                    text = stringResource(R.string.view_options),
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                ListItem(
+                    selected = false,
+                    headlineContent = {
+                        Text(stringResource(R.string.combined_search_results))
+                    },
+                    supportingContent = {
+                        Text(
+                            if (combinedResults) {
+                                stringResource(R.string.combined_search_results_on)
+                            } else {
+                                stringResource(R.string.combined_search_results_off)
+                            },
+                        )
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = combinedResults,
+                            onCheckedChange = onCombinedResultsChange,
+                            colors = SwitchColors(),
+                        )
+                    },
+                    onClick = { onCombinedResultsChange(!combinedResults) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                ListItem(
+                    selected = false,
+                    headlineContent = {
+                        Text(stringResource(R.string.show_voice_search_button))
+                    },
+                    supportingContent = {
+                        Text(
+                            if (voiceSearchButtonVisible) {
+                                stringResource(R.string.visible_ui)
+                            } else {
+                                stringResource(R.string.hidden_ui)
+                            },
+                        )
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = voiceSearchButtonVisible,
+                            onCheckedChange = onVoiceSearchButtonVisibleChange,
+                            colors = SwitchColors(),
+                        )
+                    },
+                    onClick = { onVoiceSearchButtonVisibleChange(!voiceSearchButtonVisible) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                ListItem(
+                    selected = false,
+                    headlineContent = {
+                        Text(stringResource(R.string.include_types))
+                    },
+                    onClick = onClickFilterTypes,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -910,4 +910,5 @@
     <string name="audio_books">Audio books</string>
     <string name="server_version_not_supported">Server version not supported</string>
     <string name="appears_on">Appears on</string>
+    <string name="photo_albums">Photo albums</string>
 </resources>


### PR DESCRIPTION
## Description
This PR adds several more data types to search. It also adds a setting (per use profile) to choose which types to include/exclude when searching. The combined results now uses the same types instead of a separate list.

A user can only search for types that they have access to. For example, they need Live TV access for TV channels/programs or need access to a movies-type library to search movies.

Added types to search:
- Photos & Photo albums
- Playlists
- People
- TV channels
- Live TV programs

Clicking a TV channel will play it. Clicking a TV program shows the program dialog allowing for recording or watching live if it's currently airing.

On the main search page you can also toggle whether to search Seerr or not. This does not apply to the discover search tab.

Dev note: Some minor refactoring to move setting up/canceling live tv recordings into a new service so it can be shared between with the live tv & search pages. Also search related files are moved into the same package now.

### Related issues
Closes #409
Closes #646 
Closes #1668
Closes #1750

### Testing
Emulator using users with different permissions and library access

## Screenshots
<img width="475" height="584" alt="image" src="https://github.com/user-attachments/assets/ebcff697-07ba-4ddd-8c26-57f147cfa02a" />


## AI or LLM usage
None
