### PR TITLE
Fix default home rows ignoring library collection type

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
@@ -233,6 +233,12 @@ data class HomeRowViewOptions(
                 aspectRatio = AspectRatio.WIDE,
             )
 
+        val musicDefault =
+            HomeRowViewOptions(
+                heightDp = Cards.HEIGHT_EPISODE,
+                aspectRatio = AspectRatio.SQUARE,
+            )
+
         val liveTvDefault =
             HomeRowViewOptions(
                 heightDp = Cards.HEIGHT_LIVE_TV,

--- a/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/data/model/HomeRowConfig.kt
@@ -241,3 +241,35 @@ data class HomeRowViewOptions(
             )
     }
 }
+
+/**
+ * The library, collection, or playlist a row is scoped to, or null if it is not scoped to one.
+ *
+ * The `when` is deliberately exhaustive so that a new [HomeRowConfig] carrying a parent cannot be
+ * added without deciding whether it belongs here.
+ */
+val HomeRowConfig.parentIdOrNull: UUID?
+    get() =
+        when (this) {
+            is HomeRowConfig.ByParent -> parentId
+
+            is HomeRowConfig.Genres -> parentId
+
+            is HomeRowConfig.RecentlyAdded -> parentId
+
+            is HomeRowConfig.RecentlyReleased -> parentId
+
+            is HomeRowConfig.Studios -> parentId
+
+            is HomeRowConfig.Suggestions -> parentId
+
+            is HomeRowConfig.ContinueWatching,
+            is HomeRowConfig.ContinueWatchingCombined,
+            is HomeRowConfig.Favorite,
+            is HomeRowConfig.GetItems,
+            is HomeRowConfig.NextUp,
+            is HomeRowConfig.Recordings,
+            is HomeRowConfig.TvChannels,
+            is HomeRowConfig.TvPrograms,
+            -> null
+        }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
@@ -16,6 +16,7 @@ import com.github.damontecres.wholphin.ui.HomeItemFields
 import com.github.damontecres.wholphin.ui.ProgramItemFields
 import com.github.damontecres.wholphin.ui.components.getGenreImageMap
 import com.github.damontecres.wholphin.ui.formatTypeName
+import com.github.damontecres.wholphin.ui.main.settings.HomeRowPresets
 import com.github.damontecres.wholphin.ui.main.settings.Library
 import com.github.damontecres.wholphin.ui.playback.getTypeFor
 import com.github.damontecres.wholphin.ui.toBaseItems
@@ -293,7 +294,11 @@ class HomeSettingsService
                             HomeRowConfigDisplay(
                                 id = index,
                                 title = title,
-                                config = HomeRowConfig.RecentlyAdded(parentId),
+                                config =
+                                    HomeRowConfig.RecentlyAdded(
+                                        parentId,
+                                        HomeRowPresets.WholphinDefault.getByCollectionType(it.collectionType),
+                                    ),
                             )
                         }
                     }
@@ -409,7 +414,13 @@ class HomeSettingsService
                                                 R.string.recently_added_in,
                                                 it.name ?: "",
                                             ),
