### PR TITLE
Fix experimental AC3 setting being used by default

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/preferences/ExperimentalPreference.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/preferences/ExperimentalPreference.kt
@@ -40,7 +40,7 @@ object ExperimentalPreference {
     val PreferAc3ForSurround =
         AppSwitchPreference<AppPreferences>(
             title = R.string.prefer_ac3_for_surround,
-            defaultValue = true,
+            defaultValue = false,
             getter = { it.experimentalPreferences.preferAc3Surround },
             setter = { prefs, value ->
                 prefs.updateExperimentalPreferences {

--- a/app/src/main/java/com/github/damontecres/wholphin/services/AppUpgradeHandler.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/AppUpgradeHandler.kt
@@ -13,9 +13,11 @@ import com.github.damontecres.wholphin.data.model.JellyfinUser
 import com.github.damontecres.wholphin.data.model.RememberedTab
 import com.github.damontecres.wholphin.preferences.AppPreference
 import com.github.damontecres.wholphin.preferences.AppPreferences
+import com.github.damontecres.wholphin.preferences.ExperimentalPreference
 import com.github.damontecres.wholphin.preferences.ScreensaverPreference
 import com.github.damontecres.wholphin.preferences.update
 import com.github.damontecres.wholphin.preferences.updateAdvancedPreferences
+import com.github.damontecres.wholphin.preferences.updateExperimentalPreferences
 import com.github.damontecres.wholphin.preferences.updateHomePagePreferences
 import com.github.damontecres.wholphin.preferences.updateInterfacePreferences
 import com.github.damontecres.wholphin.preferences.updateLiveTvPreferences
@@ -423,6 +425,20 @@ class AppUpgradeHandler
                 appPreferences.updateData {
                     it.updateScreensaverPreferences {
                         dimPercent = ScreensaverPreference.DimPercentage.defaultValue.toInt()
+                    }
+                }
+            }
+
+            if (previous.isEqualOrBefore(Version.fromString("1.0.6-7-g0"))) {
+                // preferAc3Surround was mistaken enabled by default, reset it only if the user hasn't enabled experimental settings
+                appPreferences.updateData {
+                    if (!it.experimentalPreferences.enabled) {
+                        it.updateExperimentalPreferences {
+                            preferAc3Surround =
+                                ExperimentalPreference.PreferAc3ForSurround.defaultValue
+                        }
+                    } else {
+                        it
                     }
                 }
             }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/DeviceProfileService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/DeviceProfileService.kt
@@ -5,6 +5,7 @@ import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.AssPlaybackMode
 import com.github.damontecres.wholphin.preferences.ExperimentalPreferences
 import com.github.damontecres.wholphin.preferences.PlaybackOverrides
+import com.github.damontecres.wholphin.preferences.enabled
 import com.github.damontecres.wholphin.util.WholphinDispatchers
 import com.github.damontecres.wholphin.util.profile.MediaCodecCapabilitiesTest
 import com.github.damontecres.wholphin.util.profile.createDeviceProfile
@@ -62,7 +63,7 @@ class DeviceProfileService
                                 pgsDirectPlay = newConfig.overrides.directPlayPgs,
                                 dolbyVisionELDirectPlay = newConfig.overrides.directPlayDolbyVisionEL,
                                 decodeAv1 = prefs.overrides.decodeAv1,
-                                preferAc3ForSurround = appPrefs.experimentalPreferences.preferAc3Surround,
+                                preferAc3ForSurround = appPrefs.experimentalPreferences.enabled { preferAc3Surround },
                                 jellyfinTenEleven = newConfig.jellyfinTenEleven,
                             )
                     }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/MusicService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/MusicService.kt
@@ -13,6 +13,7 @@ import androidx.media3.session.MediaSession
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.model.AudioItem
 import com.github.damontecres.wholphin.data.model.BaseItem
+import com.github.damontecres.wholphin.preferences.enabled
 import com.github.damontecres.wholphin.preferences.get
 import com.github.damontecres.wholphin.services.hilt.DefaultCoroutineScope
 import com.github.damontecres.wholphin.ui.DetailItemFields
@@ -108,7 +109,8 @@ class MusicService
         private suspend fun preferAc3Surround() =
             userPreferencesService
                 .getCurrent()
-                .appPreferences.experimentalPreferences.preferAc3Surround
+                .appPreferences.experimentalPreferences
+                .enabled { preferAc3Surround }
 
         /**
          * Start music playback


### PR DESCRIPTION
## Description
There were two problems with the experimental "Use AC3 for surround sound audio" setting (#947):
1. Defaulted to true
2. Access wasn't guarded by enabling experimental settings

This caused unintentional audio transcoding

### Related issues
Fixes #1878

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None
