### PR TITLE
Fix white flash on app start

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/MainActivity.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewModelScope
 import androidx.navigation3.runtime.NavBackStack
 import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.preferences.AppPreferences
@@ -62,6 +63,7 @@ import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.playback.PlayExternalViewModel
 import com.github.damontecres.wholphin.ui.showToast
 import com.github.damontecres.wholphin.ui.theme.WholphinTheme
+import com.github.damontecres.wholphin.ui.theme.colors.PurpleThemeColors
 import com.github.damontecres.wholphin.ui.util.ProvideLocalClock
 import com.github.damontecres.wholphin.util.DebugLogTree
 import com.github.damontecres.wholphin.util.ExceptionHandler
@@ -228,56 +230,54 @@ class MainActivity : AppCompatActivity() {
 
         viewModel.appStart(intent)
         setContent {
-            Surface(
-                Modifier
-                    .fillMaxSize()
-                    .background(Color.Black),
-            ) {
-                val userPreferences by userPreferencesService.flow.collectAsState(null)
-                if (userPreferences == null) {
-                    // Show loading page if it is taking a while to get app preferences
-                    var showLoading by remember { mutableStateOf(false) }
-                    LaunchedEffect(Unit) {
-                        delay(500.milliseconds)
-                        Timber.i("Showing loading page")
-                        showLoading = true
-                    }
-                    if (showLoading) {
-                        Box(
-                            modifier =
-                                Modifier
-                                    .fillMaxSize()
-                                    .background(Color.Black),
-                        ) {
-                            LoadingPage()
+            MaterialTheme(colorScheme = PurpleThemeColors.darkScheme) {
+                Surface(Modifier.fillMaxSize()) {
+                    val userPreferences by userPreferencesService.flow.collectAsState(null)
+                    if (userPreferences == null) {
+                        // Show loading page if it is taking a while to get app preferences
+                        var showLoading by remember { mutableStateOf(false) }
+                        LaunchedEffect(Unit) {
+                            delay(500.milliseconds)
+                            Timber.i("Showing loading page")
+                            showLoading = true
                         }
-                    }
-                } else {
-                    userPreferences?.let { userPreferences ->
-                        val appPreferences = userPreferences.appPreferences
-                        CoilConfig(
-                            prefs = appPreferences,
-                            okHttpClient = okHttpClient,
-                            debugLogging = false,
-                            enableCache = true,
-                        )
-                        LaunchedEffect(appPreferences.debugLogging) {
-                            DebugLogTree.INSTANCE.enabled = appPreferences.debugLogging
-                        }
-                        CompositionLocalProvider(LocalImageUrlService provides imageUrlService) {
-                            WholphinTheme(
-                                true,
-                                appThemeColors = appPreferences.interfacePreferences.appThemeColors,
+                        if (showLoading) {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .fillMaxSize()
+                                        .background(Color.Black),
                             ) {
-                                ProvideLocalClock {
-                                    MainContent(
-                                        backStack = setupNavigationManager.backStack,
-                                        navigationManager = navigationManager,
-                                        userPreferences = userPreferences,
-                                        backdropService = backdropService,
-                                        screensaverService = screensaverService,
-                                        modifier = Modifier.fillMaxSize(),
-                                    )
+                                LoadingPage()
+                            }
+                        }
+                    } else {
+                        userPreferences?.let { userPreferences ->
+                            val appPreferences = userPreferences.appPreferences
+                            CoilConfig(
+                                prefs = appPreferences,
+                                okHttpClient = okHttpClient,
+                                debugLogging = false,
+                                enableCache = true,
+                            )
+                            LaunchedEffect(appPreferences.debugLogging) {
+                                DebugLogTree.INSTANCE.enabled = appPreferences.debugLogging
+                            }
+                            CompositionLocalProvider(LocalImageUrlService provides imageUrlService) {
+                                WholphinTheme(
+                                    true,
+                                    appThemeColors = appPreferences.interfacePreferences.appThemeColors,
+                                ) {
+                                    ProvideLocalClock {
+                                        MainContent(
+                                            backStack = setupNavigationManager.backStack,
+                                            navigationManager = navigationManager,
+                                            userPreferences = userPreferences,
+                                            backdropService = backdropService,
+                                            screensaverService = screensaverService,
+                                            modifier = Modifier.fillMaxSize(),
+                                        )
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Description
This fixes the brief full screen white flash when the app starts or reloads.

I bisected to find the cause which was #1653. The newly added `Surface` uses `MaterialTheme` to set its colors. `MaterialTheme` defaults to a generic _light_ color scheme. So this PR applies the Wholphin's default purple theme, which will then be overridden once the app preferences are loaded.

### Related issues
Mentioned in https://github.com/damontecres/Wholphin/issues/1576#issuecomment-5376373039

### Testing
Used emulator with "Don't keep activities" and repeatedly opened & closed the app to see if the white flash visually occurred

## Screenshots
N/A

## AI or LLM usage
None
