### PR TITLE
Disable "Auto play next up" when playback starts via play key

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderView.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderView.kt
@@ -780,7 +780,7 @@ fun CollectionFolderView(
                                     startSlideshow = true,
                                 )
                             } else {
-                                Destination.Playback(item)
+                                Destination.Playback(item, startedViaPlayButton = true)
                             }
                         viewModel.navigateTo(destination)
                     },

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/ItemGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/ItemGrid.kt
@@ -228,7 +228,7 @@ fun ItemGrid(
                         position = index
                         contextMenu.showContextMenu(index, item)
                     },
-                    onClickPlay = { _, item -> viewModel.navigateTo(Destination.Playback(item)) },
+                    onClickPlay = { _, item -> viewModel.navigateTo(Destination.Playback(item, startedViaPlayButton = true)) },
                     letterPosition = { c: Char -> 0 },
                     gridFocusRequester = focusRequester,
                     showJumpButtons = false,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
@@ -426,7 +426,7 @@ fun RecommendedContent(
                         )
                 },
                 onClickPlay = { _, item ->
-                    viewModel.navigationManager.navigateTo(Destination.Playback(item))
+                    viewModel.navigationManager.navigateTo(Destination.Playback(item, startedViaPlayButton = true))
                 },
                 onFocusPosition = {
                     position = it

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionDetails.kt
@@ -138,7 +138,7 @@ fun CollectionDetails(
             { filter: GetItemsFilter -> viewModel.changeFilter(filter) }
         }
     val onClickPlay = { _: RowColumn, item: BaseItem ->
-        viewModel.navigateTo(Destination.Playback(item = item))
+        viewModel.navigateTo(Destination.Playback(item = item, startedViaPlayButton = true))
     }
     val onClickPlayAll =
         remember {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverview.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverview.kt
@@ -222,16 +222,17 @@ fun SeriesOverview(
                         it.copy(episodeRowIndex = episodeIndex)
                     }
                 },
-                onClick = {
+                onClick = { ep, viaPlayButton ->
                     rowFocused = EPISODE_ROW
                     val resumePosition =
-                        it.data.userData
+                        ep.data.userData
                             ?.playbackPositionTicks
                             ?.ticks ?: Duration.ZERO
                     viewModel.navigateTo(
                         Destination.Playback(
-                            it.id,
+                            ep.id,
                             resumePosition.inWholeMilliseconds,
+                            startedViaPlayButton = viaPlayButton,
                         ),
                     )
                 },

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverviewContent.kt
@@ -89,7 +89,7 @@ fun SeriesOverviewContent(
     extrasRowFocusRequester: FocusRequester,
     onChangeSeason: (Int) -> Unit,
     onFocusEpisode: (Int) -> Unit,
-    onClick: (BaseItem) -> Unit,
+    onClick: (BaseItem, viaPlayButton: Boolean) -> Unit,
     onLongClick: (BaseItem) -> Unit,
     playOnClick: (Duration) -> Unit,
     watchOnClick: () -> Unit,
@@ -261,7 +261,7 @@ fun SeriesOverviewContent(
                                             ?: 0.0,
                                     onClick = {
                                         epPosition = episodeIndex
-                                        if (episode != null) onClick.invoke(episode)
+                                        if (episode != null) onClick.invoke(episode, false)
                                     },
                                     onLongClick = {
                                         epPosition = episodeIndex
@@ -298,7 +298,7 @@ fun SeriesOverviewContent(
                                                 }
                                             }.onKeyEvent {
                                                 if (episode != null && isPlayKeyUp(it)) {
-                                                    onClick.invoke(episode)
+                                                    onClick.invoke(episode, true)
                                                     return@onKeyEvent true
                                                 }
                                                 return@onKeyEvent false

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
@@ -201,7 +201,7 @@ fun HomePage(
             val onClickPlay =
                 remember {
                     { _: RowColumn, item: BaseItem ->
-                        viewModel.navigationManager.navigateTo(Destination.Playback(item))
+                        viewModel.navigationManager.navigateTo(Destination.Playback(item, startedViaPlayButton = true))
                     }
                 }
             val onClickViewMore =

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/SearchPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/SearchPage.kt
@@ -560,7 +560,7 @@ fun SearchPage(
         contextMenu.showContextMenu(index, item)
     }
     val onPlayItem = { _: Int, item: BaseItem ->
-        viewModel.navigationManager.navigateTo(Destination.Playback(item))
+        viewModel.navigationManager.navigateTo(Destination.Playback(item, startedViaPlayButton = true))
     }
 
     val onClickDiscover = { _: Int, item: DiscoverItem ->

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/nav/Destination.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/nav/Destination.kt
@@ -91,8 +91,10 @@ sealed class Destination(
         val forceTranscoding: Boolean = false,
         val backend: PlayerBackend? = null,
         val shuffle: Boolean = false,
+        val startedViaPlayButton: Boolean = false,
     ) : Destination(true) {
-        constructor(item: BaseItem) : this(item.id, item.resumeMs)
+        constructor(item: BaseItem, startedViaPlayButton: Boolean = false) :
+            this(item.id, item.resumeMs, startedViaPlayButton = startedViaPlayButton)
     }
 
     @Serializable

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/playback/PlaybackViewModel.kt
@@ -189,6 +189,7 @@ class PlaybackViewModel
         private val jobs = mutableListOf<Job>()
 
         private val isPlaylist = destination is Destination.PlaybackList
+        private val startedViaPlayButton = (destination as? Destination.Playback)?.startedViaPlayButton == true
 
         val subtitleSearchState = MutableStateFlow(SubtitleSearchState())
 
@@ -1270,14 +1271,15 @@ class PlaybackViewModel
         }
 
         fun shouldAutoPlayNextUp(): Boolean =
-            preferences.appPreferences.playbackPreferences.let {
-                it.autoPlayNext &&
-                    if (it.passOutProtectionMs > 0) {
-                        (Date().time - lastInteractionDate.time) < it.passOutProtectionMs
-                    } else {
-                        true
-                    }
-            }
+            !startedViaPlayButton &&
+                preferences.appPreferences.playbackPreferences.let {
+                    it.autoPlayNext &&
+                        if (it.passOutProtectionMs > 0) {
+                            (Date().time - lastInteractionDate.time) < it.passOutProtectionMs
+                        } else {
+                            true
+                        }
+                }
 
         fun playNextUp() {
             viewModelScope.launchDefault {


### PR DESCRIPTION
## Description
This adds a small QOL feature that I miss from Plex clients. If playback is started by using the "Play" key on your remote/keyboard then it will disable auto-play-next-up and only play that single item. Auto-play-next-up still behaves normally when playback starts using the "OK/select" button or any method besides the "Play" button.
I find this useful when I know I may fall asleep while watching since I can use the "Play" button and prevent it from potentially playing multiple episodes while I sleep.

### Testing
 - ./gradlew :app:compileDefaultDebugKotlin passes.                                                                                                                                                                                               
  - Manually verified on 2017 Nvidia Shield, 2019 Nvidia Shield Pro, and 2024 Onn 4k Pro

## Screenshots
n/a

## AI or LLM usage
Claude Sonnet 5 was used to implement this. Code reviewed by me, installed/tested on multiple devices, and works as intended.