### PR TITLE
Fixes to default home view options for music & videos

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
@@ -14,6 +14,7 @@ import com.github.damontecres.wholphin.data.model.createStudioDestination
 import com.github.damontecres.wholphin.preferences.DefaultUserConfiguration
 import com.github.damontecres.wholphin.preferences.HomePagePreferences
 import com.github.damontecres.wholphin.ui.AspectRatio
+import com.github.damontecres.wholphin.ui.Cards
 import com.github.damontecres.wholphin.ui.HomeItemFields
 import com.github.damontecres.wholphin.ui.ProgramItemFields
 import com.github.damontecres.wholphin.ui.components.getGenreImageMap
@@ -1274,16 +1275,28 @@ private val HomeItemFieldsBoxSets get() = HomeItemFields + listOf(ItemFields.CHI
 fun viewOptionsForCollectionType(collectionType: CollectionType?): HomeRowViewOptions =
     when (collectionType) {
         CollectionType.MUSIC,
-        -> HomeRowViewOptions(aspectRatio = AspectRatio.SQUARE)
+        -> {
+            HomeRowViewOptions(
+                heightDp = Cards.HEIGHT_EPISODE,
+                aspectRatio = AspectRatio.SQUARE,
+            )
+        }
 
         CollectionType.PHOTOS,
         CollectionType.HOMEVIDEOS,
         CollectionType.MUSICVIDEOS,
         CollectionType.TRAILERS,
-        -> HomeRowViewOptions(aspectRatio = AspectRatio.WIDE)
+        -> {
+            HomeRowViewOptions(
+                heightDp = Cards.HEIGHT_EPISODE,
+                aspectRatio = AspectRatio.WIDE,
+            )
+        }
 
         CollectionType.LIVETV,
-        -> HomeRowViewOptions.liveTvDefault
+        -> {
+            HomeRowViewOptions.liveTvDefault
+        }
 
         CollectionType.MOVIES,
         CollectionType.TVSHOWS,
@@ -1293,5 +1306,7 @@ fun viewOptionsForCollectionType(collectionType: CollectionType?): HomeRowViewOp
         CollectionType.FOLDERS,
         CollectionType.UNKNOWN,
         null,
-        -> HomeRowViewOptions()
+        -> {
+            HomeRowViewOptions()
+        }
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
@@ -7,11 +7,13 @@ import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.data.model.BaseItem
 import com.github.damontecres.wholphin.data.model.HomePageSettings
 import com.github.damontecres.wholphin.data.model.HomeRowConfig
+import com.github.damontecres.wholphin.data.model.HomeRowViewOptions
 import com.github.damontecres.wholphin.data.model.SUPPORTED_HOME_PAGE_SETTINGS_VERSION
 import com.github.damontecres.wholphin.data.model.createGenreDestination
 import com.github.damontecres.wholphin.data.model.createStudioDestination
 import com.github.damontecres.wholphin.preferences.DefaultUserConfiguration
 import com.github.damontecres.wholphin.preferences.HomePagePreferences
+import com.github.damontecres.wholphin.ui.AspectRatio
 import com.github.damontecres.wholphin.ui.HomeItemFields
 import com.github.damontecres.wholphin.ui.ProgramItemFields
 import com.github.damontecres.wholphin.ui.components.getGenreImageMap
@@ -280,20 +282,25 @@ class HomeSettingsService
 
             val includedIds =
                 libraries
-                    .mapIndexed { index, it ->
-                        val parentId = it.itemId
-                        val title = getRecentlyAddedTitle(it.name)
-                        if (it.collectionType == CollectionType.LIVETV) {
+                    .mapIndexed { index, library ->
+                        val parentId = library.itemId
+                        val title = getRecentlyAddedTitle(library.name)
+                        if (library.collectionType == CollectionType.LIVETV) {
                             HomeRowConfigDisplay(
                                 id = index,
                                 title = ResStringProvider(R.string.watch_live),
                                 config = HomeRowConfig.TvPrograms(),
                             )
                         } else {
+                            val viewOptions = viewOptionsForCollectionType(library.collectionType)
                             HomeRowConfigDisplay(
                                 id = index,
                                 title = title,
-                                config = HomeRowConfig.RecentlyAdded(parentId),
+                                config =
+                                    HomeRowConfig.RecentlyAdded(
+                                        parentId = parentId,
+                                        viewOptions = viewOptions,
+                                    ),
                             )
                         }
                     }
@@ -401,15 +408,21 @@ class HomeSettingsService
                                     }
                                 }
                             if (sectionType == HomeSectionType.LATEST_MEDIA) {
-                                libraries.map {
+                                libraries.map { library ->
+                                    val viewOptions =
+                                        viewOptionsForCollectionType(library.collectionType)
                                     HomeRowConfigDisplay(
                                         id = id++,
                                         title =
                                             ResArgStringProvider(
                                                 R.string.recently_added_in,
-                                                it.name ?: "",
+                                                library.name ?: "",
                                             ),
-                                        config = HomeRowConfig.RecentlyAdded(it.id),
+                                        config =
+                                            HomeRowConfig.RecentlyAdded(
+                                                parentId = library.id,
+                                                viewOptions = viewOptions,
+                                            ),
                                     )
                                 }
                             } else if (config != null) {
@@ -1261,3 +1274,28 @@ private val Library?.itemFields: List<ItemFields>
         }
 
 private val HomeItemFieldsBoxSets get() = HomeItemFields + listOf(ItemFields.CHILD_COUNT)
+
+fun viewOptionsForCollectionType(collectionType: CollectionType?): HomeRowViewOptions =
+    when (collectionType) {
+        CollectionType.MUSIC,
+        -> HomeRowViewOptions(aspectRatio = AspectRatio.SQUARE)
+
+        CollectionType.PHOTOS,
+        CollectionType.HOMEVIDEOS,
+        CollectionType.MUSICVIDEOS,
+        CollectionType.TRAILERS,
+        -> HomeRowViewOptions(aspectRatio = AspectRatio.WIDE)
+
+        CollectionType.LIVETV,
+        -> HomeRowViewOptions.liveTvDefault
+
+        CollectionType.MOVIES,
+        CollectionType.TVSHOWS,
+        CollectionType.BOXSETS,
+        CollectionType.BOOKS,
+        CollectionType.PLAYLISTS,
+        CollectionType.FOLDERS,
+        CollectionType.UNKNOWN,
+        null,
+        -> HomeRowViewOptions()
+    }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/HomeSettingsService.kt
@@ -38,7 +38,6 @@ import com.github.damontecres.wholphin.util.GetRecordingsRequestHandler
 import com.github.damontecres.wholphin.util.GetStudiosRequestHandler
 import com.github.damontecres.wholphin.util.HomeRowLoadingState
 import com.github.damontecres.wholphin.util.HomeRowLoadingState.Success
-import com.github.damontecres.wholphin.util.supportedHomeCollectionTypes
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -57,7 +56,6 @@ import org.jellyfin.sdk.api.client.ApiClient
 import org.jellyfin.sdk.api.client.extensions.liveTvApi
 import org.jellyfin.sdk.api.client.extensions.userApi
 import org.jellyfin.sdk.api.client.extensions.userLibraryApi
-import org.jellyfin.sdk.api.client.extensions.userViewsApi
 import org.jellyfin.sdk.model.DateTime
 import org.jellyfin.sdk.model.UUID
 import org.jellyfin.sdk.model.api.BaseItemKind
@@ -330,12 +328,10 @@ class HomeSettingsService
             val userDto by api.userApi.getUserById(userId)
             val config = userDto.configuration ?: DefaultUserConfiguration
             val libraries =
-                api.userViewsApi
-                    .getUserViews(userId = userId)
-                    .content.items
-                    .filter {
-                        it.collectionType in supportedHomeCollectionTypes &&
-                            it.id !in config.latestItemsExcludes
+                navDrawerService
+                    .getAllUserLibraries(userId, userDto.tvAccess)
+                    .filterNot {
+                        it.itemId in config.latestItemsExcludes
                     }
 
             return if (customPrefs.isNotEmpty()) {
@@ -420,7 +416,7 @@ class HomeSettingsService
                                             ),
                                         config =
                                             HomeRowConfig.RecentlyAdded(
-                                                parentId = library.id,
+                                                parentId = library.itemId,
                                                 viewOptions = viewOptions,
                                             ),
                                     )

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/settings/HomeSettingsViewModel.kt
@@ -34,7 +34,7 @@ import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.services.getRecentlyAddedTitle
 import com.github.damontecres.wholphin.services.hilt.IoCoroutineScope
 import com.github.damontecres.wholphin.services.tvAccess
-import com.github.damontecres.wholphin.ui.AspectRatio
+import com.github.damontecres.wholphin.services.viewOptionsForCollectionType
 import com.github.damontecres.wholphin.ui.formatTypeName
 import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.launchIO
@@ -275,24 +275,7 @@ class HomeSettingsViewModel
             rowType: LibraryRowType,
         ): Job =
             viewModelScope.launchIO {
-                val viewOptions =
-                    when (library.collectionType) {
-                        CollectionType.MUSIC -> {
-                            HomeRowViewOptions(aspectRatio = AspectRatio.SQUARE)
-                        }
-
-                        CollectionType.HOMEVIDEOS,
-                        CollectionType.MUSICVIDEOS,
-                        -> {
-                            HomeRowViewOptions(
-                                aspectRatio = AspectRatio.WIDE,
-                            )
-                        }
-
-                        else -> {
-                            HomeRowViewOptions()
-                        }
-                    }
+                val viewOptions = viewOptionsForCollectionType(library.collectionType)
                 val id = idCounter++
                 val newRow =
                     when (rowType) {

--- a/app/src/main/java/com/github/damontecres/wholphin/util/Constants.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/util/Constants.kt
@@ -33,14 +33,7 @@ val supportedCollectionTypes =
         CollectionType.MUSICVIDEOS,
         CollectionType.FOLDERS,
         CollectionType.MUSIC,
-        null, // Mixed
-    )
-
-val supportedHomeCollectionTypes =
-    setOf(
-        CollectionType.MOVIES,
-        CollectionType.TVSHOWS,
-        CollectionType.HOMEVIDEOS,
+        CollectionType.PHOTOS,
         null, // Mixed
     )
 


### PR DESCRIPTION
## Description
This PR fixes how cards are displayed initially when creating the default home page or loading it from the web config:
- Ensure view options are selected based on the library type (this is how it's done already when manually adding a row)
- Support more home row types such as photos and music

### Related issues
Fixes https://github.com/damontecres/Wholphin/issues/1838

### Testing
Emulator, resetting to default and loading from web config

## Screenshots
N/A, music cards will be square instead of poster sized

## AI or LLM usage
None