### PR TITLE
Fix OS screensaver starting during playback with dim enabled

### DIFF
--- a/app/src/main/java/com/github/damontecres/wholphin/services/ScreensaverService.kt
+++ b/app/src/main/java/com/github/damontecres/wholphin/services/ScreensaverService.kt
@@ -173,9 +173,10 @@ class ScreensaverService
          */
         fun keepScreenOn(keep: Boolean) {
             scope.launchDefault {
-                val screensaverEnabled = _state.value.run { enabled || dimEnabled }
+                val screensaverEnabled = state.value.enabled
+                val dimEnabled = state.value.dimEnabled
                 Timber.d("Keep screen on: %s, screensaverEnabled=%s", keep, screensaverEnabled)
-                if (screensaverEnabled) {
+                if (screensaverEnabled || dimEnabled) {
                     // Page is requesting to keep screen on, so we don't wait to show the screensaver
                     _state.update {
                         it.copy(
@@ -187,7 +188,9 @@ class ScreensaverService
                     if (!keep) {
                         pulse()
                     }
-                } else {
+                }
+                if (!screensaverEnabled) {
+                    // If in-app screensaver is not enabled, send keep screen on to the OS
                     keepScreenOnInternal(keep)
                 }
             }


### PR DESCRIPTION
## Description
Fixes some devices activating the OS screensaver during playback when the in-app dim was enabled.

I was not able to reproduce this on Shield 2017/2019, but could easily on a Fire TV Stick. #1834 added the dim feature and, when enabled, would not pass the keep screen on flag to the OS during playback. It seems maybe regular Android TV's screensaver also listened to active media session to prevent starting but maybe Fire TV OS doesn't. I'm not 100% sure. This PR changes the logic slightly so that the keep screen on flag is always set during playback.

### Related issues
Fixes #1894
Related to dim feature from https://github.com/damontecres/Wholphin/pull/1834

### Testing
Emulator, shield 2019, & fire tv stick 4k

## Screenshots
N/A

## AI or LLM usage
None
