### PR TITLE
Add Seerr missing season requests to series details

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/SeerrService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/SeerrService.kt
@@ -4,9 +4,12 @@ import com.github.damontecres.wholphin.api.seerr.SeerrApiClient
 import com.github.damontecres.wholphin.api.seerr.model.CreditCast
 import com.github.damontecres.wholphin.api.seerr.model.CreditCrew
 import com.github.damontecres.wholphin.api.seerr.model.MediaInfo
+import com.github.damontecres.wholphin.api.seerr.model.MediaRequest
 import com.github.damontecres.wholphin.api.seerr.model.MovieDetails
 import com.github.damontecres.wholphin.api.seerr.model.MovieResult
 import com.github.damontecres.wholphin.api.seerr.model.RootFolder
+import com.github.damontecres.wholphin.api.seerr.model.RequestPostRequest
+import com.github.damontecres.wholphin.api.seerr.model.RequestRequestIdPutRequest
 import com.github.damontecres.wholphin.api.seerr.model.SearchGet200ResponseResultsInner
 import com.github.damontecres.wholphin.api.seerr.model.ServiceProfile
 import com.github.damontecres.wholphin.api.seerr.model.TvDetails
@@ -16,10 +19,12 @@ import com.github.damontecres.wholphin.data.model.DiscoverItem
 import com.github.damontecres.wholphin.data.model.SeerrAvailability
 import com.github.damontecres.wholphin.data.model.SeerrItemType
 import com.github.damontecres.wholphin.data.model.SeerrPermission
+import com.github.damontecres.wholphin.data.model.RequestStatus
 import com.github.damontecres.wholphin.data.model.hasPermission
 import com.github.damontecres.wholphin.ui.detail.discover.SeerrProfile
 import com.github.damontecres.wholphin.ui.detail.discover.SeerrRequestData
 import com.github.damontecres.wholphin.ui.detail.discover.SeerrRootFolder
+import com.github.damontecres.wholphin.ui.detail.discover.TvRequest
 import com.github.damontecres.wholphin.ui.formatBytes
 import com.github.damontecres.wholphin.ui.isNotNullOrBlank
 import com.github.damontecres.wholphin.ui.toLocalDate
@@ -161,6 +166,51 @@ class SeerrService
             } else {
                 null
             }
