### PR TITLE
Fix image loading issues related to VPN and/or Fire OS 6

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/ui/CoilConfig.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/CoilConfig.kt
@@ -9,6 +9,7 @@ import coil3.disk.DiskCache
 import coil3.disk.directory
 import coil3.memory.MemoryCache
 import coil3.network.CacheStrategy
+import coil3.network.ConnectivityChecker
 import coil3.network.NetworkRequest
 import coil3.network.NetworkResponse
 import coil3.network.cachecontrol.CacheControlCacheStrategy
@@ -95,6 +96,8 @@ fun CoilConfig(
                     OkHttpNetworkFetcherFactory(
                         cacheStrategy = { WholphinCacheStrategy(CacheControlCacheStrategy()) },
                         callFactory = { client },
+                        // Disable connectivity checker which may be unreliable for VPNs and/or some versions of Android
+                        connectivityChecker = { ConnectivityChecker { true } },
                     ),
                 )
             }.build()


### PR DESCRIPTION
## Description
This PR override Coil's built-in network connectivity checker with one that allows returns true. The built-in one seems to be unreliable on devices running Fire OS 6 (maybe other versions too) and/or devices using a VPN such as Tailscale.

See more details here: https://github.com/damontecres/Wholphin/issues/1800#issuecomment-5432941761

### Related issues
Should fix #1156
Should fix #1751
Should fix #1800

### Testing
Unfortunately, I've never been able to reproduce the original issue on any of my devices, but hopefully someone who is affected can try this branch out!

This change doesn't break anything on some emulators (tried Android 7.0 & Android TV 14) or NVIDIA shield

## Screenshots
N/A

## AI or LLM usage
None

## Try it

See instructions here: https://github.com/damontecres/Wholphin/releases/tag/develop-image-fix