-                                        config = HomeRowConfig.RecentlyAdded(it.id),
+                                        config =
+                                            HomeRowConfig.RecentlyAdded(
+                                                it.id,
+                                                HomeRowPresets.WholphinDefault.getByCollectionType(
+                                                    it.collectionType ?: CollectionType.UNKNOWN,
+                                                ),
+                                            ),
                                     )
                                 }
                             } else if (config != null) {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedMusic.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedMusic.kt
@@ -6,8 +6,6 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.model.HomeRowViewOptions
 import com.github.damontecres.wholphin.preferences.UserPreferences
-import com.github.damontecres.wholphin.ui.AspectRatio
-import com.github.damontecres.wholphin.ui.Cards
 import com.github.damontecres.wholphin.ui.SlimItemFields
 import com.github.damontecres.wholphin.ui.data.RowColumn
 import com.github.damontecres.wholphin.util.GetItemsRequestHandler
@@ -90,12 +88,7 @@ fun RecommendedMusic(
                     parentId = parentId,
                     suggestionsType = BaseItemKind.MUSIC_ALBUM,
                     recommendedRows = getRecommendedRows(parentId),
-                    viewOptions =
-                        HomeRowViewOptions(
-                            aspectRatio = AspectRatio.SQUARE,
-                            heightDp = Cards.HEIGHT_EPISODE,
-                            showTitles = true,
-                        ),
+                    viewOptions = HomeRowViewOptions.musicDefault.copy(showTitles = true),
                 )
             },
         ),

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionRows.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionRows.kt
@@ -66,9 +66,7 @@ fun CollectionRows(
                                     BaseItemKind.PLAYLIST,
                                     BaseItemKind.AUDIO,
                                     -> {
-                                        HomeRowViewOptions(
-                                            heightDp = Cards.HEIGHT_EPISODE,
-                                            aspectRatio = AspectRatio.SQUARE,
+                                        HomeRowViewOptions.musicDefault.copy(
                                             showTitles = cardViewOptions.showTitles,
                                         )
                                     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowPresets.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowPresets.kt
@@ -118,10 +118,7 @@ data class HomeRowPresets(
                         aspectRatio = AspectRatio.WIDE,
                         contentScale = PrefContentScale.CROP,
                     ),
-                musicLibrary =
-                    HomeRowViewOptions(
-                        aspectRatio = AspectRatio.SQUARE,
-                    ),
+                musicLibrary = HomeRowViewOptions.musicDefault,
                 playlist =
                     HomeRowViewOptions(
                         aspectRatio = AspectRatio.SQUARE,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsPage.kt
@@ -31,6 +31,7 @@ import androidx.tv.material3.surfaceColorAtElevation
 import com.github.damontecres.wholphin.R
 import com.github.damontecres.wholphin.data.model.HomeRowConfig
 import com.github.damontecres.wholphin.data.model.HomeRowViewOptions
+import com.github.damontecres.wholphin.data.model.parentIdOrNull
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.components.BasicDialog
@@ -48,6 +49,7 @@ import com.github.damontecres.wholphin.util.HomeRowLoadingState
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.jellyfin.sdk.model.api.BaseItemKind
+import org.jellyfin.sdk.model.api.CollectionType
 import timber.log.Timber
 
 val settingsWidth = 360.dp
@@ -215,10 +217,22 @@ fun HomeSettingsPage(
                                         }
                                     }
                                 val defaultViewOptions =
-                                    remember(row.config) {
+                                    remember(row.config, state.libraries) {
                                         when (row.config) {
-                                            is HomeRowConfig.Genres -> HomeRowViewOptions.genreDefault
-                                            else -> HomeRowViewOptions()
+                                            is HomeRowConfig.Genres,
+                                            is HomeRowConfig.Studios,
+                                            -> {
+                                                HomeRowViewOptions.genreDefault
+                                            }
+
+                                            else -> {
+                                                val parentId = row.config.parentIdOrNull
+                                                HomeRowPresets.WholphinDefault.getByCollectionType(
+                                                    state.libraries
+                                                        .firstOrNull { it.itemId == parentId }
+                                                        ?.collectionType ?: CollectionType.UNKNOWN,
+                                                )
+                                            }
                                         }
                                     }
                                 HomeRowSettings(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
@@ -34,7 +34,6 @@ import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.services.getRecentlyAddedTitle
 import com.github.damontecres.wholphin.services.hilt.IoCoroutineScope
 import com.github.damontecres.wholphin.services.tvAccess
-import com.github.damontecres.wholphin.ui.AspectRatio
 import com.github.damontecres.wholphin.ui.formatTypeName
 import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.launchIO
@@ -276,23 +275,7 @@ class HomeSettingsViewModel
         ): Job =
             viewModelScope.launchIO {
                 val viewOptions =
-                    when (library.collectionType) {
-                        CollectionType.MUSIC -> {
-                            HomeRowViewOptions(aspectRatio = AspectRatio.SQUARE)
-                        }
-
-                        CollectionType.HOMEVIDEOS,
-                        CollectionType.MUSICVIDEOS,
-                        -> {
-                            HomeRowViewOptions(
-                                aspectRatio = AspectRatio.WIDE,
-                            )
-                        }
-
-                        else -> {
-                            HomeRowViewOptions()
-                        }
-                    }
+                    HomeRowPresets.WholphinDefault.getByCollectionType(library.collectionType)
                 val id = idCounter++
                 val newRow =
                     when (rowType) {

--- a/app/src/test/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowPresetsTest.kt
+++ b/app/src/test/java/com/github/damontecres/wholphin/ui/main/settings/HomeRowPresetsTest.kt
@@ -1,0 +1,23 @@
+package com.github.damontecres.wholphin.ui.main.settings
+
+import com.github.damontecres.wholphin.data.model.HomeRowViewOptions
+import com.github.damontecres.wholphin.ui.AspectRatio
+import com.github.damontecres.wholphin.ui.Cards
+import org.jellyfin.sdk.model.api.CollectionType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeRowPresetsTest {
+    @Test
+    fun defaultMusicRowsMatchTheMusicLibraryCardSize() {
+        val options = HomeRowPresets.WholphinDefault.getByCollectionType(CollectionType.MUSIC)
+
+        assertEquals(
+            HomeRowViewOptions(
+                heightDp = Cards.HEIGHT_EPISODE,
+                aspectRatio = AspectRatio.SQUARE,
+            ),
+            options,
+        )
+    }
+}


### PR DESCRIPTION
<!-- By submitting this pull request, you acknowledge that you have read the [contributing guide](https://github.com/damontecres/Wholphin/blob/main/CONTRIBUTING.md), including the AI/LLM policy, and [developer's guide](https://github.com/damontecres/Wholphin/blob/main/DEVELOPMENT.md) -->

## Description

Automatic Home rows for a library used the generic movie/TV poster cards. Music albums were stretched into that tall shape, and other library types did not pick up the card style used inside those libraries.

Default row creation, per-row reset, and adding a library row now take view options from the parent library's collection type. Music rows are 128dp square, matching a Music library. Photos get wide/cropped cards, home videos and music videos get wide cards, and so on.

Studios now reset to the same genre-style cards as Genres. Existing saved rows keep their stored options until you reset them or recreate the default layout.

### Related issues

Fixes #1838

### Testing

- `./gradlew testDefaultDebugUnitTest --tests com.github.damontecres.wholphin.ui.main.settings.HomeRowPresetsTest` passed (asserts the default music row is 128dp square).
- Not tested on a TV. After installing the build, reset a music Home row (or recreate the default layout) and compare it to the Recommended tab in that Music library — cards should match in shape and size.

## Screenshots

None yet — this was not run on a TV.

## AI or LLM usage

Cursor (Grok 4.6) implemented the collection-type default lookup, the shared 128dp-square music default, and `HomeRowPresetsTest`. The music-size unit test was run locally and passed.