+
+        suspend fun requestTv(
+            tv: TvDetails,
+            request: TvRequest,
+        ): MediaRequest {
+            val currentUserId = seerrServerRepository.currentUserId.first()
+            val currentRequest =
+                tv.mediaInfo?.requests?.firstOrNull {
+                    it.status == RequestStatus.PENDING.status &&
+                        it.requestedBy?.id == currentUserId
+                }
+            val serverId =
+                when {
+                    request.profileId == null && request.folder == null -> null
+                    request.is4k -> request.data.server4kId
+                    else -> request.data.serverId
+                }
+            return if (currentRequest != null) {
+                api.requestApi.requestRequestIdPut(
+                    requestId = currentRequest.id.toString(),
+                    requestRequestIdPutRequest =
+                        RequestRequestIdPutRequest(
+                            is4k = request.is4k,
+                            mediaType = RequestRequestIdPutRequest.MediaType.TV,
+                            seasons = request.seasons,
+                            serverId = serverId,
+                            profileId = request.profileId,
+                            rootFolder = request.folder,
+                        ),
+                )
+            } else {
+                api.requestApi.requestPost(
+                    RequestPostRequest(
+                        is4k = request.is4k,
+                        mediaId = request.tvId,
+                        mediaType = RequestPostRequest.MediaType.TV,
+                        seasons = request.seasons,
+                        serverId = serverId,
+                        profileId = request.profileId,
+                        rootFolder = request.folder,
+                        tags = emptyList(),
+                    ),
+                )
+            }
+        }
 
         suspend fun createImageUrl(
             imageType: ImageType,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/SeasonCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/SeasonCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
@@ -50,6 +51,7 @@ fun SeasonCard(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     showImageOverlay: Boolean = false,
     aspectRatio: Float = item?.aspectRatio ?: AspectRatios.TALL,
+    imageAlpha: Float = 1f,
 ) {
     val imageUrl = rememberImageUrl(item, imageHeight, imageWidth)
     SeasonCard(
@@ -70,6 +72,7 @@ fun SeasonCard(
         interactionSource = interactionSource,
         showImageOverlay = showImageOverlay,
         aspectRatio = aspectRatio,
+        imageAlpha = imageAlpha,
     )
 }
 
@@ -136,6 +139,7 @@ fun SeasonCard(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     showImageOverlay: Boolean = false,
     aspectRatio: Float = AspectRatios.TALL,
+    imageAlpha: Float = 1f,
 ) {
     val focused by interactionSource.collectIsFocusedAsState()
     // Do not use `by` here, this way we are Defer reads and recompositions to only when modifier calculates
@@ -170,7 +174,8 @@ fun SeasonCard(
             Box(
                 modifier =
                     Modifier
-                        .fillMaxSize(),
+                        .fillMaxSize()
+                        .alpha(imageAlpha),
             ) {
                 ItemCardImage(
                     imageUrl = imageUrl,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/cards/SeasonCard.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/cards/SeasonCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -52,6 +53,7 @@ fun SeasonCard(
     showImageOverlay: Boolean = false,
     aspectRatio: Float = item?.aspectRatio ?: AspectRatios.TALL,
     imageAlpha: Float = 1f,
+    artworkOverlay: @Composable BoxScope.() -> Unit = {},
 ) {
     val imageUrl = rememberImageUrl(item, imageHeight, imageWidth)
     SeasonCard(
@@ -73,6 +75,7 @@ fun SeasonCard(
         showImageOverlay = showImageOverlay,
         aspectRatio = aspectRatio,
         imageAlpha = imageAlpha,
+        artworkOverlay = artworkOverlay,
     )
 }
 
@@ -140,6 +143,7 @@ fun SeasonCard(
     showImageOverlay: Boolean = false,
     aspectRatio: Float = AspectRatios.TALL,
     imageAlpha: Float = 1f,
+    artworkOverlay: @Composable BoxScope.() -> Unit = {},
 ) {
     val focused by interactionSource.collectIsFocusedAsState()
     // Do not use `by` here, this way we are Defer reads and recompositions to only when modifier calculates
@@ -171,12 +175,7 @@ fun SeasonCard(
                     containerColor = Color.Transparent,
                 ),
         ) {
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .alpha(imageAlpha),
-            ) {
+            Box(modifier = Modifier.fillMaxSize()) {
                 ItemCardImage(
                     imageUrl = imageUrl,
                     name = name,
@@ -189,8 +188,10 @@ fun SeasonCard(
                     useFallbackText = false,
                     modifier =
                         Modifier
-                            .fillMaxSize(),
+                            .fillMaxSize()
+                            .alpha(imageAlpha),
                 )
+                artworkOverlay()
             }
         }
         Column(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/discover/DiscoverSeriesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/discover/DiscoverSeriesViewModel.kt
@@ -5,8 +5,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.damontecres.wholphin.api.seerr.model.MediaInfo
 import com.github.damontecres.wholphin.api.seerr.model.RelatedVideo
-import com.github.damontecres.wholphin.api.seerr.model.RequestPostRequest
-import com.github.damontecres.wholphin.api.seerr.model.RequestRequestIdPutRequest
 import com.github.damontecres.wholphin.api.seerr.model.TvDetails
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.model.DiscoverItem
@@ -186,94 +184,7 @@ class DiscoverSeriesViewModel
             is4k: Boolean,
         ) {
             val currentUserId = seerrServerRepository.currentUserId.first()
-            val seasonStatus = mutableMapOf<Int, RequestStatus>()
-            val seasonAvailability = mutableMapOf<Int, SeerrAvailability>()
-            val editable = mutableMapOf<Int, Boolean>()
-            tv.seasons?.forEach {
-                it.seasonNumber?.let { seasonNumber ->
-                    seasonStatus[seasonNumber] = RequestStatus.UNKNOWN
-                    val status = if (is4k) it.status4k else it.status
-                    val availability =
-                        SeerrAvailability.from(status) ?: SeerrAvailability.UNKNOWN
-                    seasonAvailability[seasonNumber] = availability
-                }
-            }
-            tv.mediaInfo?.seasons?.forEach {
-                it.seasonNumber?.let { seasonNumber ->
-                    val status = if (is4k) it.status4k else it.status
-                    val availability =
-                        SeerrAvailability.from(status) ?: SeerrAvailability.UNKNOWN
-                    val current =
-                        seasonAvailability.getOrDefault(seasonNumber, SeerrAvailability.UNKNOWN)
-                    if (availability > current) {
-                        seasonAvailability[seasonNumber] = availability
-                    }
-                }
-            }
-
-            tv.mediaInfo
-                ?.requests
-                ?.filter { it.is4k == is4k }
-                ?.forEach { req ->
-                    req.seasons?.mapNotNull { season ->
-                        season.seasonNumber?.let {
-                            val current = seasonStatus[season.seasonNumber]
-                            // Not status4k because the request itself is marked as is4k or not
-                            val status = season.status
-                            val new = RequestStatus.from(status)
-                            if (current == null || new.status > current.status) {
-                                seasonStatus[season.seasonNumber] = new
-                            }
-                            editable[season.seasonNumber] =
-                                currentUserId == req.requestedBy?.id && req.status == RequestStatus.PENDING.status
-                        }
-                    }
-                }
-            Timber.v("seasonAvailability=%s", seasonAvailability)
-            Timber.v("seasonStatus=%s", seasonStatus)
-            val requestSeasons =
-                seasonStatus.mapNotNull { (seasonNumber, status) ->
-                    tv.seasons?.firstOrNull { it.seasonNumber == seasonNumber }?.let {
-                        val availability =
-                            when (status) {
-                                RequestStatus.PENDING -> {
-                                    SeerrAvailability.PENDING
-                                }
-
-                                RequestStatus.APPROVED -> {
-                                    SeerrAvailability.PROCESSING
-                                }
-
-                                RequestStatus.DECLINED -> {
-                                    SeerrAvailability.UNKNOWN
-                                }
-
-                                RequestStatus.FAILURE -> {
-                                    SeerrAvailability.UNKNOWN
-                                }
-
-                                RequestStatus.UNKNOWN,
-                                RequestStatus.COMPLETED,
-                                -> {
-                                    seasonAvailability.getOrDefault(
-                                        seasonNumber,
-                                        SeerrAvailability.UNKNOWN,
-                                    )
-                                }
-                            }
-                        val defaultEditable =
-                            availability != SeerrAvailability.AVAILABLE &&
-                                availability != SeerrAvailability.PARTIALLY_AVAILABLE &&
-                                availability != SeerrAvailability.PROCESSING &&
-                                availability != SeerrAvailability.BLOCKLISTED
-                        RequestSeason(
-                            season = it,
-                            status = status,
-                            availability = availability,
-                            editable = editable.getOrDefault(seasonNumber, defaultEditable),
-                        )
-                    }
-                }
+            val requestSeasons = tv.toRequestSeasons(currentUserId, is4k)
             Timber.v("Got %s seasons, is4k=%s", requestSeasons.size, is4k)
 //            requestSeasons.forEach {
 //                Timber.v(
@@ -331,52 +242,8 @@ class DiscoverSeriesViewModel
         fun request(request: TvRequest) {
             viewModelScope.launchIO {
                 state.value.tvSeries.successValue?.let { tv ->
-                    val currentUserId = seerrServerRepository.currentUserId.first()
-                    val currentRequest =
-                        tv.mediaInfo?.requests?.firstOrNull {
-                            it.status == RequestStatus.PENDING.status &&
-                                it.requestedBy?.id == currentUserId
-                        }
                     try {
-                        if (currentRequest != null) {
-                            Timber.v("User has pending request, will update")
-                            seerrService.api.requestApi.requestRequestIdPut(
-                                requestId = currentRequest.id.toString(),
-                                requestRequestIdPutRequest =
-                                    RequestRequestIdPutRequest(
-                                        is4k = request.is4k,
-                                        mediaType = RequestRequestIdPutRequest.MediaType.TV,
-                                        seasons = request.seasons,
-                                        serverId =
-                                            when {
-                                                request.profileId == null && request.folder == null -> null
-                                                request.is4k -> request.data.server4kId
-                                                else -> request.data.serverId
-                                            },
-                                        profileId = request.profileId,
-                                        rootFolder = request.folder,
-                                    ),
-                            )
-                        } else {
-                            Timber.v("New request for %s seasons", request.seasons.size)
-                            seerrService.api.requestApi.requestPost(
-                                RequestPostRequest(
-                                    is4k = request.is4k,
-                                    mediaId = request.tvId,
-                                    mediaType = RequestPostRequest.MediaType.TV,
-                                    seasons = request.seasons,
-                                    serverId =
-                                        when {
-                                            request.profileId == null && request.folder == null -> null
-                                            request.is4k -> request.data.server4kId
-                                            else -> request.data.serverId
-                                        },
-                                    profileId = request.profileId,
-                                    rootFolder = request.folder,
-                                    tags = emptyList(),
-                                ),
-                            )
-                        }
+                        seerrService.requestTv(tv, request)
                     } catch (ex: CancellationException) {
                         throw ex
                     } catch (ex: Exception) {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/discover/RequestSeasons.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/discover/RequestSeasons.kt
@@ -9,9 +9,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -19,6 +24,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,6 +37,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Button
 import androidx.tv.material3.ClickableSurfaceDefaults
+import androidx.tv.material3.Icon
 import androidx.tv.material3.ListItem
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
@@ -49,6 +57,8 @@ import com.github.damontecres.wholphin.ui.components.LoadingPage
 import com.github.damontecres.wholphin.ui.theme.WholphinTheme
 import com.github.damontecres.wholphin.ui.tryRequestFocus
 import com.github.damontecres.wholphin.util.LoadingState
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 
 data class RequestSeason(
     val season: Season,
@@ -128,6 +138,30 @@ fun RequestSeasons(
     }
     val profiles = remember(is4k, data) { if (is4k) data.profiles4k else data.profiles }
     val folders = remember(is4k, data) { if (is4k) data.rootFolders4k else data.rootFolders }
+    val initialSeason =
+        remember(seasons, initialSeasonNumber) {
+            seasons.firstOrNull { it.season.seasonNumber == initialSeasonNumber }
+        }
+    val remainingSeasons =
+        remember(seasons, initialSeasonNumber) {
+            seasons.filterNot { it.season.seasonNumber == initialSeasonNumber }
+        }
+    var moreSeasonsExpanded by rememberSaveable(initialSeasonNumber) {
+        mutableStateOf(initialSeasonNumber == null)
+    }
+    var advancedOptionsExpanded by rememberSaveable(initialSeasonNumber) { mutableStateOf(false) }
+    val submitFocusRequester = remember { FocusRequester() }
+    val seasonsContentBringIntoViewRequester = remember { BringIntoViewRequester() }
+    val advancedContentBringIntoViewRequester = remember { BringIntoViewRequester() }
+    val scope = rememberCoroutineScope()
+    val hasAdvancedOptions =
+        request4kEnabled ||
+            (profiles.isNotEmpty() && profile != null) ||
+            (folders.isNotEmpty() && folder != null)
+
+    LaunchedEffect(Unit) {
+        submitFocusRequester.tryRequestFocus()
+    }
 
     fun submit() {
         onSubmit.invoke(
@@ -156,113 +190,203 @@ fun RequestSeasons(
             modifier = Modifier,
         ) {
             item {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween,
+                Box(
+                    contentAlignment = Alignment.Center,
                     modifier =
                         Modifier
                             .fillMaxWidth()
                             .padding(vertical = 8.dp),
                 ) {
-                    if (request4kEnabled) {
-                        ClickSwitch(
-                            label = stringResource(R.string.request_4k),
-                            checked = is4k,
-                            onClick = { is4k = !is4k },
-                        )
-                    }
                     Button(
                         onClick = ::submit,
                         enabled = selectedSeasons.isNotEmpty(),
+                        modifier = Modifier.focusRequester(submitFocusRequester),
                     ) {
-                        Text(
-                            text = stringResource(R.string.submit),
-                        )
+                        Text(text = stringResource(R.string.submit_request))
                     }
                 }
             }
-            if (profiles.isNotEmpty()) {
-                profile?.let {
-                    item {
-                        ChooseProfile(
-                            selectedProfile = it,
-                            profiles = profiles,
-                            onClickProfile = { profile = it },
-                            modifier = Modifier,
+            initialSeason?.let { season ->
+                item(key = "initial_${season.season.seasonNumber}") {
+                    val seasonNumber = season.season.seasonNumber
+                    val checked = seasonNumber in selectedSeasons || seasonNumber in availableSeasons
+                    SeasonListItem(
+                        season = season,
+                        checked = checked,
+                        onClick = {
+                            if (checked) {
+                                selectedSeasons.remove(seasonNumber)
+                            } else {
+                                seasonNumber?.let { selectedSeasons.add(it) }
+                            }
+                        },
+                    )
+                }
+            }
+            item {
+                RequestSectionHeader(
+                    title =
+                        stringResource(
+                            if (initialSeasonNumber == null) {
+                                R.string.tv_seasons
+                            } else {
+                                R.string.more_seasons
+                            },
+                        ),
+                    expanded = moreSeasonsExpanded,
+                    onClick = {
+                        moreSeasonsExpanded = !moreSeasonsExpanded
+                        if (moreSeasonsExpanded) {
+                            scope.launch {
+                                yield()
+                                seasonsContentBringIntoViewRequester.bringIntoView()
+                            }
+                        }
+                    },
+                )
+            }
+            if (moreSeasonsExpanded) {
+                item {
+                    val isSelected = selectedSeasons.containsAll(allSeasonNumbers)
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .bringIntoViewRequester(seasonsContentBringIntoViewRequester),
+                    ) {
+                        ClickSwitch(
+                            label = stringResource(R.string.select_all),
+                            checked = isSelected,
+                            onClick = {
+                                if (isSelected) {
+                                    selectedSeasons.removeAll(allSeasonNumbers)
+                                } else {
+                                    selectedSeasons.addAll(allSeasonNumbers)
+                                }
+                            },
                         )
                     }
                 }
-            }
-            if (folders.isNotEmpty()) {
-                folder?.let {
-                    item {
-                        ChooseFolder(
-                            selectedFolder = it,
-                            folders = folders,
-                            onClickFolder = { folder = it },
-                            modifier = Modifier,
-                        )
-                    }
+                itemsIndexed(
+                    items = remainingSeasons,
+                    key = { _, season ->
+                        season.season.seasonNumber ?: season.season.id ?: season.hashCode()
+                    },
+                ) { _, season ->
+                    val seasonNumber = season.season.seasonNumber
+                    val checked = seasonNumber in selectedSeasons || seasonNumber in availableSeasons
+                    SeasonListItem(
+                        season = season,
+                        checked = checked,
+                        onClick = {
+                            if (checked) {
+                                selectedSeasons.remove(seasonNumber)
+                            } else {
+                                seasonNumber?.let { selectedSeasons.add(it) }
+                            }
+                        },
+                    )
                 }
             }
             item {
                 HorizontalDivider()
-            }
-            item {
-                Text(
-                    text = stringResource(R.string.tv_seasons),
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-                val isSelected = selectedSeasons.containsAll(allSeasonNumbers)
-                ClickSwitch(
-                    label = stringResource(R.string.select_all),
-                    checked = isSelected,
+                RequestSectionHeader(
+                    title = stringResource(R.string.advanced_options),
+                    expanded = advancedOptionsExpanded,
                     onClick = {
-                        if (isSelected) {
-                            selectedSeasons.removeAll(allSeasonNumbers)
-                        } else {
-                            selectedSeasons.addAll(allSeasonNumbers)
+                        advancedOptionsExpanded = !advancedOptionsExpanded
+                        if (advancedOptionsExpanded && hasAdvancedOptions) {
+                            scope.launch {
+                                yield()
+                                advancedContentBringIntoViewRequester.bringIntoView()
+                            }
                         }
                     },
                 )
             }
-            itemsIndexed(seasons) { index, season ->
-                val seasonNumber = season.season.seasonNumber
-                val checked = seasonNumber in selectedSeasons || seasonNumber in availableSeasons
-                SeasonListItem(
-                    season = season,
-                    checked = checked,
-                    onClick = {
-                        if (checked) {
-                            selectedSeasons.remove(seasonNumber)
-                        } else {
-                            seasonNumber?.let { selectedSeasons.add(it) }
-                        }
-                    },
-                    modifier = Modifier,
-                )
-            }
-            if (seasons.size > 3) {
-                item {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 8.dp),
-                    ) {
-                        Button(
-                            onClick = ::submit,
-                            enabled = selectedSeasons.isNotEmpty(),
+            if (advancedOptionsExpanded) {
+                if (request4kEnabled) {
+                    item {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .bringIntoViewRequester(advancedContentBringIntoViewRequester),
                         ) {
-                            Text(
-                                text = stringResource(R.string.submit),
+                            ClickSwitch(
+                                label = stringResource(R.string.request_4k),
+                                checked = is4k,
+                                onClick = { is4k = !is4k },
+                            )
+                        }
+                    }
+                }
+                if (profiles.isNotEmpty()) {
+                    profile?.let {
+                        item {
+                            ChooseProfile(
+                                selectedProfile = it,
+                                profiles = profiles,
+                                onClickProfile = { profile = it },
+                                modifier =
+                                    if (!request4kEnabled) {
+                                        Modifier.bringIntoViewRequester(
+                                            advancedContentBringIntoViewRequester,
+                                        )
+                                    } else {
+                                        Modifier
+                                    },
+                            )
+                        }
+                    }
+                }
+                if (folders.isNotEmpty()) {
+                    folder?.let {
+                        item {
+                            ChooseFolder(
+                                selectedFolder = it,
+                                folders = folders,
+                                onClickFolder = { folder = it },
+                                modifier =
+                                    if (!request4kEnabled && profiles.isEmpty()) {
+                                        Modifier.bringIntoViewRequester(
+                                            advancedContentBringIntoViewRequester,
+                                        )
+                                    } else {
+                                        Modifier
+                                    },
                             )
                         }
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun RequestSectionHeader(
+    title: String,
+    expanded: Boolean,
+    onClick: () -> Unit,
+) {
+    ClickSurface(
+        onClick = onClick,
+        modifier =
+            Modifier
+                .padding(horizontal = 8.dp)
+                .fillMaxWidth(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 12.dp),
+        ) {
+            Text(text = title)
+            Text(text = if (expanded) "−" else "+")
         }
     }
 }
@@ -278,10 +402,14 @@ fun SeasonListItem(
         enabled = season.editable,
         selected = false,
         headlineContent = {
+            val seasonNumber = season.season.seasonNumber
             Text(
                 text =
-                    season.season.name
-                        ?: (stringResource(R.string.tv_season) + " ${season.season.seasonNumber}"),
+                    when (seasonNumber) {
+                        0 -> stringResource(R.string.specials)
+                        null -> season.season.name ?: stringResource(R.string.unknown)
+                        else -> stringResource(R.string.tv_season) + " $seasonNumber"
+                    },
             )
         },
         supportingContent = {
@@ -293,29 +421,37 @@ fun SeasonListItem(
             }
         },
         leadingContent = {
-            when (season.availability) {
-                SeerrAvailability.UNKNOWN,
-                SeerrAvailability.DELETED,
-                -> {
-                }
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.width(32.dp),
+            ) {
+                when (season.availability) {
+                    SeerrAvailability.PENDING,
+                    SeerrAvailability.PROCESSING,
+                    -> {
+                        PendingIndicator()
+                    }
 
-                SeerrAvailability.PENDING,
-                SeerrAvailability.PROCESSING,
-                -> {
-                    PendingIndicator()
-                }
+                    SeerrAvailability.PARTIALLY_AVAILABLE -> {
+                        PartiallyAvailableIndicator()
+                    }
 
-                SeerrAvailability.PARTIALLY_AVAILABLE -> {
-                    PartiallyAvailableIndicator()
-                }
+                    SeerrAvailability.AVAILABLE -> {
+                        AvailableIndicator()
+                    }
 
-                SeerrAvailability.AVAILABLE -> {
-                    AvailableIndicator()
-                }
-
-                SeerrAvailability.BLOCKLISTED -> {
-                    // TODO handle block listed
-                    //                    BlocklistedIndicator()
+                    SeerrAvailability.UNKNOWN,
+                    SeerrAvailability.DELETED,
+                    SeerrAvailability.BLOCKLISTED,
+                    -> {
+                        if (season.editable) {
+                            Icon(
+                                imageVector = Icons.Default.Add,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    }
                 }
             }
         },
@@ -409,12 +545,16 @@ fun RequestSeasonsDialog(
             LoadingState.Loading,
             LoadingState.Pending,
             -> {
-                LoadingPage(Modifier)
+                LoadingPage(
+                    focusEnabled = false,
+                    modifier =
+                        Modifier
+                            .width(400.dp)
+                            .height(280.dp),
+                )
             }
 
             LoadingState.Success -> {
-                val focusRequester = remember { FocusRequester() }
-                LaunchedEffect(Unit) { focusRequester.tryRequestFocus() }
                 RequestSeasons(
                     id = id,
                     title = title,
@@ -424,10 +564,7 @@ fun RequestSeasonsDialog(
                     request4kEnabled = request4kEnabled,
                     initialSeasonNumber = initialSeasonNumber,
                     onSubmit = onSubmit,
-                    modifier =
-                        Modifier
-                            .padding(16.dp)
-                            .focusRequester(focusRequester),
+                    modifier = Modifier.padding(16.dp),
                 )
             }
         }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/discover/RequestSeasons.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/discover/RequestSeasons.kt
@@ -66,6 +66,7 @@ fun RequestSeasons(
     data: SeerrRequestData,
     request4kEnabled: Boolean,
     onSubmit: (TvRequest) -> Unit,
+    initialSeasonNumber: Int? = null,
     modifier: Modifier = Modifier,
 ) {
     var is4k by remember { mutableStateOf(request4kEnabled) }
@@ -95,10 +96,13 @@ fun RequestSeasons(
             )
         }
     val selectedSeasons =
-        remember(seasons) {
+        remember(seasons, initialSeasonNumber) {
             mutableStateSetOf<Int>(
                 *seasons
-                    .filter { season -> season.status == RequestStatus.PENDING }
+                    .filter { season ->
+                        season.status == RequestStatus.PENDING ||
+                            (season.editable && season.season.seasonNumber == initialSeasonNumber)
+                    }
                     .mapNotNull { season -> season.season.seasonNumber }
                     .toTypedArray(),
             )
@@ -390,6 +394,7 @@ fun RequestSeasonsDialog(
     seasons: List<RequestSeason>,
     seasons4k: List<RequestSeason>,
     request4kEnabled: Boolean,
+    initialSeasonNumber: Int? = null,
     onSubmit: (TvRequest) -> Unit,
     onDismissRequest: () -> Unit,
 ) {
@@ -417,6 +422,7 @@ fun RequestSeasonsDialog(
                     seasons = seasons,
                     seasons4k = seasons4k,
                     request4kEnabled = request4kEnabled,
+                    initialSeasonNumber = initialSeasonNumber,
                     onSubmit = onSubmit,
                     modifier =
                         Modifier

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/discover/RequestSeasons.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/discover/RequestSeasons.kt
@@ -67,6 +67,13 @@ data class RequestSeason(
     val editable: Boolean,
 )
 
+private fun RequestSeason.isRelevantToRequest(): Boolean =
+    editable ||
+        status == RequestStatus.PENDING ||
+        status == RequestStatus.APPROVED ||
+        availability == SeerrAvailability.PENDING ||
+        availability == SeerrAvailability.PROCESSING
+
 @Composable
 fun RequestSeasons(
     id: Int,
@@ -82,13 +89,6 @@ fun RequestSeasons(
     var is4k by remember { mutableStateOf(request4kEnabled) }
     val seasons = remember(is4k, seasons, seasons4k) { if (is4k) seasons4k else seasons }
 
-    val allSeasonNumbers =
-        remember(seasons) {
-            seasons
-                .filter { it.editable }
-                .mapNotNull { it.season.seasonNumber }
-                .toSet()
-        }
     val availableSeasons =
         remember(seasons) {
             mutableStateSetOf(
@@ -144,7 +144,16 @@ fun RequestSeasons(
         }
     val remainingSeasons =
         remember(seasons, initialSeasonNumber) {
-            seasons.filterNot { it.season.seasonNumber == initialSeasonNumber }
+            seasons.filter {
+                it.season.seasonNumber != initialSeasonNumber && it.isRelevantToRequest()
+            }
+        }
+    val allSeasonNumbers =
+        remember(remainingSeasons) {
+            remainingSeasons
+                .filter { it.editable }
+                .mapNotNull { it.season.seasonNumber }
+                .toSet()
         }
     var moreSeasonsExpanded by rememberSaveable(initialSeasonNumber) {
         mutableStateOf(initialSeasonNumber == null)
@@ -223,69 +232,71 @@ fun RequestSeasons(
                     )
                 }
             }
-            item {
-                RequestSectionHeader(
-                    title =
-                        stringResource(
-                            if (initialSeasonNumber == null) {
-                                R.string.tv_seasons
-                            } else {
-                                R.string.more_seasons
-                            },
-                        ),
-                    expanded = moreSeasonsExpanded,
-                    onClick = {
-                        moreSeasonsExpanded = !moreSeasonsExpanded
-                        if (moreSeasonsExpanded) {
-                            scope.launch {
-                                yield()
-                                seasonsContentBringIntoViewRequester.bringIntoView()
-                            }
-                        }
-                    },
-                )
-            }
-            if (moreSeasonsExpanded) {
+            if (remainingSeasons.isNotEmpty()) {
                 item {
-                    val isSelected = selectedSeasons.containsAll(allSeasonNumbers)
-                    Box(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .bringIntoViewRequester(seasonsContentBringIntoViewRequester),
-                    ) {
-                        ClickSwitch(
-                            label = stringResource(R.string.select_all),
-                            checked = isSelected,
-                            onClick = {
-                                if (isSelected) {
-                                    selectedSeasons.removeAll(allSeasonNumbers)
+                    RequestSectionHeader(
+                        title =
+                            stringResource(
+                                if (initialSeasonNumber == null) {
+                                    R.string.tv_seasons
                                 } else {
-                                    selectedSeasons.addAll(allSeasonNumbers)
+                                    R.string.more_seasons
+                                },
+                            ),
+                        expanded = moreSeasonsExpanded,
+                        onClick = {
+                            moreSeasonsExpanded = !moreSeasonsExpanded
+                            if (moreSeasonsExpanded) {
+                                scope.launch {
+                                    yield()
+                                    seasonsContentBringIntoViewRequester.bringIntoView()
+                                }
+                            }
+                        },
+                    )
+                }
+                if (moreSeasonsExpanded) {
+                    item {
+                        val isSelected = selectedSeasons.containsAll(allSeasonNumbers)
+                        Box(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .bringIntoViewRequester(seasonsContentBringIntoViewRequester),
+                        ) {
+                            ClickSwitch(
+                                label = stringResource(R.string.select_all),
+                                checked = isSelected,
+                                onClick = {
+                                    if (isSelected) {
+                                        selectedSeasons.removeAll(allSeasonNumbers)
+                                    } else {
+                                        selectedSeasons.addAll(allSeasonNumbers)
+                                    }
+                                },
+                            )
+                        }
+                    }
+                    itemsIndexed(
+                        items = remainingSeasons,
+                        key = { _, season ->
+                            season.season.seasonNumber ?: season.season.id ?: season.hashCode()
+                        },
+                    ) { _, season ->
+                        val seasonNumber = season.season.seasonNumber
+                        val checked = seasonNumber in selectedSeasons || seasonNumber in availableSeasons
+                        SeasonListItem(
+                            season = season,
+                            checked = checked,
+                            onClick = {
+                                if (checked) {
+                                    selectedSeasons.remove(seasonNumber)
+                                } else {
+                                    seasonNumber?.let { selectedSeasons.add(it) }
                                 }
                             },
                         )
                     }
-                }
-                itemsIndexed(
-                    items = remainingSeasons,
-                    key = { _, season ->
-                        season.season.seasonNumber ?: season.season.id ?: season.hashCode()
-                    },
-                ) { _, season ->
-                    val seasonNumber = season.season.seasonNumber
-                    val checked = seasonNumber in selectedSeasons || seasonNumber in availableSeasons
-                    SeasonListItem(
-                        season = season,
-                        checked = checked,
-                        onClick = {
-                            if (checked) {
-                                selectedSeasons.remove(seasonNumber)
-                            } else {
-                                seasonNumber?.let { selectedSeasons.add(it) }
-                            }
-                        },
-                    )
                 }
             }
             item {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/discover/SeerrSeasonStatus.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/discover/SeerrSeasonStatus.kt
@@ -1,0 +1,73 @@
+package com.github.damontecres.wholphin.ui.detail.discover
+
+import com.github.damontecres.wholphin.api.seerr.model.TvDetails
+import com.github.damontecres.wholphin.data.model.RequestStatus
+import com.github.damontecres.wholphin.data.model.SeerrAvailability
+
+fun TvDetails.toRequestSeasons(
+    currentUserId: Int?,
+    is4k: Boolean,
+): List<RequestSeason> {
+    val seasonStatus = mutableMapOf<Int, RequestStatus>()
+    val seasonAvailability = mutableMapOf<Int, SeerrAvailability>()
+    val editable = mutableMapOf<Int, Boolean>()
+
+    seasons?.forEach { season ->
+        season.seasonNumber?.let { seasonNumber ->
+            seasonStatus[seasonNumber] = RequestStatus.UNKNOWN
+            val status = if (is4k) season.status4k else season.status
+            seasonAvailability[seasonNumber] =
+                SeerrAvailability.from(status) ?: SeerrAvailability.UNKNOWN
+        }
+    }
+    mediaInfo?.seasons?.forEach { season ->
+        season.seasonNumber?.let { seasonNumber ->
+            val status = if (is4k) season.status4k else season.status
+            val availability = SeerrAvailability.from(status) ?: SeerrAvailability.UNKNOWN
+            val current = seasonAvailability.getOrDefault(seasonNumber, SeerrAvailability.UNKNOWN)
+            if (availability > current) seasonAvailability[seasonNumber] = availability
+        }
+    }
+    mediaInfo
+        ?.requests
+        ?.filter { it.is4k == is4k }
+        ?.forEach { request ->
+            request.seasons?.forEach { season ->
+                season.seasonNumber?.let { seasonNumber ->
+                    val current = seasonStatus[seasonNumber]
+                    val new = RequestStatus.from(season.status)
+                    if (current == null || new.status > current.status) {
+                        seasonStatus[seasonNumber] = new
+                    }
+                    editable[seasonNumber] =
+                        currentUserId == request.requestedBy?.id &&
+                            request.status == RequestStatus.PENDING.status
+                }
+            }
+        }
+
+    return seasonStatus
+        .mapNotNull { (seasonNumber, status) ->
+            seasons?.firstOrNull { it.seasonNumber == seasonNumber }?.let { season ->
+                val availability =
+                    when (status) {
+                        RequestStatus.PENDING -> SeerrAvailability.PENDING
+                        RequestStatus.APPROVED -> SeerrAvailability.PROCESSING
+                        RequestStatus.DECLINED, RequestStatus.FAILURE -> SeerrAvailability.UNKNOWN
+                        RequestStatus.UNKNOWN, RequestStatus.COMPLETED ->
+                            seasonAvailability.getOrDefault(seasonNumber, SeerrAvailability.UNKNOWN)
+                    }
+                val defaultEditable =
+                    availability != SeerrAvailability.AVAILABLE &&
+                        availability != SeerrAvailability.PARTIALLY_AVAILABLE &&
+                        availability != SeerrAvailability.PROCESSING &&
+                        availability != SeerrAvailability.BLOCKLISTED
+                RequestSeason(
+                    season = season,
+                    status = status,
+                    availability = availability,
+                    editable = editable.getOrDefault(seasonNumber, defaultEditable),
+                )
+            }
+        }.sortedBy { it.season.seasonNumber }
+}

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
@@ -573,7 +573,7 @@ fun SeriesDetailsContent(
                                     imageUrl = item.imageUrl,
                                     isFavorite = false,
                                     isPlayed = false,
-                                    unplayedItemCount = 0,
+                                    unplayedItemCount = item.seerrSeason?.season?.episodeCount ?: 0,
                                     playedPercentage = 0.0,
                                     numberOfVersions = 0,
                                     onClick = onClick,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -44,6 +45,7 @@ import com.github.damontecres.wholphin.data.ExtrasItem
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.DiscoverItem
 import com.github.damontecres.wholphin.data.model.Person
+import com.github.damontecres.wholphin.data.model.SeerrAvailability
 import com.github.damontecres.wholphin.data.model.Trailer
 import com.github.damontecres.wholphin.data.model.studioNames
 import com.github.damontecres.wholphin.preferences.UserPreferences
@@ -53,6 +55,8 @@ import com.github.damontecres.wholphin.ui.RequestOrRestoreFocus
 import com.github.damontecres.wholphin.ui.cards.ExtrasRow
 import com.github.damontecres.wholphin.ui.cards.ItemRow
 import com.github.damontecres.wholphin.ui.cards.PersonRow
+import com.github.damontecres.wholphin.ui.cards.PartiallyAvailableIndicator
+import com.github.damontecres.wholphin.ui.cards.PendingIndicator
 import com.github.damontecres.wholphin.ui.cards.SeasonCard
 import com.github.damontecres.wholphin.ui.components.ConfirmDialog
 import com.github.damontecres.wholphin.ui.components.ContextMenu
@@ -582,6 +586,18 @@ fun SeriesDetailsContent(
                                     imageWidth = Dp.Unspecified,
                                     showImageOverlay = true,
                                     imageAlpha = .45f,
+                                    artworkOverlay = {
+                                        when (item.seerrSeason?.availability) {
+                                            SeerrAvailability.PENDING,
+                                            SeerrAvailability.PROCESSING,
+                                            -> PendingIndicator(Modifier.align(Alignment.TopStart))
+
+                                            SeerrAvailability.PARTIALLY_AVAILABLE ->
+                                                PartiallyAvailableIndicator(Modifier.align(Alignment.TopStart))
+
+                                            else -> Unit
+                                        }
+                                    },
                                     modifier = mod,
                                 )
                             }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
@@ -52,6 +52,7 @@ import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.services.TrailerService
 import com.github.damontecres.wholphin.ui.Cards
 import com.github.damontecres.wholphin.ui.RequestOrRestoreFocus
+import com.github.damontecres.wholphin.ui.cards.AvailableIndicator
 import com.github.damontecres.wholphin.ui.cards.ExtrasRow
 import com.github.damontecres.wholphin.ui.cards.ItemRow
 import com.github.damontecres.wholphin.ui.cards.PersonRow
@@ -403,6 +404,7 @@ fun SeriesDetailsContent(
                 item {
                     SeriesDetailsHeader(
                         series = series,
+                        availability = discoverSeries?.availability,
                         showLogo = preferences.appPreferences.interfacePreferences.showLogos,
                         overviewOnClick = overviewOnClick,
                         bringIntoViewRequester = bringIntoViewRequester,
@@ -719,6 +721,7 @@ fun SeriesDetailsContent(
 @Composable
 fun SeriesDetailsHeader(
     series: BaseItem,
+    availability: SeerrAvailability?,
     showLogo: Boolean,
     overviewOnClick: () -> Unit,
     bringIntoViewRequester: BringIntoViewRequester,
@@ -742,11 +745,20 @@ fun SeriesDetailsHeader(
             verticalArrangement = Arrangement.spacedBy(4.dp),
             modifier = Modifier.fillMaxWidth(.60f),
         ) {
-            QuickDetails(
-                series.ui.quickDetails,
-                null,
-                Modifier.padding(start = HeaderUtils.startPadding),
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(start = HeaderUtils.startPadding),
+            ) {
+                QuickDetails(
+                    series.ui.quickDetails,
+                    null,
+                )
+                when (availability) {
+                    SeerrAvailability.AVAILABLE -> AvailableIndicator()
+                    SeerrAvailability.PARTIALLY_AVAILABLE -> PartiallyAvailableIndicator()
+                    else -> Unit
+                }
+            }
             dto.studios?.let {
                 val studios = remember { series.studioNames }
                 GenreText(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
@@ -77,6 +77,7 @@ import com.github.damontecres.wholphin.ui.data.AddPlaylistViewModel
 import com.github.damontecres.wholphin.ui.data.ItemDetailsDialog
 import com.github.damontecres.wholphin.ui.data.ItemDetailsDialogInfo
 import com.github.damontecres.wholphin.ui.detail.PlaylistDialog
+import com.github.damontecres.wholphin.ui.detail.discover.RequestSeasonsDialog
 import com.github.damontecres.wholphin.ui.discover.DiscoverRow
 import com.github.damontecres.wholphin.ui.discover.DiscoverRowData
 import com.github.damontecres.wholphin.ui.letNotEmpty
@@ -115,6 +116,8 @@ fun SeriesDetails(
 
     var showWatchConfirmation by remember { mutableStateOf(false) }
     var showPlaylistDialog by remember { mutableStateOf<Optional<UUID>>(Optional.absent()) }
+    var requestSeasonNumber by remember { mutableStateOf<Int?>(null) }
+    val request4kEnabled by viewModel.request4kEnabled.collectAsState()
 
     val contextActions =
         remember {
@@ -186,7 +189,7 @@ fun SeriesDetails(
             SeriesDetailsContent(
                 preferences = preferences,
                 series = series,
-                seasons = state.seasons,
+                seasons = state.detailsSeasons,
                 trailers = state.trailers,
                 extras = state.extras,
                 people = state.people,
@@ -219,6 +222,10 @@ fun SeriesDetails(
                             canRemoveNextUp = false,
                             actions = contextActions,
                         )
+                },
+                onClickMissingSeason = { seasonNumber ->
+                    viewModel.requestOnClick()
+                    requestSeasonNumber = seasonNumber
                 },
                 overviewOnClick = {
                     overviewDialog = ItemDetailsDialogInfo(series)
@@ -261,6 +268,23 @@ fun SeriesDetails(
                 },
                 actions = contextActions,
             )
+            requestSeasonNumber?.let { seasonNumber ->
+                RequestSeasonsDialog(
+                    id = state.seerrTvDetails?.id ?: -1,
+                    title = state.seerrTvDetails?.name ?: series.title.orEmpty(),
+                    seasons = state.requestSeasons,
+                    seasons4k = state.requestSeasons4k,
+                    request4kEnabled = request4kEnabled,
+                    initialSeasonNumber = seasonNumber,
+                    loading = state.profileLoading,
+                    data = state.requestData,
+                    onSubmit = {
+                        requestSeasonNumber = null
+                        viewModel.request(it)
+                    },
+                    onDismissRequest = { requestSeasonNumber = null },
+                )
+            }
             if (showWatchConfirmation) {
                 ConfirmDialog(
                     title = series.name ?: "",
@@ -324,7 +348,7 @@ private const val DISCOVER_ROW = SIMILAR_ROW + 1
 fun SeriesDetailsContent(
     preferences: UserPreferences,
     series: BaseItem,
-    seasons: List<BaseItem?>,
+    seasons: List<SeriesDetailsSeason>,
     similar: List<BaseItem>,
     trailers: List<Trailer>,
     extras: List<ExtrasItem>,
@@ -336,6 +360,7 @@ fun SeriesDetailsContent(
     onClickItem: (Int, BaseItem) -> Unit,
     onClickPerson: (Person) -> Unit,
     onLongClickItem: (Int, BaseItem) -> Unit,
+    onClickMissingSeason: (Int) -> Unit,
     overviewOnClick: () -> Unit,
     playOnClick: (Boolean) -> Unit,
     watchOnClick: () -> Unit,
@@ -512,26 +537,54 @@ fun SeriesDetailsContent(
                         items = seasons,
                         onClickItem = { index, item ->
                             position = SEASONS_ROW
-                            onClickItem.invoke(index, item)
+                            item.jellyfinItem?.let { onClickItem.invoke(index, it) }
+                                ?: onClickMissingSeason(item.seasonNumber)
                         },
                         onLongClickItem = { index, item ->
                             position = SEASONS_ROW
-                            onLongClickItem.invoke(index, item)
+                            item.jellyfinItem?.let { onLongClickItem.invoke(index, it) }
                         },
                         modifier =
                             Modifier
                                 .fillMaxWidth()
                                 .focusRequester(focusRequesters[SEASONS_ROW]),
                         cardContent = @Composable { index, item, mod, onClick, onLongClick ->
-                            SeasonCard(
-                                item = item,
-                                onClick = onClick,
-                                onLongClick = onLongClick,
-                                imageHeight = Cards.height2x3,
-                                imageWidth = Dp.Unspecified,
-                                showImageOverlay = true,
-                                modifier = mod,
-                            )
+                            if (item?.jellyfinItem != null) {
+                                SeasonCard(
+                                    item = item.jellyfinItem,
+                                    onClick = onClick,
+                                    onLongClick = onLongClick,
+                                    imageHeight = Cards.height2x3,
+                                    imageWidth = Dp.Unspecified,
+                                    showImageOverlay = true,
+                                    modifier = mod,
+                                )
+                            } else if (item != null) {
+                                val title =
+                                    if (item.seasonNumber == 0) {
+                                        stringResource(R.string.specials)
+                                    } else {
+                                        stringResource(R.string.tv_season) + " ${item.seasonNumber}"
+                                    }
+                                SeasonCard(
+                                    title = title,
+                                    subtitle = item.seerrSeason?.season?.airDate?.take(4),
+                                    name = title,
+                                    imageUrl = item.imageUrl,
+                                    isFavorite = false,
+                                    isPlayed = false,
+                                    unplayedItemCount = 0,
+                                    playedPercentage = 0.0,
+                                    numberOfVersions = 0,
+                                    onClick = onClick,
+                                    onLongClick = onLongClick,
+                                    imageHeight = Cards.height2x3,
+                                    imageWidth = Dp.Unspecified,
+                                    showImageOverlay = true,
+                                    imageAlpha = .45f,
+                                    modifier = mod,
+                                )
+                            }
                         },
                     )
                 }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
@@ -535,6 +535,7 @@ class SeriesViewModel
                     viewModelScope.launchIO {
                         val seasons = getSeasons(series, null).await()
                         _state.update { it.copy(seasons = seasons) }
+                        updateSeerrDetails(seasons, state.value.seerrTvDetails)
                     }
                 } catch (ex: Exception) {
                     Timber.e(ex, "Error updating series")

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
@@ -13,6 +13,7 @@ import com.github.damontecres.wholphin.data.model.DiscoverItem
 import com.github.damontecres.wholphin.data.model.ItemPlayback
 import com.github.damontecres.wholphin.data.model.Person
 import com.github.damontecres.wholphin.data.model.Trailer
+import com.github.damontecres.wholphin.api.seerr.model.TvDetails
 import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.ExtrasService
@@ -22,6 +23,7 @@ import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.PeopleFavorites
 import com.github.damontecres.wholphin.services.SeerrService
+import com.github.damontecres.wholphin.services.SeerrServerRepository
 import com.github.damontecres.wholphin.services.StreamChoiceService
 import com.github.damontecres.wholphin.services.ThemeSongPlayer
 import com.github.damontecres.wholphin.services.TrailerService
@@ -36,6 +38,10 @@ import com.github.damontecres.wholphin.ui.letNotEmpty
 import com.github.damontecres.wholphin.ui.lt
 import com.github.damontecres.wholphin.ui.nav.Destination
 import com.github.damontecres.wholphin.ui.showToast
+import com.github.damontecres.wholphin.ui.detail.discover.RequestSeason
+import com.github.damontecres.wholphin.ui.detail.discover.SeerrRequestData
+import com.github.damontecres.wholphin.ui.detail.discover.TvRequest
+import com.github.damontecres.wholphin.ui.detail.discover.toRequestSeasons
 import com.github.damontecres.wholphin.util.ApiRequestPager
 import com.github.damontecres.wholphin.util.BlockingList
 import com.github.damontecres.wholphin.util.DataLoadingState
@@ -43,6 +49,7 @@ import com.github.damontecres.wholphin.util.ExceptionHandler
 import com.github.damontecres.wholphin.util.GetEpisodesRequestHandler
 import com.github.damontecres.wholphin.util.GetItemsRequestHandler
 import com.github.damontecres.wholphin.util.WholphinDispatchers
+import com.github.damontecres.wholphin.util.LoadingState
 import com.github.damontecres.wholphin.util.successValue
 import com.google.common.cache.CacheBuilder
 import dagger.assisted.Assisted
@@ -62,6 +69,10 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -100,6 +111,7 @@ class SeriesViewModel
         private val userPreferencesService: UserPreferencesService,
         private val backdropService: BackdropService,
         private val seerrService: SeerrService,
+        private val seerrServerRepository: SeerrServerRepository,
         private val mediaManagementService: MediaManagementService,
         @Assisted val seriesId: UUID,
         @Assisted val seasonEpisodeIds: SeasonEpisodeIds?,
@@ -118,6 +130,11 @@ class SeriesViewModel
         val state: StateFlow<SeriesState> = _state
 
         val position = MutableStateFlow(SeriesOverviewPosition(0, 0))
+
+        val request4kEnabled =
+            seerrServerRepository.current
+                .map { it?.request4kTvEnabled ?: false }
+                .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
         init {
             viewModelScope.launchIO {
@@ -211,6 +228,7 @@ class SeriesViewModel
                 }
 
                 if (seriesPageType == SeriesPageType.DETAILS) {
+                    updateSeerrDetails(seasons, null)
                     viewModelScope.launchIO {
                         trailerService.getLocalTrailers(series).letNotEmpty { localTrailers ->
                             _state.update { it.copy(trailers = localTrailers + remoteTrailers) }
@@ -249,9 +267,7 @@ class SeriesViewModel
                             val tv =
                                 if (active) {
                                     try {
-                                        seerrService
-                                            .getTvSeries(series)
-                                            ?.let { seerrService.createDiscoverItem(it) }
+                                        seerrService.getTvSeries(series)
                                     } catch (ex: Exception) {
                                         Timber.e(ex)
                                         null
@@ -259,7 +275,7 @@ class SeriesViewModel
                                 } else {
                                     null
                                 }
-                            _state.update { it.copy(discoverSeries = tv) }
+                            updateSeerrDetails(seasons, tv)
                         }
                     }
                 }
@@ -273,10 +289,94 @@ class SeriesViewModel
                             )
                             val seasons = getSeasons(series, seasonEpisodeIds?.seasonNumber).await()
                             _state.update { it.copy(seasons = seasons) }
+                            updateSeerrDetails(seasons, state.value.seerrTvDetails)
                         }
                     }.catch { ex ->
                         Timber.e(ex, "Error refreshing after deleted item")
                     }.launchIn(viewModelScope)
+            }
+        }
+
+        private suspend fun updateSeerrDetails(
+            seasons: List<BaseItem?>,
+            tv: TvDetails?,
+        ) {
+            val localSeasons =
+                if (seasons is ApiRequestPager<*>) {
+                    List(seasons.size) { seasons.getBlocking(it) }
+                } else {
+                    seasons
+                }.filterNotNull()
+            val currentUserId = seerrServerRepository.currentUserId.first()
+            val requestSeasons = tv?.toRequestSeasons(currentUserId, false).orEmpty()
+            val requestSeasons4k =
+                if (request4kEnabled.value) tv?.toRequestSeasons(currentUserId, true).orEmpty() else emptyList()
+            val localByNumber = localSeasons.associateBy { it.data.indexNumber }
+            val seerrByNumber = requestSeasons.associateBy { it.season.seasonNumber }
+            val allNumbers =
+                (localByNumber.keys.filterNotNull() + seerrByNumber.keys.filterNotNull())
+                    .distinct()
+                    .sorted()
+            val detailsSeasons =
+                allNumbers.map { number ->
+                    val seerrSeason = seerrByNumber[number]
+                    SeriesDetailsSeason(
+                        seasonNumber = number,
+                        jellyfinItem = localByNumber[number],
+                        seerrSeason = seerrSeason,
+                        imageUrl =
+                            if (localByNumber[number] == null) {
+                                seerrService.createImageUrl(
+                                    org.jellyfin.sdk.model.api.ImageType.PRIMARY,
+                                    seerrSeason?.season?.posterPath,
+                                    null,
+                                )
+                            } else {
+                                null
+                            },
+                    )
+                }
+            _state.update {
+                it.copy(
+                    detailsSeasons = detailsSeasons,
+                    seerrTvDetails = tv,
+                    requestSeasons = requestSeasons,
+                    requestSeasons4k = requestSeasons4k,
+                    discoverSeries = tv?.let { details -> seerrService.createDiscoverItem(details) },
+                )
+            }
+        }
+
+        fun requestOnClick() {
+            viewModelScope.launchIO {
+                _state.update { it.copy(profileLoading = LoadingState.Loading) }
+                try {
+                    val data =
+                        seerrService.getProfilesAndFolders(
+                            com.github.damontecres.wholphin.data.model.SeerrItemType.TV,
+                        )
+                    _state.update { it.copy(profileLoading = LoadingState.Success, requestData = data) }
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Error getting profiles & folders")
+                    showToast(context, "Error getting profiles & folders: ${ex.localizedMessage}")
+                    _state.update { it.copy(profileLoading = LoadingState.Error(ex)) }
+                }
+            }
+        }
+
+        fun request(request: TvRequest) {
+            viewModelScope.launchIO {
+                val tv = state.value.seerrTvDetails ?: return@launchIO
+                try {
+                    seerrService.requestTv(tv, request)
+                    val refreshed = seerrService.api.tvApi.tvTvIdGet(request.tvId)
+                    updateSeerrDetails(state.value.seasons, refreshed)
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Exception) {
+                    Timber.e(ex, "Error requesting %s", request.tvId)
+                    showToast(context, "An error occurred")
+                }
             }
         }
 
@@ -838,5 +938,18 @@ data class SeriesState(
     val peopleInEpisode: PeopleInItem = PeopleInItem(),
     val discovered: List<DiscoverItem> = emptyList(),
     val discoverSeries: DiscoverItem? = null,
+    val detailsSeasons: List<SeriesDetailsSeason> = emptyList(),
+    val seerrTvDetails: TvDetails? = null,
+    val requestSeasons: List<RequestSeason> = emptyList(),
+    val requestSeasons4k: List<RequestSeason> = emptyList(),
+    val profileLoading: LoadingState = LoadingState.Pending,
+    val requestData: SeerrRequestData = SeerrRequestData(),
     val chosenStreams: ChosenStreams? = null,
+)
+
+data class SeriesDetailsSeason(
+    val seasonNumber: Int,
+    val jellyfinItem: BaseItem?,
+    val seerrSeason: RequestSeason?,
+    val imageUrl: String?,
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,7 @@
     <string name="tv_guide">Guide</string>
     <string name="tv_season">Season</string>
     <string name="tv_seasons">Seasons</string>
+    <string name="specials">Specials</string>
     <string name="tv_shows_title">TV Shows</string>
     <string name="ui_interface">Interface</string>
     <string name="unknown">Unknown</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,6 +159,9 @@
     <string name="tv_season">Season</string>
     <string name="tv_seasons">Seasons</string>
     <string name="specials">Specials</string>
+    <string name="more_seasons">More Seasons</string>
+    <string name="advanced_options">Advanced Options</string>
+    <string name="submit_request">Submit Request</string>
     <string name="tv_shows_title">TV Shows</string>
     <string name="ui_interface">Interface</string>
     <string name="unknown">Unknown</string>


### PR DESCRIPTION
<!-- By submitting this pull request, you acknowledge that you have read the [contributing guide](https://github.com/damontecres/Wholphin/blob/main/CONTRIBUTING.md, including the AI/LLM policy, and [developer's guide](https://github.com/damontecres/Wholphin/blob/main/DEVELOPMENT.md) -->

## Description
When viewing Shows/Library/Show you only see season cards for seasons that are available in Jellyfin + a Season(count) header. User does not know how many seasons exist for the given show.
This enhancement combines Jellyfin (local) series seasons with Seerr series seasons metadata into a single season row with the ability to directly request a season from its card.

## Changes
- Shows missing Seerr seasons as greyed season cards in the existing season row.
- Missing seasons remain focusable and use the existing TV card focus/scale behavior.
- Selecting a missing season opens the existing season request dialog with that season preselected.
- Reuses the existing Seerr POST/PUT request behavior.
- Filters fully available/non-actionable seasons from the request dialog.
- Keeps pending/requested seasons visible with their existing status.
- Adds pending/processing and partially-available indicators to missing season cards.
- Displays episode-count pills for Seerr-only seasons when available.
- Adds whole-series Available / Partially Available indicators to the Jellyfin details header.
- Refreshes merged season metadata after Jellyfin watched/favorite updates so visible cards do not become stale.
- Preserves the existing Jellyfin season pager, navigation, context menus and episode flow.

The request dialog also received a TV-focused layout pass:

- Submit action first and initially focused.
- Preselected season shown directly below Submit.
- Expandable Seasons / More Seasons section.
- Expandable Advanced Options section.
- D-pad-friendly focus and scrolling behavior.
- Select All applies only to actionable/editable seasons.


### Related issues
Discussion: https://github.com/damontecres/Wholphin/discussions/1918
Related to https://github.com/damontecres/Wholphin/issues/702 and the existing season-request work in https://github.com/damontecres/Wholphin/issues/961.

### Testing
Tested with the Google TV emulator and manually verified:

- Existing Jellyfin season navigation.
- Missing-season card focus and selection.
- Requesting individual missing seasons.
- Multi-season request selection.
- Pending request status updates.
- Pending indicator focus transform.
- Transition from pending/missing to locally available after download completion.
- Fully available and partially available whole-series indicators.
- Specials / Season 0 handling.
- Watched/unwatched season refresh.
- Favorite/unfavorite season refresh.
- Whole-series watched/unwatched refresh.
- Generic Discover request flow remains functional.

Validation:

- `:app:compileDefaultDebugKotlin`
- `:app:testDefaultDebugUnitTest`
- `git diff --check`

All passed.

## Screenshots
<img width="1920" height="1080" alt="Show" src="https://github.com/user-attachments/assets/760adb28-6984-4ba6-b5a2-3762da83d784" />
<img width="1920" height="1080" alt="Seerr season selection" src="https://github.com/user-attachments/assets/32e97e4a-cb7c-4e37-8b89-b9c173f30b77" />
<img width="1920" height="1080" alt="Submit request" src="https://github.com/user-attachments/assets/7dafe513-793b-4980-b741-9cb6a434cd15" />
<img width="1920" height="1080" alt="Submit request expanded" src="https://github.com/user-attachments/assets/5840ba44-b962-44b3-9545-7176be1d53c7" />

## AI or LLM usage
AI assistance was used for code analysis, implementation guidance and regression review.
Affected areas were manually reviewed and validated through compilation, unit tests and device/emulator testing.