### PR TITLE
Consolidate sending media reports & app logs

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/MediaReportService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/MediaReportService.kt
@@ -2,8 +2,10 @@ package com.github.damontecres.wholphin.services
 
 import android.content.Context
 import android.os.Build
+import com.github.damontecres.wholphin.BuildConfig
 import com.github.damontecres.wholphin.data.ServerRepository
 import com.github.damontecres.wholphin.services.hilt.IoCoroutineScope
+import com.github.damontecres.wholphin.ui.detail.DebugViewModel.Companion.getLogCatLines
 import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.ui.showToast
 import com.github.damontecres.wholphin.util.ExceptionHandler
@@ -68,25 +70,41 @@ class MediaReportService
                 deviceProfileService.getOrCreateDeviceProfile(appPreferences, serverVersion)
             val deviceProfileJson = json.encodeToString(deviceProfile)
             val body =
-                """
-                Send media info
+                buildLogHeader("Send media info") + "\n\n" +
+                    """
+                    playbackPrefs=${appPreferences.playbackPreferences.toStringOneLine()}
+
+                    experimental=${appPreferences.experimentalPreferences.toStringOneLine()}
+
+                    mediaSources=$sourcesJson
+
+                    deviceProfile=$deviceProfileJson
+                    """.trimIndent()
+            body.chunked(2048).forEach { Timber.w(it) }
+            Timber.w("End send media info")
+            val response by api.clientLogApi.logFile(body)
+            showToast(context, "Sent! Filename=${response.fileName}")
+        }
+
+        fun buildLogHeader(title: String): String {
+            val serverVersion = serverRepository.currentServer?.serverVersion
+            return """
+                $title
                 serverVersion=$serverVersion
                 clientInfo=$clientInfo
+                flavor=${BuildConfig.FLAVOR}
                 deviceInfo=$deviceInfo
                 manufacturer=${Build.MANUFACTURER}
                 model=${Build.MODEL}
                 apiLevel=${Build.VERSION.SDK_INT}
