### PR TITLE
Increase memory for CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   BRANCH_NAME: ${{ github.ref_name }}
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx8g -XX:MaxMetaspaceSize=512m'"
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx12g -XX:MaxMetaspaceSize=512m'"
 
 jobs:
   build:
@@ -54,7 +54,8 @@ jobs:
           ORG_GRADLE_PROJECT_WholphinExtensionsUsername: "${{ secrets.EXTENSIONS_USERNAME }}"
           ORG_GRADLE_PROJECT_WholphinExtensionsPassword: "${{ secrets.EXTENSIONS_PASSWORD }}"
         run: |
-          ./gradlew clean assembleDefaultRelease assembleDefaultDebug --no-daemon
+          ./gradlew clean assembleDefaultDebug
+          ./gradlew assembleDefaultRelease
 
       - name: Verify signatures
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   BRANCH_NAME: ${{ github.ref_name }}
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx12g -XX:MaxMetaspaceSize=512m'"
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx12g -XX:MaxMetaspaceSize=1024m'"
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ defaults:
 
 env:
   BUILD_DIRS_ARTIFACT: build-dirs
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx8g -XX:MaxMetaspaceSize=512m'"
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx12g -XX:MaxMetaspaceSize=1024m'"
 
 jobs:
   pre-commit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ defaults:
 
 env:
   APK_SHORT_NAME: Wholphin.apk
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx12g -XX:MaxMetaspaceSize=512m'"
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx12g -XX:MaxMetaspaceSize=1024m'"
   TAG_NAME: ${{ github.ref_name }}
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ defaults:
 
 env:
   APK_SHORT_NAME: Wholphin.apk
-  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx8g -XX:MaxMetaspaceSize=512m'"
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx12g -XX:MaxMetaspaceSize=512m'"
   TAG_NAME: ${{ github.ref_name }}
 
 jobs:
@@ -36,7 +36,8 @@ jobs:
           ORG_GRADLE_PROJECT_WholphinExtensionsUsername: "${{ secrets.EXTENSIONS_USERNAME }}"
           ORG_GRADLE_PROJECT_WholphinExtensionsPassword: "${{ secrets.EXTENSIONS_PASSWORD }}"
         run: |
-          ./gradlew clean bundleAppstoreRelease bundleFiretvRelease
+          ./gradlew clean bundleAppstoreRelease
+          ./gradlew bundleFiretvRelease
           ./gradlew assembleDefaultRelease
       - name: Verify signatures
         run: |


### PR DESCRIPTION
## Description
Increases the memory available for CI builds and splits up builds a bit more

There are no user facing changes

### Related issues
Recently dev builds failed due to OOM

### Testing
https://github.com/damontecres/Wholphin/actions/runs/34710759629

## Screenshots
N/A

## AI or LLM usage
None