### PR TITLE
Only apply Fire TV DV/HDR10+ defect workaround with a Dolby Vision display

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/util/profile/DeviceProfileUtils.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/profile/DeviceProfileUtils.kt
@@ -124,6 +124,7 @@ fun createDeviceProfile(
     val supportsHevcDolbyVisionEL = mediaTest.supportsHevcDolbyVisionEL()
     val supportsHevcHDR10 = mediaTest.supportsHevcHDR10()
     val supportsHevcHDR10Plus = mediaTest.supportsHevcHDR10Plus()
+    val displaySupportsDolbyVision = mediaTest.displaySupportsDolbyVision()
 
     name = "AndroidTV-Default"
 
@@ -510,7 +511,7 @@ fun createDeviceProfile(
                 if (!supportsHevcHDR10) add(VideoRangeType.HDR10.serialName)
             }
 
-            if (jellyfinTenEleven && KnownDefects.hevcDoviHdr10PlusBug) {
+            if (jellyfinTenEleven && KnownDefects.hevcDoviHdr10PlusBug && displaySupportsDolbyVision) {
                 add("DOVIWithHDR10Plus")
                 add("DOVIWithELHDR10Plus")
             }

--- a/app/src/main/java/com/github/damontecres/wholphin/util/profile/MediaCodecCapabilitiesTest.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/profile/MediaCodecCapabilitiesTest.kt
@@ -8,6 +8,7 @@ import android.media.MediaCodecList
 import android.media.MediaFormat
 import android.os.Build
 import android.util.Size
+import android.view.Display
 import androidx.core.content.ContextCompat
 import androidx.media3.common.MimeTypes
 import timber.log.Timber
@@ -198,6 +199,13 @@ class MediaCodecCapabilitiesTest(
     fun supportsHevcDolbyVision(): Boolean =
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
             hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_DOLBY_VISION)
+
+    // Whether the connected display can actually render Dolby Vision
+    fun displaySupportsDolbyVision(): Boolean =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+            display.hdrCapabilities
+                ?.supportedHdrTypes
+                ?.contains(Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION) == true
 
     // Checks for Dolby Vision Profile 7 (Enhancement Layer) and multi-instance HEVC support
     fun supportsHevcDolbyVisionEL(): Boolean =


### PR DESCRIPTION
## Description

The `hevcDoviHdr10PlusBug` workaround ( jellyfin/jellyfin-androidtv#4995) currently marks `DOVIWithHDR10Plus` and `DOVIWithELHDR10Plus` as unsupported based only on the Fire TV model.

On a Fire TV connected to a display that does not support Dolby Vision, this causes Dolby Vision Profile 8.1 / HDR10+ hybrid files to be transcoded to SDR instead of being played using Direct Play.

The Fire TV model alone does not indicate whether the connected display supports Dolby Vision. The workaround should therefore also take the display's actual HDR capabilities into account.

This change adds a display capability check using `Display.HdrCapabilities` and only applies the existing
`hevcDoviHdr10PlusBug` workaround when Dolby Vision is actually supported by the connected display.

Devices connected to a Dolby Vision capable display retain the existing behavior. Devices connected to a display without Dolby Vision are no longer affected by this workaround.

## Related issues

- #1789
- jellyfin/jellyfin-androidtv#4995

## Testing

Tested on:

- Amazon Fire TV Stick 4K Max (2nd Gen) Model: 'AFTKRT`
- Fire OS 8.1.8.0
- Jellyfin Server: 10.11.11
- TV: Samsung S90D

The connected TV supports HDR10, HDR10+ and HLG, but does not support Dolby Vision.

ADB reports:
`mSupportedHdrTypes=[2, 3, 4]`
No Dolby Vision capability (`HDR_TYPE_DOLBY_VISION`) is reported.

Before this change, the HEVC device profile included:

`DOVIWithHDR10Plus`
`DOVIWithELHDR10Plus`

After this change, these entries are omitted when the connected display does not support Dolby Vision.


Without this change, the affected DV Profile 8.1 / HDR10+ file was transcoded to SDR.
With this change, the file is played using Direct Play and the TV correctly switches to HDR10+.

## AI or LLM usage

ChatGPT and Claude was used to investigate the Dolby Vision / HDR10+ Direct Play
behavior and code files.

The proposed change was built and tested manually on the setup in the Testing section.