-
-                playbackPrefs=${appPreferences.playbackPreferences.toStringOneLine()}
-                experimental=${appPreferences.experimentalPreferences.toStringOneLine()}
-
-                mediaSources=$sourcesJson
-
-                deviceProfile=$deviceProfileJson
                 """.trimIndent()
-            body.chunked(2048).forEach { Timber.w(it) }
-            Timber.w("End send media info")
-            val response by api.clientLogApi.logFile(body)
+        }
+
+        suspend fun sendAppLogs() {
+            val logcat = getLogCatLines().joinToString("\n") { it.text }
+            val header = buildLogHeader("Send App Logs")
+            Timber.w(header)
+            val response by api.clientLogApi.logFile(header + "\n\n" + logcat)
             showToast(context, "Sent! Filename=${response.fileName}")
         }
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/services/ServerReportService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/ServerReportService.kt
@@ -25,10 +25,10 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Send media info to the server
+ * Send reports to the server such as media info or app logs
  */
 @Singleton
-class MediaReportService
+class ServerReportService
     @Inject
     constructor(
         @param:ApplicationContext private val context: Context,
@@ -48,17 +48,17 @@ class MediaReportService
         /**
          * Fetch the media info and send it to the server
          */
-        fun sendReportFor(itemId: UUID) {
+        fun sendMediaReportFor(itemId: UUID) {
             ioScope.launchIO(ExceptionHandler(autoToast = true)) {
                 val item = api.userLibraryApi.getItem(itemId = itemId).content
-                sendReportFor(item)
+                sendMediaReportFor(item)
             }
         }
 
         /**
          * Send the media report for the given item
          */
-        suspend fun sendReportFor(item: BaseItemDto) {
+        suspend fun sendMediaReportFor(item: BaseItemDto) {
             val sources =
                 item.mediaSources ?: api.userLibraryApi
                     .getItem(itemId = item.id)

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderView.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/CollectionFolderView.kt
@@ -46,9 +46,9 @@ import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.FilterOptionCache
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.MusicService
 import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.StreamChoiceService
 import com.github.damontecres.wholphin.services.ThemeSongPlayer
 import com.github.damontecres.wholphin.services.UserPreferencesService
@@ -120,7 +120,7 @@ class CollectionFolderViewModel
         private val mediaManagementService: MediaManagementService,
         private val musicService: MusicService,
         val streamChoiceService: StreamChoiceService,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         private val filterOptionCache: FilterOptionCache,
         @Assisted val itemId: String,
         @Assisted initialSortAndDirection: SortAndDirection?,
@@ -609,7 +609,7 @@ class CollectionFolderViewModel
             index: Int,
         ) = addToQueue(api, musicService, item, index)
 
-        override fun sendReportFor(itemId: UUID) = mediaReportService.sendReportFor(itemId)
+        override fun sendReportFor(itemId: UUID) = serverReportService.sendMediaReportFor(itemId)
 
         override fun isAdministrator(): Boolean = serverRepository.currentUserDto?.policy?.isAdministrator == true
     }

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/ErrorMessage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/ErrorMessage.kt
@@ -1,6 +1,5 @@
 package com.github.damontecres.wholphin.ui.components
 
-import android.content.Context
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -10,30 +9,25 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.wholphin.R
-import com.github.damontecres.wholphin.ui.detail.DebugViewModel.Companion.sendAppLogs
+import com.github.damontecres.wholphin.services.MediaReportService
+import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.util.DataLoadingState
 import com.github.damontecres.wholphin.util.LoadingState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
-import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.model.ClientInfo
-import org.jellyfin.sdk.model.DeviceInfo
 import javax.inject.Inject
 
 @HiltViewModel
 class ErrorViewModel
     @Inject
     constructor(
-        @param:ApplicationContext private val context: Context,
-        private val api: ApiClient,
-        private val clientInfo: ClientInfo,
-        private val deviceInfo: DeviceInfo,
+        private val mediaReportService: MediaReportService,
     ) : ViewModel() {
         fun sendLogs() {
-            sendAppLogs(context, api, clientInfo, deviceInfo)
+            viewModelScope.launchIO { mediaReportService.sendAppLogs() }
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/ErrorMessage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/ErrorMessage.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.github.damontecres.wholphin.R
-import com.github.damontecres.wholphin.services.MediaReportService
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.util.DataLoadingState
 import com.github.damontecres.wholphin.util.LoadingState
@@ -24,10 +24,10 @@ import javax.inject.Inject
 class ErrorViewModel
     @Inject
     constructor(
-        private val mediaReportService: MediaReportService,
+        private val serverReportService: ServerReportService,
     ) : ViewModel() {
         fun sendLogs() {
-            viewModelScope.launchIO { mediaReportService.sendAppLogs() }
+            viewModelScope.launchIO { serverReportService.sendAppLogs() }
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/ItemGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/ItemGrid.kt
@@ -21,8 +21,8 @@ import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.deleteItem
 import com.github.damontecres.wholphin.ui.cards.GridCard
 import com.github.damontecres.wholphin.ui.data.AddPlaylistViewModel
@@ -63,7 +63,7 @@ class ItemGridViewModel
         private val favoriteWatchManager: FavoriteWatchManager,
         private val mediaManagementService: MediaManagementService,
         val serverRepository: ServerRepository,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         @Assisted private val destination: Destination.ItemGrid<*>,
     ) : ViewModel(),
         ContextMenuProvider {
@@ -173,7 +173,7 @@ class ItemGridViewModel
 
         override fun isAdministrator(): Boolean = serverRepository.currentUserDto?.policy?.isAdministrator == true
 
-        override fun sendReportFor(itemId: UUID) = mediaReportService.sendReportFor(itemId)
+        override fun sendReportFor(itemId: UUID) = serverReportService.sendMediaReportFor(itemId)
     }
 
 data class ItemGridState(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/components/RecommendedContent.kt
@@ -22,9 +22,9 @@ import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.MusicService
 import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.SuggestionService
 import com.github.damontecres.wholphin.services.SuggestionsResource
 import com.github.damontecres.wholphin.services.UserPreferencesService
@@ -80,7 +80,7 @@ class RecommendedViewModel
         private val backdropService: BackdropService,
         private val mediaManagementService: MediaManagementService,
         private val suggestionService: SuggestionService,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         @Assisted private val parentId: UUID,
         @Assisted private val suggestionsType: BaseItemKind,
         @Assisted private val recommendedRows: List<RecommendedRow<*>>,
@@ -390,7 +390,7 @@ fun RecommendedContent(
                             playlistViewModel.loadPlaylists()
                             showPlaylistDialog.makePresent(itemId)
                         },
-                        onSendMediaInfo = viewModel.mediaReportService::sendReportFor,
+                        onSendMediaInfo = viewModel.serverReportService::sendMediaReportFor,
                         onDeleteItem = { viewModel.deleteItem(position, it) },
                         onShowOverview = { overviewDialog = ItemDetailsDialogInfo(it) },
                         onChooseVersion = { _, _ ->

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/DebugPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/DebugPage.kt
@@ -45,19 +45,17 @@ import com.github.damontecres.wholphin.data.model.ItemPlayback
 import com.github.damontecres.wholphin.preferences.UserPreferences
 import com.github.damontecres.wholphin.ui.launchDefault
 import com.github.damontecres.wholphin.ui.launchIO
-import com.github.damontecres.wholphin.ui.showToast
 import com.github.damontecres.wholphin.util.ExceptionHandler
+import com.github.damontecres.wholphin.util.WholphinDispatchers
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.acra.util.versionCodeLong
-import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.api.client.extensions.clientLogApi
 import org.jellyfin.sdk.model.ClientInfo
 import org.jellyfin.sdk.model.DeviceInfo
-import timber.log.Timber
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.util.Date
@@ -211,71 +209,48 @@ class DebugViewModel
         }
 
         companion object {
-            fun getLogCatLines(): List<LogcatLine> {
-                val lineCount = 500
-                val args =
-                    buildList {
-                        add("logcat")
-                        add("-d")
-                        add("-t")
-                        add(lineCount.toString())
-                        addAll(THIRD_PARTY_TAGS)
-                        add("*:V")
-                    }
-                val process = ProcessBuilder().command(args).redirectErrorStream(true).start()
-                val logLines = mutableListOf<LogcatLine>()
-                try {
-                    val reader = BufferedReader(InputStreamReader(process.inputStream))
-                    var count = 0
-
-                    while (count < lineCount) {
-                        val line = reader.readLine()
-                        if (line != null) {
-                            val level = line.split(Regex("\\s+")).getOrNull(4)
-                            val logLevel =
-                                when (level?.uppercase()) {
-                                    "V" -> Log.VERBOSE
-                                    "D" -> Log.DEBUG
-                                    "I" -> Log.INFO
-                                    "W" -> Log.WARN
-                                    "E" -> Log.ERROR
-                                    else -> Log.VERBOSE
-                                }
-                            logLines.add(LogcatLine(logLevel, line))
-                        } else {
-                            break
+            suspend fun getLogCatLines(): List<LogcatLine> =
+                withContext(WholphinDispatchers.IO) {
+                    val lineCount = 500
+                    val args =
+                        buildList {
+                            add("logcat")
+                            add("-d")
+                            add("-t")
+                            add(lineCount.toString())
+                            addAll(THIRD_PARTY_TAGS)
+                            add("*:V")
                         }
-                        count++
+                    val process = ProcessBuilder().command(args).redirectErrorStream(true).start()
+                    val logLines = mutableListOf<LogcatLine>()
+                    try {
+                        val reader = BufferedReader(InputStreamReader(process.inputStream))
+                        var count = 0
+
+                        while (count < lineCount) {
+                            val line = reader.readLine()
+                            if (line != null) {
+                                val level = line.split(Regex("\\s+")).getOrNull(4)
+                                val logLevel =
+                                    when (level?.uppercase()) {
+                                        "V" -> Log.VERBOSE
+                                        "D" -> Log.DEBUG
+                                        "I" -> Log.INFO
+                                        "W" -> Log.WARN
+                                        "E" -> Log.ERROR
+                                        else -> Log.VERBOSE
+                                    }
+                                logLines.add(LogcatLine(logLevel, line))
+                            } else {
+                                break
+                            }
+                            count++
+                        }
+                    } finally {
+                        process.destroy()
                     }
-                } finally {
-                    process.destroy()
+                    return@withContext logLines
                 }
-                return logLines
-            }
-
-            fun ViewModel.sendAppLogs(
-                context: Context,
-                api: ApiClient,
-                clientInfo: ClientInfo?,
-                deviceInfo: DeviceInfo?,
-            ) {
-                viewModelScope.launchIO(ExceptionHandler(true)) {
-                    val logcat = getLogCatLines().joinToString("\n") { it.text }
-                    val body =
-                        """
-                        Send App Logs
-                        clientInfo=$clientInfo
-                        deviceInfo=$deviceInfo
-                        manufacturer=${Build.MANUFACTURER}
-                        model=${Build.MODEL}
-                        apiLevel=${Build.VERSION.SDK_INT}
-
-                        """.trimIndent()
-                    Timber.w(body)
-                    val response by api.clientLogApi.logFile(body + logcat)
-                    showToast(context, "Sent! Filename=${response.fileName}")
-                }
-            }
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/FavoritesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/FavoritesViewModel.kt
@@ -18,10 +18,10 @@ import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.FilterOptionCache
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavDrawerService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.RememberedTabService
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.StreamChoiceService
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.services.deleteItem
@@ -89,7 +89,7 @@ class FavoritesViewModel
         private val userPreferencesService: UserPreferencesService,
         private val mediaManagementService: MediaManagementService,
         val streamChoiceService: StreamChoiceService,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         private val filterOptionCache: FilterOptionCache,
         private val rememberedTabService: RememberedTabService,
     ) : ViewModel() {
@@ -590,7 +590,7 @@ class FavoritesViewModel
                 }
             }
 
-            override fun sendReportFor(itemId: UUID) = mediaReportService.sendReportFor(itemId)
+            override fun sendReportFor(itemId: UUID) = serverReportService.sendMediaReportFor(itemId)
 
             override fun updateBackdrop(item: BaseItem) {
                 viewModelScope.launchIO {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/HomeRowGrid.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/HomeRowGrid.kt
@@ -26,10 +26,10 @@ import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.HomeSettingsService
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.MusicService
 import com.github.damontecres.wholphin.services.NavDrawerService
 import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.StreamChoiceService
 import com.github.damontecres.wholphin.services.ThemeSongPlayer
 import com.github.damontecres.wholphin.services.UserPreferencesService
@@ -83,7 +83,7 @@ class HomeRowGridViewModel
         private val mediaManagementService: MediaManagementService,
         private val musicService: MusicService,
         val streamChoiceService: StreamChoiceService,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         @Assisted private val title: StringProvider,
         @Assisted private val rowConfig: HomeRowConfig,
     ) : ViewModel(),
@@ -187,7 +187,7 @@ class HomeRowGridViewModel
             }
         }
 
-        override fun sendReportFor(itemId: UUID) = mediaReportService.sendReportFor(itemId)
+        override fun sendReportFor(itemId: UUID) = serverReportService.sendMediaReportFor(itemId)
 
         fun updateBackdrop(item: BaseItem) {
             viewModelScope.launchIO {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/PlaylistDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/PlaylistDetails.kt
@@ -66,10 +66,10 @@ import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.FilterOptionCache
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.MusicService
 import com.github.damontecres.wholphin.services.MusicServiceState
 import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.ui.SlimItemFields
 import com.github.damontecres.wholphin.ui.cards.ItemCardImage
 import com.github.damontecres.wholphin.ui.components.BasicDialog
@@ -144,7 +144,7 @@ class PlaylistViewModel
         private val serverRepository: ServerRepository,
         private val libraryDisplayInfoDao: LibraryDisplayInfoDao,
         private val favoriteWatchManager: FavoriteWatchManager,
-        private val mediaReportService: MediaReportService,
+        private val serverReportService: ServerReportService,
         private val filterOptionCache: FilterOptionCache,
         @Assisted itemId: UUID,
     ) : MusicViewModel(itemId, context, api, musicService, navigationManager, mediaManagementService) {
@@ -331,7 +331,7 @@ class PlaylistViewModel
         }
 
         fun sendMediaReport(itemId: UUID) {
-            viewModelScope.launchDefault { mediaReportService.sendReportFor(itemId) }
+            viewModelScope.launchDefault { serverReportService.sendMediaReportFor(itemId) }
         }
     }
 

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionDetails.kt
@@ -93,7 +93,7 @@ fun CollectionDetails(
                 playlistViewModel.loadPlaylists()
                 showPlaylistDialog.makePresent(itemId)
             },
-            onSendMediaInfo = viewModel.mediaReportService::sendReportFor,
+            onSendMediaInfo = viewModel.serverReportService::sendMediaReportFor,
             onDeleteItem = { viewModel.deleteItem(it, position) },
             onShowOverview = { overviewDialog = ItemDetailsDialogInfo(it) },
             onChooseVersion = { _, _ ->

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/collection/CollectionViewModel.kt
@@ -18,9 +18,9 @@ import com.github.damontecres.wholphin.services.FilterOptionCache
 import com.github.damontecres.wholphin.services.ImageUrlService
 import com.github.damontecres.wholphin.services.KeyValueService
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.MusicService
 import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.ThemeSongPlayer
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.services.deleteItem
@@ -90,7 +90,7 @@ class CollectionViewModel
         private val libraryDisplayInfoDao: LibraryDisplayInfoDao,
         private val imageUrlService: ImageUrlService,
         private val musicService: MusicService,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         private val filterOptionCache: FilterOptionCache,
         @Assisted private val itemId: UUID,
     ) : ViewModel() {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/episode/EpisodeDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/episode/EpisodeDetails.kt
@@ -90,7 +90,7 @@ fun EpisodeDetails(
                     playlistViewModel.loadPlaylists()
                     showPlaylistDialog.makePresent(itemId)
                 },
-                onSendMediaInfo = viewModel.mediaReportService::sendReportFor,
+                onSendMediaInfo = viewModel.serverReportService::sendMediaReportFor,
                 onDeleteItem = viewModel::deleteItem,
                 onShowOverview = { overviewDialog = ItemDetailsDialogInfo(it) },
                 onChooseVersion = { item, source ->

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/episode/EpisodeViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/episode/EpisodeViewModel.kt
@@ -11,8 +11,8 @@ import com.github.damontecres.wholphin.data.model.ItemPlayback
 import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.StreamChoiceService
 import com.github.damontecres.wholphin.services.ThemeSongPlayer
 import com.github.damontecres.wholphin.services.UserPreferencesService
@@ -52,7 +52,7 @@ class EpisodeViewModel
         val serverRepository: ServerRepository,
         val itemPlaybackRepository: ItemPlaybackRepository,
         val streamChoiceService: StreamChoiceService,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         private val themeSongPlayer: ThemeSongPlayer,
         private val favoriteWatchManager: FavoriteWatchManager,
         private val userPreferencesService: UserPreferencesService,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/movie/MovieDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/movie/MovieDetails.kt
@@ -109,7 +109,7 @@ fun MovieDetails(
                     playlistViewModel.loadPlaylists()
                     showPlaylistDialog.makePresent(itemId)
                 },
-                onSendMediaInfo = viewModel.mediaReportService::sendReportFor,
+                onSendMediaInfo = viewModel.serverReportService::sendMediaReportFor,
                 onDeleteItem = viewModel::deleteItem,
                 onChooseVersion = { item, source ->
                     viewModel.savePlayVersion(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/movie/MovieViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/movie/MovieViewModel.kt
@@ -17,10 +17,10 @@ import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.ExtrasService
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.PeopleFavorites
 import com.github.damontecres.wholphin.services.SeerrService
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.StreamChoiceService
 import com.github.damontecres.wholphin.services.ThemeSongPlayer
 import com.github.damontecres.wholphin.services.TrailerService
@@ -62,7 +62,7 @@ class MovieViewModel
         val serverRepository: ServerRepository,
         val itemPlaybackRepository: ItemPlaybackRepository,
         val streamChoiceService: StreamChoiceService,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         private val themeSongPlayer: ThemeSongPlayer,
         private val favoriteWatchManager: FavoriteWatchManager,
         private val peopleFavorites: PeopleFavorites,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/music/AlbumDetailsPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/music/AlbumDetailsPage.kt
@@ -53,9 +53,9 @@ import com.github.damontecres.wholphin.services.ExtrasService
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.ImageUrlService
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.MusicService
 import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.ui.AspectRatios
 import com.github.damontecres.wholphin.ui.ItemRowFields
@@ -118,7 +118,7 @@ class AlbumViewModel
         navigationManager: NavigationManager,
         mediaManagementService: MediaManagementService,
         val serverRepository: ServerRepository,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         private val favoriteWatchManager: FavoriteWatchManager,
         private val userPreferencesService: UserPreferencesService,
         private val backdropService: BackdropService,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/music/ArtistDetailsPage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/music/ArtistDetailsPage.kt
@@ -49,9 +49,9 @@ import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.ImageUrlService
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.MusicService
 import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.ui.AspectRatios
 import com.github.damontecres.wholphin.ui.ItemRowFields
@@ -115,7 +115,7 @@ class ArtistViewModel
         navigationManager: NavigationManager,
         mediaManagementService: MediaManagementService,
         val serverRepository: ServerRepository,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         private val favoriteWatchManager: FavoriteWatchManager,
         private val userPreferencesService: UserPreferencesService,
         private val backdropService: BackdropService,
@@ -656,7 +656,7 @@ fun ArtistDetailsPage(
                                                         playlistViewModel.loadPlaylists()
                                                         showPlaylistDialog.makePresent(itemId)
                                                     },
-                                                    onSendMediaInfo = viewModel.mediaReportService::sendReportFor,
+                                                    onSendMediaInfo = viewModel.serverReportService::sendMediaReportFor,
                                                     onDeleteItem = viewModel::deleteItem,
                                                     onChooseVersion = { _, _ -> },
                                                     onChooseTracks = { },

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesDetails.kt
@@ -135,7 +135,7 @@ fun SeriesDetails(
                     playlistViewModel.loadPlaylists()
                     showPlaylistDialog = Optional.present(itemId)
                 },
-                onSendMediaInfo = viewModel.mediaReportService::sendReportFor,
+                onSendMediaInfo = viewModel.serverReportService::sendMediaReportFor,
                 onDeleteItem = viewModel::deleteItem,
                 onChooseVersion = { item, source ->
                     viewModel.savePlayVersion(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverview.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesOverview.kt
@@ -118,7 +118,7 @@ fun SeriesOverview(
                     playlistViewModel.loadPlaylists()
                     showPlaylistDialog = itemId
                 },
-                onSendMediaInfo = viewModel.mediaReportService::sendReportFor,
+                onSendMediaInfo = viewModel.serverReportService::sendMediaReportFor,
                 onDeleteItem = viewModel::deleteItem,
                 onChooseVersion = { item, source ->
                     viewModel.savePlayVersion(

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/detail/series/SeriesViewModel.kt
@@ -18,10 +18,10 @@ import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.ExtrasService
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.PeopleFavorites
 import com.github.damontecres.wholphin.services.SeerrService
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.StreamChoiceService
 import com.github.damontecres.wholphin.services.ThemeSongPlayer
 import com.github.damontecres.wholphin.services.TrailerService
@@ -96,7 +96,7 @@ class SeriesViewModel
         private val trailerService: TrailerService,
         private val extrasService: ExtrasService,
         val streamChoiceService: StreamChoiceService,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         private val userPreferencesService: UserPreferencesService,
         private val backdropService: BackdropService,
         private val seerrService: SeerrService,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomePage.kt
@@ -179,7 +179,7 @@ fun HomePage(
                                             playlistViewModel.loadPlaylists()
                                             showPlaylistDialog = itemId
                                         },
-                                        onSendMediaInfo = viewModel.mediaReportService::sendReportFor,
+                                        onSendMediaInfo = viewModel.serverReportService::sendMediaReportFor,
                                         onDeleteItem = {
                                             viewModel.deleteItem(position, it)
                                         },

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomeViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/main/HomeViewModel.kt
@@ -14,9 +14,9 @@ import com.github.damontecres.wholphin.services.HomePageResolvedSettings
 import com.github.damontecres.wholphin.services.HomeSettingsService
 import com.github.damontecres.wholphin.services.LatestNextUpService
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavDrawerService
 import com.github.damontecres.wholphin.services.NavigationManager
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.services.deleteItem
 import com.github.damontecres.wholphin.services.tvAccess
@@ -55,7 +55,7 @@ class HomeViewModel
         @param:ApplicationContext private val context: Context,
         val navigationManager: NavigationManager,
         val serverRepository: ServerRepository,
-        val mediaReportService: MediaReportService,
+        val serverReportService: ServerReportService,
         private val navDrawerService: NavDrawerService,
         private val homeSettingsService: HomeSettingsService,
         private val favoriteWatchManager: FavoriteWatchManager,

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesViewModel.kt
@@ -18,11 +18,11 @@ import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.resetSubtitles
 import com.github.damontecres.wholphin.preferences.updateSubtitlePreferences
 import com.github.damontecres.wholphin.services.BackdropService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.Release
 import com.github.damontecres.wholphin.services.ScreensaverService
 import com.github.damontecres.wholphin.services.SeerrServerRepository
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.UpdateChecker
 import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.util.DataLoadingState
@@ -52,7 +52,7 @@ class PreferencesViewModel
         private val serverRepository: ServerRepository,
         private val seerrServerRepository: SeerrServerRepository,
         private val updateChecker: UpdateChecker,
-        private val mediaReportService: MediaReportService,
+        private val serverReportService: ServerReportService,
     ) : ViewModel() {
         val currentUser =
             serverRepository.currentUserFlow.stateIn(
@@ -94,7 +94,7 @@ class PreferencesViewModel
         }
 
         fun sendAppLogs() {
-            viewModelScope.launchIO { mediaReportService.sendAppLogs() }
+            viewModelScope.launchIO { serverReportService.sendAppLogs() }
         }
 
         fun resetSubtitleSettings() {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/preferences/PreferencesViewModel.kt
@@ -18,12 +18,12 @@ import com.github.damontecres.wholphin.preferences.AppPreferences
 import com.github.damontecres.wholphin.preferences.resetSubtitles
 import com.github.damontecres.wholphin.preferences.updateSubtitlePreferences
 import com.github.damontecres.wholphin.services.BackdropService
+import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.Release
 import com.github.damontecres.wholphin.services.ScreensaverService
 import com.github.damontecres.wholphin.services.SeerrServerRepository
 import com.github.damontecres.wholphin.services.UpdateChecker
-import com.github.damontecres.wholphin.ui.detail.DebugViewModel.Companion.sendAppLogs
 import com.github.damontecres.wholphin.ui.launchIO
 import com.github.damontecres.wholphin.util.DataLoadingState
 import com.github.damontecres.wholphin.util.ExceptionHandler
@@ -36,8 +36,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import org.jellyfin.sdk.api.client.ApiClient
-import org.jellyfin.sdk.model.ClientInfo
-import org.jellyfin.sdk.model.DeviceInfo
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -53,9 +51,8 @@ class PreferencesViewModel
         val screensaverService: ScreensaverService,
         private val serverRepository: ServerRepository,
         private val seerrServerRepository: SeerrServerRepository,
-        private val deviceInfo: DeviceInfo,
-        private val clientInfo: ClientInfo,
         private val updateChecker: UpdateChecker,
+        private val mediaReportService: MediaReportService,
     ) : ViewModel() {
         val currentUser =
             serverRepository.currentUserFlow.stateIn(
@@ -97,7 +94,7 @@ class PreferencesViewModel
         }
 
         fun sendAppLogs() {
-            sendAppLogs(context, api, clientInfo, deviceInfo)
+            viewModelScope.launchIO { mediaReportService.sendAppLogs() }
         }
 
         fun resetSubtitleSettings() {

--- a/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/ui/search/SearchViewModel.kt
@@ -15,10 +15,10 @@ import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.KeyValueService
 import com.github.damontecres.wholphin.services.LiveTvService
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavDrawerService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.SeerrService
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.services.deleteItem
 import com.github.damontecres.wholphin.services.tvAccess
@@ -73,7 +73,7 @@ class SearchViewModel
         private val serverRepository: ServerRepository,
         private val favoriteWatchManager: FavoriteWatchManager,
         private val mediaManagementService: MediaManagementService,
-        private val mediaReportService: MediaReportService,
+        private val serverReportService: ServerReportService,
         private val liveTvService: LiveTvService,
         private val keyValueService: KeyValueService,
         private val navDrawerService: NavDrawerService,
@@ -447,7 +447,7 @@ class SearchViewModel
 
         override fun isAdministrator(): Boolean = serverRepository.currentUserDto?.policy?.isAdministrator == true
 
-        override fun sendReportFor(itemId: UUID) = mediaReportService.sendReportFor(itemId)
+        override fun sendReportFor(itemId: UUID) = serverReportService.sendMediaReportFor(itemId)
 
         fun fetchProgramForDialog(programId: UUID) {
             _programDialogState.update { it.copy(loading = DataLoadingState.Loading) }

--- a/app/src/test/java/com/github/damontecres/wholphin/ui/components/CollectionFolderViewModelTest.kt
+++ b/app/src/test/java/com/github/damontecres/wholphin/ui/components/CollectionFolderViewModelTest.kt
@@ -115,7 +115,7 @@ class CollectionFolderViewModelTest {
             mediaManagementService = mockMediaManagementService,
             musicService = mockk(relaxed = true),
             streamChoiceService = mockk(relaxed = true),
-            mediaReportService = mockk(relaxed = true),
+            serverReportService = mockk(relaxed = true),
             filterOptionCache = mockk(relaxed = true),
             itemId = libraryId.toString(),
             initialSortAndDirection = null,

--- a/app/src/test/java/com/github/damontecres/wholphin/ui/detail/TestFavoritesViewModel.kt
+++ b/app/src/test/java/com/github/damontecres/wholphin/ui/detail/TestFavoritesViewModel.kt
@@ -9,11 +9,11 @@ import com.github.damontecres.wholphin.services.BackdropService
 import com.github.damontecres.wholphin.services.FavoriteWatchManager
 import com.github.damontecres.wholphin.services.FilterOptionCache
 import com.github.damontecres.wholphin.services.MediaManagementService
-import com.github.damontecres.wholphin.services.MediaReportService
 import com.github.damontecres.wholphin.services.NavDrawerItemState
 import com.github.damontecres.wholphin.services.NavDrawerService
 import com.github.damontecres.wholphin.services.NavigationManager
 import com.github.damontecres.wholphin.services.RememberedTabService
+import com.github.damontecres.wholphin.services.ServerReportService
 import com.github.damontecres.wholphin.services.StreamChoiceService
 import com.github.damontecres.wholphin.services.UserPreferencesService
 import com.github.damontecres.wholphin.test.item
@@ -61,7 +61,7 @@ class TestFavoritesViewModel {
     private val userPreferencesService: UserPreferencesService = mockk()
     private val mediaManagementService: MediaManagementService = mockk()
     private val streamChoiceService: StreamChoiceService = mockk()
-    private val mediaReportService: MediaReportService = mockk()
+    private val serverReportService: ServerReportService = mockk()
     private val filterOptionCache: FilterOptionCache = mockk()
     private val rememberedTabService: RememberedTabService = mockk()
     private val navDrawerService: NavDrawerService = mockk()
@@ -100,7 +100,7 @@ class TestFavoritesViewModel {
             userPreferencesService = userPreferencesService,
             mediaManagementService = mediaManagementService,
             streamChoiceService = streamChoiceService,
-            mediaReportService = mediaReportService,
+            serverReportService = serverReportService,
             filterOptionCache = filterOptionCache,
             rememberedTabService = rememberedTabService,
             navDrawerService = navDrawerService,


### PR DESCRIPTION
## Description
Consolidates sending reports/logs to the server into `ServerReportService` (renamed from `MediaReportService`)

Also ensures a consistent header is used including the build flavor.

### Related issues
N/A

### Testing
Emulator

## Screenshots
N/A

## AI or LLM usage
None